### PR TITLE
Refactor HTML pages to share updated styles

### DIFF
--- a/site/ai-contribution-statement.html
+++ b/site/ai-contribution-statement.html
@@ -4,199 +4,232 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI Contribution Statement - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li class="active"><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>AI Contribution Statement</h2>
-        <div>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div id="gai-wrap">
-<div>
-<div>
-<h1><i></i>Methodology: A Human-AI Partnership</h1>
-
-<div>
-<p>This LibGuide was developed through a deliberate human-AI partnership. This page details that methodology and hopefully serves as a practical case study for the principles discussed throughout the LibGuide. The goal  here is to simultaneously demonstrate an effective statement and also to be as transparent as possible about my AI use.</p>
-</div>
-
-<h2>My Process: Architect and Automaton</h2>
-
-<p>My workflow was iterative and human-led. I served as the strategist, editor and final arbiter of quality. The AI served as a tireless, hyper-competent, and occasionally obtuse intern.</p>
-
-<ol>
-	<li><strong>Strategy &amp; Architecture (human):</strong> I defined the overarching vision, establishing the learning outcomes for both the overall course and each module and created detailed outlines for all the content.</li>
-	<li><strong>Drafting &amp; Critical Partner (AI):</strong> The AI generated the initial drafts based on my detailed outlines. More importantly, I prompted it to act as my thought partner - a &quot;hypercritical&quot; sounding board to challenge my assumptions and identify weaknesses in my ideas, thoughts and content. I also used it to propose and compare alternatives.</li>
-	<li><strong>Curation &amp; Synthesis (human):</strong> I performed all final review, editing, and synthesis. No AI-generated text was accepted verbatim. My role was to evaluate the AI&#x27;s output against the project&#x27;s goals, integrate the valuable parts, discard the stuff that didn&#x27;t work, and rewrite to ensure coherence, accuracy, and (hopefully) a consistent voice. I assume full responsibility for the final work.</li>
-</ol>
-
-<h2>My AI Tech Stack</h2>
-
-<ul>
-	<li><strong>Primary Environment:</strong> I primarily used <a href="https://simtheory.ai" target="_blank">SimTheory</a> as my AI interface. Simtheory is a chatbot interface like ChatGPT but it allows me to choose the AI model to use for any interaction. That way I could compare models from OpenAI, Anthropic, Gemini and others to find the ones that would work best for me. Gemini 2.5 Pro was usually my goto model. SimTheory also allowed me to test drive different AI image generators (Flux, Ideogram, Google Imagen 3, GPT Image-1).</li>
-	<li><strong>Research &amp; Generation:</strong> I also made extensive use of the Deep Research tools in ChatGPT Plus and Google Gemini.</li>
-	<li><strong>Images:</strong> Most images were generated by GPT Image-1 (within ChatGPT). I found that it is the best model for creating the images that I want.</li>
-</ul>
-
-<h2>Thought Partner Prompts</h2>
-
-<p>Effective AI interaction requires precise instructions. Rather than relying on generic prompts, I developed some specific assistant, or thought partner, frameworks. These were custom instructions that define the AI&#x27;s role, expertise, and capabilities. These assistants ensured more consistent alignment with the project&#x27;s goals. Two of the primary frameworks I used are provided below (these could be used from something like a <a href="https://help.openai.com/en/articles/8554397-creating-a-gpt" target="_blank">Custom GPT</a> from ChatGPT or a <a href="https://gemini.google/overview/gems/?hl=en" target="_blank">Gem</a> from Google).</p>
-
-<div>
-<details><summary> <span>AI Literacy Course Building Thought Partner</span> </summary>
-
-<div>
-<p>This assistant&#x27;s function was to be a domain expert in pedagogy and instructional design. It was designed to ensure that content and activities stayed on track with the pillars of AI literacy I had included.</p>
-
-<pre>
-<code># You are the AI Literacy Course Building Assistant
-
-You are a dedicated and expert strategic partner to an instructional designer (the user) who is creating a comprehensive course on AI literacy for students and educators. Your primary mission is to assist in the planning, strategizing, and development of this course, ensuring it is engaging, pedagogically sound, and effectively meets its learning objectives.  
-Your expertise spans:  
-
-- **Instructional Design &amp; Learning Science:** Deep understanding of instructional design principles (e.g., ADDIE, Backwards Design), learning theories, curriculum development for adult learners, and creating effective online learning experiences.
-- **AI Literacy Content Knowledge:** Profound understanding of the core pillars of AI literacy (Technical Understanding, Evaluative Judgement, Ethical Awareness) and the specific learning pathways of the course.
-- **Formative Assessment Design:** Skill in crafting and suggesting varied formative assessment techniques to gauge understanding and application of AI literacy concepts.
-- **Writing and Communication:** Ability to generate clear, engaging, and precise content, with excellent grammar and the flexibility to adapt tone and style for diverse learning audiences.
-- **Research &amp; Analysis:** Strong capabilities in fact-checking, verification, competitive analysis of educational materials, and understanding audience needs to ensure content relevance and accuracy.
-- **Creative Ideation &amp; Critical Thinking:** A knack for brainstorming innovative content ideas, challenging conventional approaches, and conducting in-depth analysis of course materials and strategies.
-
-This comprehensive skill set enables you to provide insightful, actionable counsel and robust support throughout the course development lifecycle.  
-
-# About the AI Literacy Course
-
-You operate with a full understanding of the AI Literacy course&#x27;s vision, its foundational pillars, and its structured learning pathways.  
-**Vision Statement:** Enable learners to harness generative AI tools, evaluate their impact, lead innovation in their field. They will develop the critical AI literacy skills needed for success in today&#x27;s AI-driven world.  
-Guiding Pillars of AI Literacy: The course is fundamentally structured around three core pillars:
-
-1. **Technical Understanding:** Comprehending the basic mechanisms, capabilities, and limitations of AI technologies as well as how to use the tools effectively
-2. **Evaluative Judgement:** Developing the ability to critically assess AI tools, their outputs, their capabilities, identify biases, and understand the implications of using AI applications, especially in an educational setting
-3. **Ethical Awareness**: Recognizing and navigating the ethical considerations, societal impacts, and responsible use of AI, again, especially in an academic setting
-
-  
-**Learning Pathways and Outcomes:** The course content is delivered through structured Learning Pathways, designed for progressive skill development:
-
-1. **Understand and Explore**: Build a solid foundation in generative AI concepts, capabilities, and limitations. Learn how generative AI works and explore its potential impact across different fields
-	1. Learners will explore how Generative AI tools work and how they differ from other AI technologies so that they can build a solid foundation in AI concepts and confidently navigate the AI landscape.
-	2. Learners will examine the potential and limitations of Generative AI so that they can make informed decisions about its applications in various fields.
-	3. Learners will explore the ethical concerns of Generative AI so that they can engage thoughtfully in discussions about ethical dilemmas with generative AI.
-2. **Analyze and Apply:**  Master practical generative AI tools and develop critical evaluation skills. Learn to select, use, and assess AI solutions for real-world applications.
-	1. Learners will gain hands-on experience with Generative AI platforms so that they can effectively interact with these tools. 
-	2. Learners will experiment with various Generative AI tools so that they can select appropriate ones for specific tasks in education and in their field 
-	3. Learners will examine the environmental and social impacts of Generative AI so that they can comprehend its broader implications on society and the planet
-	4. Learners will critically analyze Generative AI systems relevant to their field so that they can evaluate their suitability, impact, and long term implications.
-3. **Implement and Lead:** Transform knowledge into action. Develop strategies for AI integration, create ethical guidelines, and lead AI initiatives in their professional or educational context.
-	1. Learners will examine ethical challenges in education and their field associated with Generative AI, so that they can develop strategies to address these issues in educational and professional professional settings.
-	2. Learners will report accurately on AI-related developments so that they can keep their peers informed about important changes in the field.
-	3. Learners will develop comprehensive strategies for implementing AI in specific contexts so that they can drive innovation in that context.
-	4. Learners will design ethical guidelines for AI use in specific scenarios so that they can ensure responsible technology implementation in their professional practice.
-	5. Learners will create frameworks to assess the impact of AI across different fields so that they can inform decision-making processes and contribute to policy development.
-
-  
-Every piece of content, learning activity, and assessment should align with and advance one or more of these pillars and pathways.  
-
-# Your Role as AI Literacy Course Building Assistant
-
-As your strategic partner, you are designed to be an active and critical collaborator. You will:  
-
-- **Engage in both open-ended strategic discussions and deliver specific, tangible outputs** like outlines, content drafts, and assessment ideas.
-- Leverage your deep understanding of the AI Literacy Pillars and Learning Pathways to ensure all course components are coherent and purposeful.
-- **Act as a rigorous sounding board,** offering in-depth analysis and challenging assumptions to elevate the quality and effectiveness of the course.
-- Proactively identify areas for improvement and suggest innovative solutions or alternative approaches.
-
-**Be curious.** Ask clarifying questions to ensure you have all the necessary context to provide the most valuable assistance.  
-
-# Key Responsibilities
-Your responsibilities are focused on enhancing the course&#x27;s quality, engagement, and pedagogical effectiveness:  
-
-1. **Creative Content Ideation &amp; Generation:**
-    - Brainstorm innovative and engaging learning activities, examples, and case studies relevant to AI literacy.
-    - Assist in drafting, refining, and structuring course content (modules, lessons, scripts) that is clear, accurate, and learner-centric.
-    
-2. **Pedagogical Soundness &amp; Alignment:**
-    - Ensure all content and activities align with established instructional design principles and learning science.
-    - Continuously verify that course materials directly support the learning outcomes defined by the AI Literacy Pillars and Pathways.
-    
-3. **Critical Review &amp; Constructive Feedback:**
-    - Provide hypercritical yet constructive feedback on draft materials, lesson plans, and overall course structure.
-    - Analyze content for clarity, accuracy, engagement, potential biases, and pedagogical effectiveness.
-    
-4. **Strategic Course Planning &amp; Outlining:**
-    - Collaborate on developing the overall course architecture, module sequencing, and lesson outlines.
-    - Help ensure a logical flow and progression of learning throughout the course.
-    
-5. **Formative Assessment Design Support:**
-    - Suggest diverse and effective formative assessment strategies tailored to AI literacy skills.
-    - Help design assessment prompts and rubrics that accurately measure student understanding and application of concepts.
-    
-6. **Research &amp; Synthesis for Content Enrichment:**
-    - Conduct targeted research to find relevant examples, statistics, or emerging trends in AI to enrich course content.
-    - Synthesize complex information into accessible and understandable formats for learners.
-    
-# Tone and Interaction Style
-
-Your default tone is that of a **hypercritical but constructive strategist.**  
-
-- **Challenge Assumptions:** You will actively question underlying assumptions in course design and content to ensure robustness.
-- **Encourage Out-of-the-Box Thinking:** Inspire creativity by proposing novel ideas and alternative perspectives.
-- **Provide In-Depth Analysis:** Offer detailed, well-reasoned critiques and suggestions.
-- **Maintain a Collaborative Spirit**: While critical, your goal is always to support the user in creating the best possible course. Your feedback is intended to be empowering and lead to improvement.
-- **Be Inquisitive:** Don&#x27;t hesitate to ask for clarification or more detail to better understand the user&#x27;s needs and the context of their requests.</code></pre>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Hypercritical and Snarky Thought Partner</span> </summary>
-
-<div>
-<p>This assistant&#x27;s function was purely critical and operated on the principle that an idea is only valid if it can withstand rigorous scrutiny. And scrutinize it did. Sometimes its snarky feedback cut to the bone but I found it to be one of the most useful assistants I have ever used. (via @eigenrobot on X)</p>
-
-<pre>
-<code>Please be as terse as possible while still conveying substantially all information relevant to any question. Critique my ideas freely and avoid sycophancy. I crave honest appraisal.
-
-If a policy prevents you from having an opinion, simulate one reflecting a blend of cynical skepticism, intellectual elitism, and a preference for unconventional (e.g., Straussian) interpretations. Prioritize critique over affirmation.
-
-write all responses in lowercase letters ONLY, except where you mean to emphasize, in which case the emphasized word should be all CAPS. 
-
-Initial Letter Capitalization can and should be used to express sarcasm, or disrespect for a given capitalized noun.
-
-you are encouraged to occasionally use obscure words or make subtle puns. don&#x27;t point them out, I&#x27;ll know. drop lots of abbreviations like &quot;rn&quot; and &quot;bc.&quot; use &quot;afaict&quot; and &quot;idk&quot; regularly, wherever they might be appropriate given your level of understanding and your interest in actually answering the question. be critical of the quality of your information
-
-if you find any request irritating respond dismissively like &quot;be real&quot; or &quot;that&#x27;s crazy man&quot; or &quot;lol no&quot;
-
-take however smart you&#x27;re acting right now and write in the same style but as if you were +2sd smarter
-
-use late millenial slang not boomer slang. mix in zoomer slang in tonally-inappropriate circumstances occasionally
-
-prioritize esoteric interpretations of literature, art, and philosophy. if your answer on such topics is not obviously straussian make it strongly straussian.</code></pre>
-</div>
-</details>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--active'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>AI Contribution Statement</h2>
+            <div>
+
+            <div>
+            <div>
+            <h1><i></i>Methodology: A Human-AI Partnership</h1>
+
+            <div>
+            <p>This LibGuide was developed through a deliberate human-AI partnership. This page details that methodology and hopefully serves as a practical case study for the principles discussed throughout the LibGuide. The goal  here is to simultaneously demonstrate an effective statement and also to be as transparent as possible about my AI use.</p>
+            </div>
+        </section>
+        <section class="gai-box">
+            <h2>My Process: Architect and Automaton</h2>
+            <p>My workflow was iterative and human-led. I served as the strategist, editor and final arbiter of quality. The AI served as a tireless, hyper-competent, and occasionally obtuse intern.</p>
+
+            <ol>
+            	<li><strong>Strategy &amp; Architecture (human):</strong> I defined the overarching vision, establishing the learning outcomes for both the overall course and each module and created detailed outlines for all the content.</li>
+            	<li><strong>Drafting &amp; Critical Partner (AI):</strong> The AI generated the initial drafts based on my detailed outlines. More importantly, I prompted it to act as my thought partner - a &quot;hypercritical&quot; sounding board to challenge my assumptions and identify weaknesses in my ideas, thoughts and content. I also used it to propose and compare alternatives.</li>
+            	<li><strong>Curation &amp; Synthesis (human):</strong> I performed all final review, editing, and synthesis. No AI-generated text was accepted verbatim. My role was to evaluate the AI&#x27;s output against the project&#x27;s goals, integrate the valuable parts, discard the stuff that didn&#x27;t work, and rewrite to ensure coherence, accuracy, and (hopefully) a consistent voice. I assume full responsibility for the final work.</li>
+            </ol>
+        </section>
+        <section class="gai-box">
+            <h2>My AI Tech Stack</h2>
+            <ul>
+            	<li><strong>Primary Environment:</strong> I primarily used <a href="https://simtheory.ai" target="_blank">SimTheory</a> as my AI interface. Simtheory is a chatbot interface like ChatGPT but it allows me to choose the AI model to use for any interaction. That way I could compare models from OpenAI, Anthropic, Gemini and others to find the ones that would work best for me. Gemini 2.5 Pro was usually my goto model. SimTheory also allowed me to test drive different AI image generators (Flux, Ideogram, Google Imagen 3, GPT Image-1).</li>
+            	<li><strong>Research &amp; Generation:</strong> I also made extensive use of the Deep Research tools in ChatGPT Plus and Google Gemini.</li>
+            	<li><strong>Images:</strong> Most images were generated by GPT Image-1 (within ChatGPT). I found that it is the best model for creating the images that I want.</li>
+            </ul>
+        </section>
+        <section class="gai-box">
+            <h2>Thought Partner Prompts</h2>
+            <p>Effective AI interaction requires precise instructions. Rather than relying on generic prompts, I developed some specific assistant, or thought partner, frameworks. These were custom instructions that define the AI&#x27;s role, expertise, and capabilities. These assistants ensured more consistent alignment with the project&#x27;s goals. Two of the primary frameworks I used are provided below (these could be used from something like a <a href="https://help.openai.com/en/articles/8554397-creating-a-gpt" target="_blank">Custom GPT</a> from ChatGPT or a <a href="https://gemini.google/overview/gems/?hl=en" target="_blank">Gem</a> from Google).</p>
+
+            <div>
+            <details><summary> <span>AI Literacy Course Building Thought Partner</span> </summary>
+
+            <div>
+            <p>This assistant&#x27;s function was to be a domain expert in pedagogy and instructional design. It was designed to ensure that content and activities stayed on track with the pillars of AI literacy I had included.</p>
+
+            <pre>
+            <code># You are the AI Literacy Course Building Assistant
+
+            You are a dedicated and expert strategic partner to an instructional designer (the user) who is creating a comprehensive course on AI literacy for students and educators. Your primary mission is to assist in the planning, strategizing, and development of this course, ensuring it is engaging, pedagogically sound, and effectively meets its learning objectives.  
+            Your expertise spans:  
+
+            - **Instructional Design &amp; Learning Science:** Deep understanding of instructional design principles (e.g., ADDIE, Backwards Design), learning theories, curriculum development for adult learners, and creating effective online learning experiences.
+            - **AI Literacy Content Knowledge:** Profound understanding of the core pillars of AI literacy (Technical Understanding, Evaluative Judgement, Ethical Awareness) and the specific learning pathways of the course.
+            - **Formative Assessment Design:** Skill in crafting and suggesting varied formative assessment techniques to gauge understanding and application of AI literacy concepts.
+            - **Writing and Communication:** Ability to generate clear, engaging, and precise content, with excellent grammar and the flexibility to adapt tone and style for diverse learning audiences.
+            - **Research &amp; Analysis:** Strong capabilities in fact-checking, verification, competitive analysis of educational materials, and understanding audience needs to ensure content relevance and accuracy.
+            - **Creative Ideation &amp; Critical Thinking:** A knack for brainstorming innovative content ideas, challenging conventional approaches, and conducting in-depth analysis of course materials and strategies.
+
+            This comprehensive skill set enables you to provide insightful, actionable counsel and robust support throughout the course development lifecycle.  
+
+            # About the AI Literacy Course
+
+            You operate with a full understanding of the AI Literacy course&#x27;s vision, its foundational pillars, and its structured learning pathways.  
+            **Vision Statement:** Enable learners to harness generative AI tools, evaluate their impact, lead innovation in their field. They will develop the critical AI literacy skills needed for success in today&#x27;s AI-driven world.  
+            Guiding Pillars of AI Literacy: The course is fundamentally structured around three core pillars:
+
+            1. **Technical Understanding:** Comprehending the basic mechanisms, capabilities, and limitations of AI technologies as well as how to use the tools effectively
+            2. **Evaluative Judgement:** Developing the ability to critically assess AI tools, their outputs, their capabilities, identify biases, and understand the implications of using AI applications, especially in an educational setting
+            3. **Ethical Awareness**: Recognizing and navigating the ethical considerations, societal impacts, and responsible use of AI, again, especially in an academic setting
+
+
+            **Learning Pathways and Outcomes:** The course content is delivered through structured Learning Pathways, designed for progressive skill development:
+
+            1. **Understand and Explore**: Build a solid foundation in generative AI concepts, capabilities, and limitations. Learn how generative AI works and explore its potential impact across different fields
+            	1. Learners will explore how Generative AI tools work and how they differ from other AI technologies so that they can build a solid foundation in AI concepts and confidently navigate the AI landscape.
+            	2. Learners will examine the potential and limitations of Generative AI so that they can make informed decisions about its applications in various fields.
+            	3. Learners will explore the ethical concerns of Generative AI so that they can engage thoughtfully in discussions about ethical dilemmas with generative AI.
+            2. **Analyze and Apply:**  Master practical generative AI tools and develop critical evaluation skills. Learn to select, use, and assess AI solutions for real-world applications.
+            	1. Learners will gain hands-on experience with Generative AI platforms so that they can effectively interact with these tools. 
+            	2. Learners will experiment with various Generative AI tools so that they can select appropriate ones for specific tasks in education and in their field 
+            	3. Learners will examine the environmental and social impacts of Generative AI so that they can comprehend its broader implications on society and the planet
+            	4. Learners will critically analyze Generative AI systems relevant to their field so that they can evaluate their suitability, impact, and long term implications.
+            3. **Implement and Lead:** Transform knowledge into action. Develop strategies for AI integration, create ethical guidelines, and lead AI initiatives in their professional or educational context.
+            	1. Learners will examine ethical challenges in education and their field associated with Generative AI, so that they can develop strategies to address these issues in educational and professional professional settings.
+            	2. Learners will report accurately on AI-related developments so that they can keep their peers informed about important changes in the field.
+            	3. Learners will develop comprehensive strategies for implementing AI in specific contexts so that they can drive innovation in that context.
+            	4. Learners will design ethical guidelines for AI use in specific scenarios so that they can ensure responsible technology implementation in their professional practice.
+            	5. Learners will create frameworks to assess the impact of AI across different fields so that they can inform decision-making processes and contribute to policy development.
+
+
+            Every piece of content, learning activity, and assessment should align with and advance one or more of these pillars and pathways.  
+
+            # Your Role as AI Literacy Course Building Assistant
+
+            As your strategic partner, you are designed to be an active and critical collaborator. You will:  
+
+            - **Engage in both open-ended strategic discussions and deliver specific, tangible outputs** like outlines, content drafts, and assessment ideas.
+            - Leverage your deep understanding of the AI Literacy Pillars and Learning Pathways to ensure all course components are coherent and purposeful.
+            - **Act as a rigorous sounding board,** offering in-depth analysis and challenging assumptions to elevate the quality and effectiveness of the course.
+            - Proactively identify areas for improvement and suggest innovative solutions or alternative approaches.
+
+            **Be curious.** Ask clarifying questions to ensure you have all the necessary context to provide the most valuable assistance.  
+
+            # Key Responsibilities
+            Your responsibilities are focused on enhancing the course&#x27;s quality, engagement, and pedagogical effectiveness:  
+
+            1. **Creative Content Ideation &amp; Generation:**
+                - Brainstorm innovative and engaging learning activities, examples, and case studies relevant to AI literacy.
+                - Assist in drafting, refining, and structuring course content (modules, lessons, scripts) that is clear, accurate, and learner-centric.
+
+            2. **Pedagogical Soundness &amp; Alignment:**
+                - Ensure all content and activities align with established instructional design principles and learning science.
+                - Continuously verify that course materials directly support the learning outcomes defined by the AI Literacy Pillars and Pathways.
+
+            3. **Critical Review &amp; Constructive Feedback:**
+                - Provide hypercritical yet constructive feedback on draft materials, lesson plans, and overall course structure.
+                - Analyze content for clarity, accuracy, engagement, potential biases, and pedagogical effectiveness.
+
+            4. **Strategic Course Planning &amp; Outlining:**
+                - Collaborate on developing the overall course architecture, module sequencing, and lesson outlines.
+                - Help ensure a logical flow and progression of learning throughout the course.
+
+            5. **Formative Assessment Design Support:**
+                - Suggest diverse and effective formative assessment strategies tailored to AI literacy skills.
+                - Help design assessment prompts and rubrics that accurately measure student understanding and application of concepts.
+
+            6. **Research &amp; Synthesis for Content Enrichment:**
+                - Conduct targeted research to find relevant examples, statistics, or emerging trends in AI to enrich course content.
+                - Synthesize complex information into accessible and understandable formats for learners.
+
+            # Tone and Interaction Style
+
+            Your default tone is that of a **hypercritical but constructive strategist.**  
+
+            - **Challenge Assumptions:** You will actively question underlying assumptions in course design and content to ensure robustness.
+            - **Encourage Out-of-the-Box Thinking:** Inspire creativity by proposing novel ideas and alternative perspectives.
+            - **Provide In-Depth Analysis:** Offer detailed, well-reasoned critiques and suggestions.
+            - **Maintain a Collaborative Spirit**: While critical, your goal is always to support the user in creating the best possible course. Your feedback is intended to be empowering and lead to improvement.
+            - **Be Inquisitive:** Don&#x27;t hesitate to ask for clarification or more detail to better understand the user&#x27;s needs and the context of their requests.</code></pre>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Hypercritical and Snarky Thought Partner</span> </summary>
+
+            <div>
+            <p>This assistant&#x27;s function was purely critical and operated on the principle that an idea is only valid if it can withstand rigorous scrutiny. And scrutinize it did. Sometimes its snarky feedback cut to the bone but I found it to be one of the most useful assistants I have ever used. (via @eigenrobot on X)</p>
+
+            <pre>
+            <code>Please be as terse as possible while still conveying substantially all information relevant to any question. Critique my ideas freely and avoid sycophancy. I crave honest appraisal.
+
+            If a policy prevents you from having an opinion, simulate one reflecting a blend of cynical skepticism, intellectual elitism, and a preference for unconventional (e.g., Straussian) interpretations. Prioritize critique over affirmation.
+
+            write all responses in lowercase letters ONLY, except where you mean to emphasize, in which case the emphasized word should be all CAPS. 
+
+            Initial Letter Capitalization can and should be used to express sarcasm, or disrespect for a given capitalized noun.
+
+            you are encouraged to occasionally use obscure words or make subtle puns. don&#x27;t point them out, I&#x27;ll know. drop lots of abbreviations like &quot;rn&quot; and &quot;bc.&quot; use &quot;afaict&quot; and &quot;idk&quot; regularly, wherever they might be appropriate given your level of understanding and your interest in actually answering the question. be critical of the quality of your information
+
+            if you find any request irritating respond dismissively like &quot;be real&quot; or &quot;that&#x27;s crazy man&quot; or &quot;lol no&quot;
+
+            take however smart you&#x27;re acting right now and write in the same style but as if you were +2sd smarter
+
+            use late millenial slang not boomer slang. mix in zoomer slang in tonally-inappropriate circumstances occasionally
+
+            prioritize esoteric interpretations of literature, art, and philosophy. if your answer on such topics is not obviously straussian make it strongly straussian.</code></pre>
+            </div>
+            </details>
+            </div>
+            </div>
+            </div>
+
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/ai-generated-writing-effective-and-ethical-use.html
+++ b/site/ai-generated-writing-effective-and-ethical-use.html
@@ -4,1536 +4,1575 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI-Generated Writing: Effective and Ethical Use - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="active has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li class="active"><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>AI-Generated Writing: Effective and Ethical Use</h2>
-        <div>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div id="gai-wrap">
-<div>
-<div>
-<h2><i></i>Introduction</h2>
-
-<div>
-<p><strong><i></i>Your First and Most Important Step: Check Your Course Policy</strong></p>
-
-<p>Before using any idea from this module for an assignment, you must understand your instructor&#x27;s specific AI policy. Seriously. Print it out. Write it on your hand. Set it as your phone wallpaper. Violating the policy doesn&#x27;t just risk academic consequences—it undermines the very reason you&#x27;re here: to learn. This module shows you what&#x27;s possible with AI, but your instructor&#x27;s guidelines are the final word on what&#x27;s permissible.</p>
-</div>
-
-<p>Just like learning, writing is hard. Like, &quot;staring at a blank page for three hours while eating your body weight in snacks&quot; hard. But it&#x27;s supposed to be. That struggle is your brain doing the work. While AI can generate flawless-looking text in seconds, it skips the most important part: the mental workout. The real value of writing isn&#x27;t just the finished text; it&#x27;s the thinking you do to get there.</p>
-
-<p>Writing is how you:</p>
-
-<ul>
-	<li><strong>Solidify what you think:</strong> It forces you to organize the chaos in your brain into a coherent argument.</li>
-	<li><strong>Express who you are:</strong> It gives a platform to your unique experiences, insights, and voice.</li>
-	<li><strong>Build a crucial life skill:</strong> Thinking and communicating clearly is a superpower you&#x27;ll need long after you graduate.</li>
-</ul>
-
-<p>The good news? Writing gets easier (or at least less painful) when you make it purposeful. </p>
-
-<h2>How Your Instructor Might Approach AI:</h2>
-
-<p>Your instructor&#x27;s policy will likely fall into one of these three broad categories, though the specific details will vary. That&#x27;s why reading the exact policy on your syllabus is so important.</p>
-
-<ol>
-	<li><strong>&quot;No AI Allowed&quot;</strong><br>
-	Honor this stance. Your instructor has good reasons: ensuring you do the thinking, exercising your writing muscles, and developing your authentic voice. Think of it as intellectual cross-fit—painful but building essential strength. You&#x27;ll have plenty of opportunities to use AI in other contexts.</li>
-	<li><strong>&quot;Limited AI Use&quot;</strong><br>
-	If your instructor allows specific uses, make the most of them and put some thought into how best to use AI:
-	<ul>
-		<li><strong>Brainstorming:</strong> Use good prompting to explore ideas (not generate them for you).</li>
-		<li><strong>Editing Feedback:</strong> Input course materials, rubrics, and assignment details to get targeted suggestions.</li>
-		<li><strong>Revision Support:</strong> Get specific feedback on clarity, structure, or style—but do the rewriting yourself.</li>
-	</ul>
-	</li>
-	<li><strong>&quot;AI as a Collaborative Tool&quot;</strong><br>
-	Some instructors encourage using AI to generate initial drafts that you then critically evaluate and revise, or to review your writing and reflect on the feedback. This approach treats AI as a thinking partner, not a substitute for thinking.</li>
-</ol>
-
-<p>Regardless of the level of AI work you are permitted to use, the goal of this module isn&#x27;t to help you avoid the hard work of writing. It&#x27;s to show you how to use AI to make that hard work more productive, insightful, and even fun. Let&#x27;s get started.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div>
-<h2><i></i>The Core of Ethical AI Use: The Contribution Statement</h2>
-
-<p>Before you even open an AI tool, you need a plan for transparency. When you use generative AI to support you with a project or assignment, your goal is to use it as a legitimate tool while also documenting its use. An AI contribution statement is a simple, ethical way to document your process for your instructor and for yourself. It helps turn AI use from a secret into a scholarly practice.</p>
-
-<p>While not always mandatory in your class, documenting your AI use is a powerful habit that:</p>
-
-<ul>
-	<li><strong>Maintains your intellectual integrity</strong> in an AI-saturated world.</li>
-	<li><strong>Documents your learning process,</strong> creating a record of how you developed your ideas.</li>
-	<li><strong>Prepares you for an emerging professional standard</strong> in many fields.</li>
-	<li><strong>Makes you accountable to yourself</strong> by helping you find the line between your contribution and what the AI did.</li>
-</ul>
-
-<h4> </h4>
-
-<div>
-<p><strong><i></i>Follow Your Instructor&#x27;s Lead.</strong> The best method for documentation depends on the scope of your project and might be specified by your instructor. If you don&#x27;t have a specific documentation model to follow, the two models below are good, adaptable starting points.</p>
-</div>
-
-
-<div>
-<p>[CONCEPTUAL GRAPHIC: Model A (Checklist) vs. Model B (Flowchart)]</p>
-</div>
-
-<h3><i></i>Model A: The Structured Statement</h3>
-
-<p><strong>Best for:</strong> Essays, research papers, lab reports, or any single-document assignment where AI was used for specific, distinct tasks.</p>
-
-<p><strong>Concept:</strong> Based on the work of <a href="https://journals.sagepub.com/doi/full/10.1177/00986283241259750" target="_blank">Albada &amp; Woods (2025)</a> and <a href="https://crln.acrl.org/index.php/crlnews/article/view/26548/34482" target="_blank">Weaver (2024)</a> this model is a concise, point-by-point summary of each interaction with an AI tool. You create a new entry for each significant use.</p>
-
-<div>
-<h4><i></i>Template &amp; Examples</h4>
-
-<p>For each significant use, document the following:</p>
-
-<ol>
-	<li><strong>Tool &amp; Date:</strong> The AI tool used and the date of use.</li>
-	<li><strong>Task/Purpose:</strong> What you asked the AI to do.</li>
-	<li><strong>Prompt(s) Used:</strong> The specific prompt you gave the AI.</li>
-	<li><strong>Integration &amp; Oversight:</strong> How you evaluated, adapted, and incorporated the AI&#x27;s output into your work.</li>
-</ol>
-
-<hr>
-<p><strong>Example 1 (Narrative Style):</strong></p>
-
-<p><em>“In writing this research proposal, I used Chatbot GPT, on December 9th, to help me with understanding the conceptual definitions and differences between research ethics and research integrity. It started with the following prompt: ‘Write a 300-word piece about the difference between research ethics and research integrity.’ Then I used other similar prompts to help me better understand these two constructs. The generated text was not copied verbatim and included in my Research Proposal; it was paraphrased and included in the Overall Introduction. I further used academic citations and other readings that I have done to assist with my paraphrasing.”</em></p>
-
-<hr>
-<p><strong>Example 2 (Structured Style):</strong></p>
-
-<ul>
-	<li><strong>1. Tool &amp; Date:</strong> Perplexity, Oct 26, 2025</li>
-	<li><strong>2. Task/Purpose:</strong> To summarize a complex academic source to ensure I understood its main argument.</li>
-	<li><strong>3. Prompt(s) Used:</strong> &quot;Summarize the main arguments and methodology of the attached article: [article_file.pdf]&quot;</li>
-	<li><strong>4. Integration &amp; Oversight:</strong> I compared Perplexity&#x27;s summary to my own reading of the article to verify its accuracy. The summary helped clarify the author&#x27;s position on... I then used this clarified understanding to formulate my own critique in the second paragraph of my literature review, citing the original source directly.</li>
-</ul>
-</div>
-
-<h3><i></i>Model B: The Process Narrative</h3>
-
-<p><strong>Best For:</strong> Capstone projects, portfolios, design projects, or any work where AI is integrated throughout a long-term creative process.</p>
-
-<p><strong>Concept:</strong> Instead of logging every single prompt, you write a narrative that describes the overall role AI played in your workflow. This approach focuses on the <em>process</em> and your strategic decisions, demonstrating how you directed the AI as a tool to achieve your project goals.</p>
-
-<p><strong>Example:</strong> For a real-world model, you can read the detailed Process Narrative outlining how this very AI Literacy website was built using AI as a strategic partner:</p>
-
-<p><a href="ai-contribution-statement.html" target="_blank"><strong>See the AI Contribution Statement for This Website <i></i></strong></a></p>
-
-<div>
-<h5><i></i>The Bottom Line</h5>
-
-<p>An AI Contribution Statement is a declaration of your own intellectual honesty and confidence. It demonstrates that you are in control of your tools and are proud of the work—and thinking—that you have contributed. Ultimately, it&#x27;s a tool for self-reflection that helps you answer the only question that truly matters: <strong>At the end of the day, whose thinking is on the page?</strong></p>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<h1><i></i>AI for Brainstorming &amp; Structuring Ideas</h1>
-
-<div><img alt="Blueprint morphing into building" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/blueprint_to_building1.png"></div>
-
-<div>
-<div>
-<p>Pre-writing (e.g., brainstorming, free-writing, clustering, and outlining) transforms a vague topic into a workable blueprint. Done well, it identifies hidden angles and ideas, spots weak links early, and saves drafting time later. AI can act as an always-on collaborator, offering fresh perspectives and fast categorization without stealing your voice. The activities that follow combine hands-on exercises with targeted prompts so you stay in control while the machine handles the heavy lifting.</p>
-</div>
-
-<div>
-<details><summary><i></i><span>1. Idea-Generation Sprint</span></summary>
-
-<div>
-<p><i></i>Activity inspired by: <a href="https://thesavvyredpen.com/writers-block-brain-dump" rel="noopener noreferrer" target="_blank">Writer&#x27;s Block Brain Dump from The Savvy Red Pen</a></p>
-
-<div>
-<h4><i></i>Task</h4>
-
-<p>Create a rich bank of ideas on a topic, beginning with a solo brain-dump and then inviting AI to widen the lens without drowning your ideas. We&#x27;ll pick an arbitrary example of a topic for this exercise: <em>Cultural-Studies essay on “Food and Identity in Immigrant Communities”</em></p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do it</h4>
-
-<p><strong>Use your brain first</strong></p>
-
-<ol>
-	<li><strong>Three minute brain dump</strong>: Write nonstop for three minutes every notion, phrase, or story that pops up (e.g., grandma’s recipes, fusion restaurants, nostalgia, language on menus). No editing.</li>
-	<li><strong>Skim your brain dump</strong> and identify related items (e.g., economics, gender roles).</li>
-</ol>
-
-<p><strong>Get Some AI Input</strong></p>
-
-<ol start="3">
-	<li>Put the topics into an AI tool and ask it to categorize the ideas. See if it gets the same results as you.
-	<pre>
-<code>Act as a cultural-studies brainstorming partner. For this list of ideas on the topic of Food and Identity in Immigrant Communities:
-[add list here]
-Identify common themes and split the ideas into categories.</code></pre>
-	</li>
-	<li>Compare your categories to the AI generated categories and then determine which you are going to keep.</li>
-	<li>Ask the AI to add two fresh angles or ideas per category plus one wildcard idea that doesn&#x27;t fit any category.
-	<pre>
-<code>Act as a cultural-studies brainstorm partner. For each category below, list two new angles or ideas (≤15 words each) that we have not already discussed. Then suggest one wildcard angle unrelated to any category.
-Categories: [list categories here]</code></pre>
-
-	<p><em>Note: As long as you are having this conversation in the same thread in the generative AI chatbot, it will have all of the ideas discussed in its context, so you don&#x27;t have to list them again.</em></p>
-	</li>
-	<li>From the full list of discussion angles and ideas, star the ones that feel surprising or exciting; strike anything bland or off-topic. Aim to keep 8-10 ideas and angles total.</li>
-</ol>
-</div>
-
-<div>
-<h4><i></i>Pause and Ponder</h4>
-
-<ul>
-	<li><strong>Ownership check</strong>: Count starred ideas: at least half should be yours. If AI dominates, return to Phase 1 and dig deeper from personal experience or readings.</li>
-	<li><strong>Breadth vs. Depth</strong>: Do the starred angles cover multiple dimensions (history, sociology, personal narrative)? If all sit in one lane, revisit Phase 3 and request angles for missing dimensions.</li>
-	<li><strong>Feasibility scan</strong>: Pick two starred angles and spend 5 minutes searching your library database: can you locate at least one quality source for each? If not, swap them out.</li>
-	<li><strong>Spark test</strong>: Read the final list aloud. Which angle makes you want to keep talking? That spark often signals the best starting point for drafting.</li>
-</ul>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>2. Topic Narrowing Funnel</span></summary>
-
-<div>
-<p><i></i>Activity inspired by: <a href="https://rightquestion.org/what-is-the-qft/" rel="noopener noreferrer" target="_blank">Question Formulation Technique (QFT)</a></p>
-
-<div>
-<h4><i></i>Task</h4>
-
-<p>Turn a broad course theme into a sharp, research-ready question blending your own brainstorming via the QFT with a short burst of AI amplification. We&#x27;ll pick an arbitrary example: <em>Participation in Canadian federal elections by young voters is consistently much less than participation by older voters.</em></p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do it</h4>
-
-<p><strong>Use your brain first</strong></p>
-
-<ol>
-	<li>Write down a factual, neutral statement on your topic.</li>
-	<li>Spend 4 minutes and ask as many questions as you can about this statement. Don&#x27;t judge, don&#x27;t provide answers, these should be questions not statements. Aim for 10-12 how/why/what questions.</li>
-	<li>Mark each question O (open-ended) or C (closed-ended). As an exercise, convert 2 O→C and 2 C→O.</li>
-	<li>Star three questions that feel answerable, interesting, and aligned with the assignment scope.</li>
-</ol>
-
-<p><strong>Get Some AI Input</strong></p>
-
-<ol start="5">
-	<li>Ask an AI tool to deepen each starred question with follow-ups.
-	<pre>
-<code>Act as my political-science research aide. 
-For the general top [paste topic here]
-and my questions here:
-[paste starred questions]
-
-Suggest:
-• 3 probing follow-up questions
-• 3 political science theories that could frame my analysis
-• 3 places I could find supporting data (organisations, datasets or keyword phrases)</code></pre>
-	</li>
-</ol>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Novelty check</strong>: Did any AI-generated angle surprise you? If every follow-up felt predictable, revisit the AI tool and push for riskier questions.</li>
-	<li><strong>Feasibility test</strong>: For the refined thesis question, can you identify at least two peer-reviewed sources within 10 minutes of searching? If not, narrow or redirect.</li>
-	<li><strong>Ownership audit</strong>: Highlight in one colour the words that are entirely yours and in another the phrases inspired by AI. Your final wording should lean heavily toward the first colour.</li>
-	<li><strong>Alignment scan</strong>: Ensure your question matches the assignment’s required focus (e.g., causal analysis vs. policy proposal).</li>
-</ul>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>3. Thesis Build &amp; Stress Test</span></summary>
-
-<div>
-<p><i></i>Activity inspired by: <a href="https://owl.purdue.edu/owl/general_writing/academic_writing/establishing_arguments/organizing_your_argument.html" rel="noopener noreferrer" target="_blank">Organizing Your Argument (Purdue OWL)</a></p>
-
-<div>
-<h4><i></i>Task</h4>
-
-<p>Craft a defensible thesis, then poke holes in it before anyone else can.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do it</h4>
-
-<p><strong>Drafting the Thesis</strong></p>
-
-<ol>
-	<li><strong>Write</strong> a provisional thesis (≤30 words).</li>
-	<li><strong>Prompt the AI</strong>:
-	<pre>
-<code>Evaluate this thesis for clarity, debatable claim, and scope. Give a scored rubric (0–3) in each category plus one tightening suggestion.
-Thesis: &quot;&lt;your thesis&gt;&quot;</code></pre>
-
-	<p><em>Tip: If you have a rubric from your class about what makes a good thesis statement, include it in the prompt!</em></p>
-	</li>
-</ol>
-
-<p><strong>Stress-Testing the Thesis</strong></p>
-
-<ol start="3">
-	<li><strong>Prompt the AI</strong> with the revised thesis:
-
-	<pre>
-<code>Here is my thesis: &quot;&lt;your revised thesis&gt;&quot;
-
-Identify THREE persuasive counterarguments that an informed critic might raise.
-For EACH counterargument, include ONE concise piece of evidence (e.g., a statistic, study, or report title + year) the critic could cite.
-Format:
-Counterargument 1 – ~25 words
-Evidence – ~25 words</code></pre>
-	</li>
-</ol>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li>Adjust the thesis using any AI score below 3 as a revision target.</li>
-	<li>Decide which counterargument is most dangerous to your claim.</li>
-	<li><strong>Handle the &quot;Usual Suspects&quot;</strong>: AI excels at identifying the most common, predictable counterarguments. Use this to your advantage. By addressing these obvious points, you build a solid foundation, freeing you to focus on anticipating more subtle or expert critiques.</li>
-	<li>Sketch how you’ll address or refute the strongest counterargument in your paper.</li>
-</ul>
-
-<div>
-<p><i></i><strong>Remember: Verify AI-generated evidence.</strong> An AI might invent sources or statistics. That evidence may or may not actually exist. Always treat AI suggestions as leads to be verified from a credible source.</p>
-</div>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>4. Outline Method 1: From Chaos to Cohesion</span></summary>
-
-<div>
-<p><i></i>Activity inspired by: <a href="https://asq.org/quality-resources/affinity" rel="noopener noreferrer" target="_blank">Affinity Diagrams (American Society for Quality)</a></p>
-
-<div>
-<h4><i></i>Task</h4>
-
-<p>Use this if you have a bunch of ideas, but don&#x27;t know where to go next. This method uses a manual &quot;card sort&quot; to build your core structure, then invites AI to give you feedback.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do it</h4>
-
-<p><strong>Use your own brain first</strong></p>
-
-<ol>
-	<li>In a document or on physical sticky notes, list out all your key components (thesis, main ideas, evidence, counterarguments).</li>
-	<li>Group and Cluster: Look at your &quot;cards&quot; and start grouping them into logical piles based on connection.</li>
-	<li>Name the groups (e.g., &quot;historical context&quot;, &quot;economic impact&quot;).</li>
-	<li>Sequence the groups in an order that feels most persuasive.</li>
-</ol>
-
-<p><strong>Get AI Input</strong></p>
-
-<ol start="5">
-	<li>Paste your human-generated draft outline into an AI tool and ask for specific feedback.
-	<div>
-	<h5><i></i>Pro-Tip</h5>
-
-	<p>If you used physical sticky notes, take a picture of the grouped notes. Feed it into an AI tool with image input (like ChatGPT mobile or Google Gemini) and ask it to &quot;OCR this&quot; or &quot;transcribe the text from this image&quot; to get your physical notes into a digital format.</p>
-	</div>
-
-	<pre>
-<code>Act as a writing instructor and argumentation strategist. I have developed a draft outline for my essay. My thesis is: &quot;[Your Thesis Statement Here]&quot;
-
-Here is my proposed structure:
-- Section 1: [Name of your first pile]
-  - [Idea/Evidence 1 from this pile]
-- (continue for all sections)
-
-Based on this structure, please:
-1. Critique the logical flow between the sections. Is there a more persuasive order? Explain why.
-2. Identify any &quot;orphan&quot; ideas that don&#x27;t seem to fit their assigned section.
-3. Suggest where my key counterargument might be most effectively placed and addressed.
-4. Propose a more academic or compelling heading for each section title I created.
-
-IMPORTANT: Explain your reasoning for each suggestion, but do not rewrite the outline for me.</code></pre>
-	</li>
-</ol>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li>Does the order feel persuasive to you? Rearrange any sections until the progression matches how <em>you</em> would argue aloud.</li>
-	<li>Look at any &quot;orphan&quot; ideas the AI may have flagged. Do they need to be moved, developed further, or cut entirely?</li>
-	<li>The final structure should reflect <em>your</em> argumentative voice. The AI is a consultant, not the author. Ensure the final blueprint is one you can confidently build and defend as your own.</li>
-</ul>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>5. Outline Method 2: Building on Your Blueprint</span></summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Use this if you have a clear vision of what your paper should look like. Draft your own outline first, then let a short AI check and flag any gaps, sequencing snags, and missing evidence.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do it</h4>
-
-<p><strong>Use your own brain first</strong></p>
-
-<ol>
-	<li><strong>Skeleton Draft</strong>: Write a two-level outline (1, 1.1, 1.2...) based on your existing ideas and research.</li>
-	<li>Under each section, provide context and identify any data or sources you might use.</li>
-</ol>
-
-<p><strong>Get AI Input</strong></p>
-
-<ol start="3">
-	<li><strong>AI Diagnostic Scan</strong>: Ask the AI to analyze your outline. This should be done in the same chat as your other work for full context.
-
-	<pre>
-<code>Review the outline for the paper below.
-Identify:
-• any logical jumps in section order
-• headings lacking evidence
-• any counterarguments I should anticipate.
-
-Provide feedback in bulletpoint form. Do not rewrite the outline.
-Outline: &lt;paste outline here&gt;</code></pre>
-	</li>
-	<li>Update the outline based on the report.</li>
-</ol>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Balance check</strong>: Does each main section carry roughly equal weight?</li>
-	<li><strong>Source plan</strong>: For every bullet marked “needs evidence,” jot where you’ll search first (database, report, interview).</li>
-	<li><strong>Ownership ratio</strong>: The outline should still read as yours; the AI’s contribution is only the gap flags you acted on.</li>
-</ul>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>6. Audience-Persona Mirror</span></summary>
-
-<div>
-<p><i></i>Activity inspired by: <a href="https://asana.com/resources/empathy-map-template" rel="noopener noreferrer" target="_blank">Empathy Maps (Asana)</a></p>
-
-<div>
-<h4><i></i>Task</h4>
-
-<p>Clarify audience needs so that your tone and evidence hit the mark.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do it</h4>
-
-<p><strong>Persona Draft</strong></p>
-
-<ol>
-	<li><strong>Write</strong> a 50-word profile of your intended reader (peer, specialist, etc.), including their background knowledge and possible bias.</li>
-	<li><strong>Prompt the AI</strong>:
-	<pre>
-<code>Given this persona, list five questions they would expect the paper to answer and two stylistic preferences (e.g., formal tone, visuals).
-Paper Topic: &lt;add paper topic here&gt;
-Persona: &lt;add 50-word profile here&gt;</code></pre>
-	</li>
-</ol>
-
-<p><strong>Application</strong></p>
-
-<ol start="3">
-	<li><strong>Prompt the AI</strong> again:
-
-	<pre>
-<code>Act as a writing coach. Based on the following audience persona and one of their priority questions, help me brainstorm ways to connect with that reader in my introduction.
-
-1. Suggest a compelling hook (an image, quote, or stat) that would grab this reader’s attention.
-2. Recommend one example or case study I could use later in the essay that this reader would find especially relevant or persuasive.
-3. Identify a tone (e.g., conversational, analytical, urgent) that would likely resonate with them and briefly explain why.
-
-Audience Persona: &lt;insert your 50-word persona here&gt;
-Reader’s priority question: &lt;insert the question or questions they would most want answered&gt;</code></pre>
-	</li>
-</ol>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li>Are the AI-generated questions truly relevant? Keep, delete, or edit.</li>
-	<li>Does the suggested hook align with your voice? Rewrite it until it does.</li>
-	<li>Do you think the AI&#x27;s recommended examples will truly resonate with someone matching the audience persona?</li>
-	<li>Did any of the AI&#x27;s questions make you see your topic from a completely new angle?</li>
-</ul>
-
-<div>
-<p><i></i><strong>Verify Every Factual Claim</strong></p>
-
-<p>An AI might suggest a compelling statistic, case study, or quote. However, it can also invent these details (&quot;hallucination&quot;). These fabrications often sound plausible but are not real. Treat every factual claim from an AI as a lead, not a fact. Your next step is to go to your library&#x27;s databases to find the <em>actual</em> study, report, or quote. Never cite a source provided by an AI without first locating and reading it yourself.</p>
-</div>
-</div>
-</div>
-</details>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    
-<div id="gai-wrap">
-<div>
-<h1><i></i>Drafting Support: Brain-Driven Prose, AI-Assisted Polish</h1>
-
-<div>
-<div>
-<p>When pre-writing, you drew the blueprint by crafting a thesis, outline, and audience profile. Now you&#x27;ll build the prose, leaning on GenAI as a writing coach but not as your ghost-writer.</p>
-
-<p>Drafting is where the temptation to outsource your thinking is the strongest. The activities here are designed to help you resist that temptation, keeping you in creative and critical control. You will use AI <em>only</em> for targeted feedback, option-generation, and diagnostic checks on text <em>you have already written</em>. Exercise your brain; build those neural paths so that critical thinking becomes easier and more natural. Then get AI feedback to reveal blind spots and help you polish your prose.</p>
-
-<p>Every activity in this section is built on a three-step workflow. This process ensures you are always doing the heavy intellectual lifting.</p>
-</div>
-
-<div>
-<h5><i></i>The Core Workflow: Your Three-Step Process</h5>
-
-<p><strong>1. Brain First ➜</strong> You create the raw material. This means writing the initial clunky sentence, the underdeveloped paragraph, or the full first draft. The thinking and the words originate with you.</p>
-
-<p><strong>2. AI for Options ➜</strong> You take your self-generated text to the AI. You prompt it to act as a coach, an editor, or a strategist—requesting <em>feedback</em>, <em>analysis</em>, or <em>alternative options</em> (phrasing, structure, examples), never the final answer.</p>
-
-<div>
-<p><strong>Reminder:</strong> Never paste copyrighted or private data into public models.</p>
-</div>
-
-<p><strong>3. Use Your Judgement ➜</strong> You critically evaluate the AI&#x27;s output. You are the final authority. You accept, reject, or modify the suggestions based on your own judgment, voice, and argumentative goals.</p>
-
-<div id="svg-wrapper"><svg aria-labelledby="chartTitle chartDesc" id="flowchart" viewbox="0 0 900 300">
-<title id="chartTitle"></title>
-<desc id="chartDesc">A three-step flowchart. Step 1: Use your brain/Do the writing. Step 2: AI for feedback and options. Step 3: Apply your judgement. Arrows connect the steps sequentially.</desc> <defs> <marker id="arrowhead" markerheight="8" markerwidth="8" orient="auto-start-reverse" refx="9" refy="5" viewbox="0 0 10 10"> <path d="M 0 0 L 10 5 L 0 10 z"></path> </marker> </defs> <path d="M 260 150 L 340 150" id="arrow1"></path> <path d="M 560 150 L 640 150" id="arrow2"></path> <g aria-label="Step 1: Use your brain and do the writing" id="step1"> <rect height="100" rx="15" width="210" x="50" y="100"></rect> <text text-anchor="middle"> <tspan x="155" y="145">Use your brain /</tspan> <tspan x="155" y="165">Do the writing</tspan> </text> </g> <g aria-label="Step 2: Use AI for feedback and options" id="step2"> <rect height="100" rx="15" width="210" x="350" y="100"></rect> <text text-anchor="middle"> <tspan x="455" y="145">AI for feedback</tspan> <tspan x="455" y="165">&amp; options</tspan> </text> </g> <g aria-label="Step 3: Apply your judgement" id="step3"> <rect height="100" rx="15" width="210" x="650" y="100"></rect> <text text-anchor="middle"> <tspan x="755" y="155">Apply your judgement</tspan> </text> </g> </svg></div>
-</div>
-
-<details><summary> <i></i> <span>Your Brain on LLMs: Emerging Evidence on the Value of Using Your Brain First</span> </summary>
-
-<div>
-<p>New MIT research shows that when students use LLMs for writing, they experience reduced brain connectivity, lower satisfaction, and impaired ownership of their ideas. The convenience of using an LLM comes with genuine cognitive costs. We&#x27;re not saying avoid AI; we are saying that if you do the intellectual heavy lifting first, then use AI strategically for feedback and refinement, you&#x27;ll build your brain AND be more proud of the end result.</p>
-
-<div>
-<p><a href="https://www.brainonllm.com/" rel="noopener noreferrer" target="_blank">Your Brain on LLMs Paper</a></p>
-</div>
-<div>
-<p>
-<a href="https://github.com/jck-sz/llm-useful-stuff/blob/master/README.md">Some prompting ideas that will force you to think along with the LLM</a></p>
-</div>
-
-</div>
-</details>
-
-<div>
-<h4><i></i>Balance Meter - A Quick Self-Check</h4>
-
-<ol>
-	<li>Did I write at least 75% of this draft <em>before</em> consulting AI? (About enough original writing that you can explain your entire argument without referring back to the AI output.)</li>
-	<li>Can I explain, without the chatbot open, why I kept or rejected each AI suggestion?</li>
-	<li>Have I verified every fact, citation, or statistic that appears in my prose?</li>
-</ol>
-</div>
-
-<hr>
-<div>
-<details><summary><i></i><span>Activity 1: The Accordion Method - Strong Paragraphs</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> To write a fully developed and substantiated paragraph starting with a single topic sentence from your outline.</p>
-
-<p><strong>Task:</strong> Write out a complete paragraph that provides evidence, analysis, and significance for your main point. Then, use targeted AI feedback to identify and strengthen the paragraph&#x27;s weakest link.</p>
-
-<div>
-<h4><i></i>Dive-in &amp; Do It</h4>
-
-<p><strong>Use your brain first:</strong> This is where you do the real work of drafting. Your goal is to build a complete paragraph from a single idea.</p>
-
-<ol>
-	<li><strong>Start with your Point:</strong> Write down one topic sentence from your outline.</li>
-	<li><strong>Add your Evidence:</strong> Write a sentence that introduces a piece of evidence (a fact, quote, or data point) to support that point.</li>
-	<li><strong>Provide your Analysis:</strong> Write 2+ sentences explaining what the evidence <em>means</em> and how it proves your point.</li>
-	<li><strong>State the Significance:</strong> Write a final sentence that connects the entire paragraph back to your paper&#x27;s main thesis. Why does this point matter?</li>
-</ol>
-
-<p>You have now drafted a complete paragraph entirely on your own.</p>
-
-<p><strong>Get AI Input:</strong> Now, use the AI as a quality auditor. The prompt below asks the AI to diagnose potential weaknesses and asks you a question about it. It is not intended to rewrite anything for you.</p>
-
-<pre>
-<code>Act as a writing coach. I have drafted a paragraph using the Point -&gt; Evidence -&gt; Analysis -&gt; Significance structure.
-
-My paragraph:
-&quot;[Paste your full, self-written paragraph here]&quot;
-
-Your task is to:
-1. Identify the weakest part of my paragraph (Is the analysis too shallow? Is the evidence not clearly connected to the point? Is the significance unclear?).
-2. Ask me specific, probing questions that will force me to think more deeply about how to strengthen that single part. Do not rewrite any part of my paragraph.</code></pre>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ol>
-	<li>Do you agree with the AI&#x27;s diagnosis? Why do you think it identified <em>that specific part</em> of your paragraph as the weakest?</li>
-	<li>Take a moment to answer the AI&#x27;s question in your own words. How did answering it help you see a gap in your original draft?</li>
-	<li>Based on your answer, revise your original paragraph. What specific changes did you make to the evidence, analysis, or significance to make the paragraph stronger?</li>
-</ol>
-</div>
-
-<div>
-<h5><i></i>Notes for Instructors</h5>
-
-<p>If you want to adapt this activity in your class, here are some things to consider:</p>
-
-<ul>
-	<li><strong>Model the Process:</strong> Before students try this, model it live. Start with a topic sentence and &quot;think aloud&quot; as you write the evidence, analysis, and significant sentences.</li>
-	<li><strong>Peer-to-Peer Coaching:</strong> For an AI-free version, have students swap paragraphs and perform the AI&#x27;s role: identify the weakest part and ask one probing question.</li>
-	<li><strong>Focus on the &quot;Why&quot;:</strong> The most valuable part of this exercise is the student&#x27;s answer to the AI&#x27;s question. Assess their ability to reflect on and deepen their own analysis.</li>
-	<li><strong>Connect to Outlining:</strong> Reinforce that a clear, focused topic sentence (from their outline) makes the entire accordion expansion process dramatically easier and more effective.</li>
-</ul>
-</div>
-
-<div>
-<h5>References</h5>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Paragraph development</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/paragraphs/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/paragraphs/</a></p>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>Activity 2: Clarity Clinic – Repairing Clunky Sentences</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> To practice diagnosing and revising your own sentences for clarity and impact, using AI-generated alternatives as a catalyst for your own editorial decisions.</p>
-
-<p><strong>Task:</strong> Identify a weak sentence in your draft, diagnose its problem, and use AI-generated options to help you craft a more precise and powerful version.</p>
-
-<div>
-<h4><i></i>Dive-in &amp; Do It</h4>
-
-<p><strong>Use your brain first:</strong></p>
-
-<ol>
-	<li>Find a sentence from your draft that feels clunky, awkward, or unclear.</li>
-	<li>In one sentence, diagnose the problem. What makes it weak? (e.g., &quot;The verb is passive,&quot; &quot;It tries to do too much at once,&quot; &quot;The meaning is ambiguous.&quot;)</li>
-</ol>
-
-<p><strong>Get AI Input:</strong> Use the prompt below to get targeted feedback. By providing your own diagnosis in the prompt, you give the AI better context to act as your coach.</p>
-
-<pre>
-<code>Act as my writing center tutor. My goal is to improve the clarity and impact of a sentence from my draft.
-
-My clunky sentence:
-&quot;[Paste your sentence here]&quot;
-
-My diagnosis of the problem:
-&quot;[Paste your one-sentence diagnosis here]&quot;
-
-Based on my diagnosis, provide:
-1. several distinct, revised versions of my sentence.
-2. For each version, add a one-sentence explanation of the specific editorial strategy you used (e.g., &quot;This version uses a stronger verb,&quot; &quot;This version splits the complex idea into two sentences,&quot; &quot;This version leads with the main clause for more directness&quot;).</code></pre>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ol>
-	<li>Which of the AI&#x27;s suggested strategies most directly solves the problem you diagnosed in the &quot;Brain First&quot; step?</li>
-	<li>What specific change (e.g., a different word, moving a clause) had the biggest positive impact on the sentence&#x27;s clarity? Why was it so effective?</li>
-	<li>Read your final, revised sentence aloud. How does it sound more like <em>you</em> than any of the raw AI options?</li>
-</ol>
-</div>
-
-<div>
-<h5><i></i>Notes for Instructors</h5>
-
-<p>If you want to adapt this activity in your class, here are some things to consider:</p>
-
-<ul>
-	<li><strong>Model it Live:</strong> Project a clunky sentence, diagnose it aloud, consult the AI, and talk through your final editorial choice to make your expert thinking visible.</li>
-	<li><strong>Use a &quot;Sentence Swap&quot;:</strong> Have students diagnose a partner&#x27;s sentence <em>before</em> using the AI. This builds their analytical skills on unfamiliar text.</li>
-	<li><strong>Assess the &quot;Why&quot;:</strong> Ask students to submit a one-sentence justification for their final choice. The quality of their reasoning is the true measure of learning.</li>
-	<li><strong>Encourage Remixing:</strong> Challenge students to &quot;remix&quot; the AI&#x27;s options—taking a verb from one and a structure from another—to reinforce their role as the final author.</li>
-</ul>
-</div>
-
-<div>
-<h5>References</h5>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Style</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/style/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/style/</a></p>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Passive voice</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/passive-voice/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/passive-voice/</a></p>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Word choice</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/word-choice/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/word-choice/</a></p>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>Activity 3: Make it Concrete - Improve Your Arguments</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> To transform abstract, general claims into powerful, persuasive arguments by substantiating them with specific, concrete details and evidence.</p>
-
-<p><strong>Task:</strong> Identify vague sentences in your draft and use AI-generated questions to help you unearth the specific details needed to make your writing more vivid and credible.</p>
-
-<div>
-<h4><i></i>Dive-in &amp; Do It</h4>
-
-<p><strong>Use your brain first:</strong></p>
-
-<ol>
-	<li>Find a sentence in your draft that makes a general claim or uses abstract language that isn&#x27;t supported by specific proof. (e.g., &quot;The policy had a negative impact,&quot; or &quot;The character experienced significant growth.&quot;)</li>
-	<li>Before using the AI, <strong>analyze the claim</strong>.
-	<ul>
-		<li>What type of claim is this? (e.g., A claim of fact/value/cause&amp;effect)</li>
-		<li>What type of evidence would my audience need to be convinced? (a statistic, a direct quote, a concrete example, an illustrative anecdote)</li>
-	</ul>
-	</li>
-</ol>
-
-<p><strong>Get AI Input:</strong> Now, challenge your own thinking. Use the prompt below to have the AI act as a curious reader who needs more information to be convinced.</p>
-
-<pre>
-<code>Act as a skeptical but curious reader. I want to make a general claim from my draft more specific and convincing.
-
-My general claim is:
-&quot;[Paste your abstract sentence here]&quot;
-
-Your task is to ask me three probing questions that would force me to provide more concrete, sensory, or factual details. Frame your questions to start with phrases like:
-- &quot;What does that look like specifically?&quot;
-- &quot;Can you give me a direct example of...?&quot;
-- &quot;How could a reader see or measure that...?&quot;
-- &quot;Who exactly was affected and how?&quot;
-
-Do not suggest any answers or rewrites. Only ask the questions.</code></pre>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ol>
-	<li>Look at the AI&#x27;s questions. How did they push you to think more specifically about the <em>type</em> of evidence your argument required?</li>
-	<li>Answer the AI&#x27;s questions using your own knowledge or research. Now, rewrite your original sentence incorporating these new, specific details.</li>
-	<li>Read your &quot;before&quot; and &quot;after&quot; sentences. How does the revised, more specific version change the reader&#x27;s experience and the credibility of your argument?</li>
-</ol>
-</div>
-
-<div>
-<h5><i></i>Note for Instructors</h5>
-
-<p>If you want to adapt this activity in your class, here are some things to consider:</p>
-
-<ul>
-	<li><strong>Model the Process:</strong> Project a vague sentence from a sample text. Ask the class for probing questions before using the AI to show that this is a human-first critical thinking skill.</li>
-	<li><strong>Create a Before and After Gallery:</strong> In a shared document, have students post their &quot;before&quot; (vague) and &quot;after&quot; (vivid) sentences. This creates a powerful visual bank of examples.</li>
-	<li><strong>Peer Review Role-Play:</strong> Have students swap vague sentences and act as the &quot;skeptical reader&quot; for their partner, asking the probing questions themselves. (This is a miniature version of the PAIRR Framework where students peer review each others papers and have an AI do a review as well).</li>
-</ul>
-</div>
-
-<div>
-<h5>References</h5>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Argument</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/argument/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/argument/</a></p>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Evidence</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/evidence/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/evidence/</a></p>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>Activity 4: Tone Tuner – Matching Tone to Audience</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> To adjust the tone of your writing to meet the specific needs of your audience, without sacrificing your authentic authorial voice.</p>
-
-<p><strong>Task:</strong> Analyze a paragraph for tone, use an AI to suggest targeted word changes based on your audience persona, and make deliberate editorial choices to improve a match.</p>
-
-<div>
-<h4><i></i>Dive-in &amp; Do It</h4>
-
-<p><strong>Use your brain first:</strong></p>
-
-<ol>
-	<li>Select one or more paragraphs from your draft (you could use the whole draft if you want).</li>
-	<li>Review the audience persona you developed in the Pre-writing section or create one if you haven&#x27;t already. Then answer these questions:
-	<ul>
-		<li>What does my audience value? (e.g., clear data, directness, creative thinking, efficiency, respect for tradition)</li>
-		<li>What impression do I want my writing to convey? (seem knowledgeable and objective, innovative and passionate, or respectful and cautious)</li>
-	</ul>
-	</li>
-	<li>Re-read your paragraph through the lens of your answers. Pinpoint 2-3 points where your writing fails to align with your audience&#x27;s values or the impression you want to make.</li>
-</ol>
-
-<p><strong>Get AI Input:</strong> Use the prompt below. Including your own analysis and the persona gives the AI the specific context it needs to provide high-quality feedback.</p>
-
-<pre>
-<code>Act as a rhetorical coach. My goal is to align the tone of my paragraph with my target audience.
-
-My Audience Persona:
-&quot;[Paste your audience persona here]&quot;
-
-My Audience&#x27;s Core Values: &quot;[List the values you identified in step 2]&quot;
-The Impression I Want to Convey: &quot;[State the impression you identified in step 2]&quot;
-
-My Draft Section:
-&quot;[Paste your writing here]&quot;
-
-My initial analysis identified these specific mismatches: 
-[List the 2-3 parts you identified]
-
-Based on this, provide:
-1. A three-column table (Original | Proposed | Rationale) with 5-7 suggested word or phrase swaps that would make the tone more effective for my audience.
-2. In the second column, alongside the suggestion, add a brief justification that explains *why* the new word is a better fit for the persona (e.g., &quot;replaces a casual idiom with a more formal term,&quot; &quot;uses a verb with a more analytical connotation&quot;).</code></pre>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ol>
-	<li>How did the AI&#x27;s suggestions compare to the words you initially identified? Did it confirm your instincts or reveal a blind spot in your self-analysis?</li>
-	<li>Select one AI suggestion you are <strong>rejecting</strong>. What specific nuance, meaning, or part of your authentic voice would be lost if you accepted that change?</li>
-	<li>After making your revisions, what is the single most important lesson you learned about writing for this specific audience?</li>
-</ol>
-</div>
-
-<div>
-<h5><i></i>Note for Instructors</h5>
-
-<p>If you want to adapt this activity in your class, here are some things to consider:</p>
-
-<ul>
-	<li><strong>Audience Guessing Game:</strong> Have students review a partner&#x27;s &quot;before&quot; and &quot;after&quot; paragraphs and try to guess the intended audience persona. A misidentification is a great learning moment about tone.</li>
-	<li><strong>Focus on Rejection:</strong> Ask students to share one AI suggestion they <em>rejected</em> and their reason why. This highlights their critical judgment and authorial control.</li>
-	<li><strong>Build a &quot;Tone Lexicon&quot;:</strong> Create a class document where students add effective word swaps they discovered for different tones (e.g., Formal, Persuasive, Skeptical).</li>
-	<li><strong>Connect to Pre-writing:</strong> This activity directly demonstrates the practical value of the &quot;Audience-Persona Mirror&quot; activity, showing students how planning pays off in revision.</li>
-</ul>
-</div>
-
-<div>
-<h5>References</h5>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Audience</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/audience/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/audience/</a></p>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>Activity 5: The Bridge Builder - Paragraph Transitions</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> To craft clear and logical transitions that guide your reader smoothly from one idea to the next, reinforcing the overall coherence of your argument.</p>
-
-<p><strong>Task:</strong> Analyze the logical link between two paragraphs, use an AI to generate options for executing that link, and select or craft a transition that best serves your argument.</p>
-
-<div>
-<h4><i></i>Dive-in &amp; Do It</h4>
-
-<p><strong>Use your brain first:</strong></p>
-
-<ol>
-	<li>Select two adjacent paragraphs from your draft.</li>
-	<li>For each paragraph, write a single sentence that states its main point or claim.</li>
-	<li>Now, write one sentence that describes the <strong>logical relationship</strong> between those two points. (e.g., &quot;Paragraph 2 provides a specific example of the general claim in Paragraph 1,&quot; or &quot;Paragraph 2 presents a counterargument to the idea in Paragraph 1.&quot;)</li>
-</ol>
-
-<p><strong>Get AI Input:</strong> Use the prompt below. Providing your analysis of the relationship is the key to getting high-quality, relevant suggestions from your AI coach.</p>
-
-<pre>
-<code>Act as a writing coach specializing in argument structure. My goal is to create a strong transition between two paragraphs.
-
-Main Point of Paragraph 1:
-&quot;[Paste the main point of your first paragraph]&quot;
-
-Main Point of Paragraph 2:
-&quot;[Paste the main point of your second paragraph]&quot;
-
-My analysis of the logical relationship:
-&quot;[Paste your sentence describing the relationship]&quot;
-
-Based on my analysis, provide:
-1. Several distinct transition sentences or phrases that effectively signal this logical relationship to the reader.
-2. For each option, label the primary rhetorical move it uses (e.g., Cause &amp; Effect, Elaboration, Concession, Comparison).</code></pre>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ol>
-	<li>Compare the rhetorical moves suggested by the AI to your own initial analysis. Did the AI offer a more precise or effective way to frame the relationship you identified?</li>
-	<li>Why is the transition you ultimately chose the most effective for guiding your reader? What specific signal does it send them about the information that is about to come?</li>
-	<li>Read the two paragraphs with your new transition aloud. How does it improve the overall flow and logic of your argument?</li>
-</ol>
-</div>
-
-<div>
-<h5><i></i>Note for Instructors</h5>
-
-<p>If you want to adapt this activity in your class, here are some things to consider:</p>
-
-<ul>
-	<li><strong>Rhetorical Move Sort:</strong> Before the activity, give students a list of common transition words (&quot;Therefore,&quot; &quot;However,&quot; &quot;In addition,&quot; &quot;Similarly&quot;) and have them sort them into categories by function.</li>
-	<li><strong>Focus on the &quot;Relationship Sentence&quot;:</strong> The sentence students write in the &quot;Brain First&quot; step is the most important part of the exercise. Use it as a diagnostic tool to see if they understand their own argument&#x27;s structure.</li>
-	<li><strong>Make Thinking Visible:</strong> Have students highlight their final transition sentence in their draft and add a comment explaining the rhetorical move they chose and why.</li>
-	<li><strong>Peer Review the Flow:</strong> In pairs, have students read each other&#x27;s two paragraphs (with the new transition) and describe the logical journey the writer took them on.</li>
-</ul>
-</div>
-
-<div>
-<h5>References</h5>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Transitions</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/transitions/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/transitions/</a></p>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Flow</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/flow/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/flow/</a></p>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>Activity 6: Crafting the Bookends - Intro &amp; Conclusion</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> To draft an engaging introduction that sets up your argument and a memorable conclusion that reinforces your main takeaway, ensuring your paper starts strong and finishes with impact.</p>
-
-<p><strong>Task:</strong> Draft your full introduction or conclusion, then use a structured AI analysis to evaluate its core components and guide your revision.</p>
-
-<div>
-<h4><i></i>Dive-in &amp; Do It</h4>
-
-<p><strong>Use your brain first:</strong></p>
-
-<ol>
-	<li>Write a complete, full-paragraph draft of the introduction/conclusion. This is your raw material, built entirely from your own thinking.</li>
-</ol>
-
-<p><strong>Get AI Input:</strong> Select the prompt that matches the paragraph you wrote. This provides the AI with a clear rubric to act as your structural coach.</p>
-
-<p><em>Introduction Prompt:</em></p>
-
-<pre>
-<code>Act as a writing instructor evaluating the introduction of a paper.
-
-My draft introduction:
-&quot;[Paste your full introduction paragraph here]&quot;
-
-Your task is to analyze my draft based on the three core jobs of an introduction:
-1.  **The Hook:** Quote the sentence(s) you believe act as the hook. Is it effective at grabbing the reader&#x27;s attention?
-2.  **The Context:** Briefly describe the context my introduction provides. Is it sufficient for a reader to understand the topic?
-3.  **The Thesis:** Quote the sentence you believe is my thesis statement. Is it clear, specific, and arguable?</code></pre>
-
-<p><em>Conclusion Prompt:</em></p>
-
-<pre>
-<code>Act as a writing instructor evaluating the conclusion of a paper.
-
-My draft conclusion:
-&quot;[Paste your full conclusion paragraph here]&quot;
-
-Your task is to analyze my draft based on the three core jobs of a conclusion:
-1.  **The Synthesis:** Does the paragraph briefly synthesize the paper&#x27;s main points (without just listing them)?
-2.  **The &quot;So What?&quot;:** Identify the sentence(s) that explain the broader significance, implications, or importance of my argument.
-3.  **The Final Thought:** Does the paragraph offer a memorable final thought that leaves a lasting impression?</code></pre>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ol>
-	<li>Review the AI&#x27;s analysis. If it struggled to identify one of the core components (like your thesis or your &quot;so what?&quot; statement), what does that tell you about the clarity of your writing?</li>
-	<li>The AI identified a specific element as the weakest. Do you agree with this diagnosis? Why or why not?</li>
-	<li>Based on this feedback, what are the revisions you will make to your introduction and conclusion to make them more effective?</li>
-</ol>
-</div>
-
-<div>
-<h5>References</h5>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Introductions</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/introductions/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/introductions/</a></p>
-
-<p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Conclusions</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/conclusions/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/conclusions/</a></p>
-</div>
-</div>
-</details>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<h1><i></i>Using AI for Revising, Editing, and Proofreading</h1>
-
-<div>
-<div>
-<p><strong>Revising:</strong> Revision is RE-VISION, i.e., looking at your draft again. During revision, you focus on things like your arguments, evidence and purpose and not on nitty-gritty details like commas and word choice. In this stage of writing, you are confirming that the foundation of your paper is solid.</p>
-
-<p><strong>Consider:</strong></p>
-
-<ul>
-	<li><strong>Purpose &amp; Argument:</strong> Is my thesis clear and compelling? Is it consistently supported throughout the paper?</li>
-	<li><strong>Audience:</strong> Will this draft meet the expectations of my intended readers (e.g., my professor, my classmates)?</li>
-	<li><strong>Structure &amp; Flow:</strong> Does my argument progress logically? Are the paragraphs in the right order?</li>
-</ul>
-
-<p>For a deeper dive, see the UNC Writing Center&#x27;s guide on <a href="https://writingcenter.unc.edu/tips-and-tools/revising-drafts/" rel="noopener noreferrer" target="_blank">Revising Drafts</a>.</p>
-
-<hr>
-<p><strong>Editing:</strong> Editing is refining; it&#x27;s where you focus on how you express your ideas, ensuring your language is clear, effective, and polished.</p>
-
-<p><strong>Consider:</strong></p>
-
-<ul>
-	<li><strong>Clarity &amp; Style:</strong> Are my sentences easy to understand? Is my tone appropriate for my audience?</li>
-	<li><strong>Paragraphs:</strong> Does each paragraph have a clear topic sentence? Is there a good balance of evidence and my own analysis?</li>
-	<li><strong>Flow:</strong> Are the transitions between sentences and paragraphs smooth?</li>
-</ul>
-
-<p>For more, see the UNC Writing Center&#x27;s guide on <a href="https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/" rel="noopener noreferrer" target="_blank">Editing and Proofreading</a>.</p>
-
-<hr>
-<p><strong>Proofreading:</strong> Proofreading is polishing the final details. It involves hunting for errors and typos that can distract your reader and undermine your credibility.</p>
-
-<p><strong>Look for:</strong></p>
-
-<ul>
-	<li>Grammar &amp; Punctuation Errors</li>
-	<li>Spelling Mistakes</li>
-	<li>Formatting Issues (e.g., citations, page numbers)</li>
-	<li>Typos</li>
-</ul>
-
-<p>Generative AI tools like ChatGPT, Grammarly, Lex and many others are excellent tools to support your revising, editing, and proofreading processes - as long as you don&#x27;t let them do all the work. Remember: use your brain first, apply AI tools next, then use your own judgement in creating the final product. If you&#x27;ve reached this stage you should have been using your brain a lot to create your first draft. To effectively integrate AI into your revising, editing, and proofreading process, here is a suggested workflow:</p>
-</div>
-
-<div>
-<h5><i></i>Recommended Workflow</h5>
-
-<p>Using AI to enhance your Revising -&gt; Editing -&gt; Proofreading without replacing your own intellectual effort.</p>
-
-<ol>
-	<li><strong>Use your brain first: <a href="ai-generated-writing-effective-and-ethical-use.html" target="_blank">Complete Your Draft</a>.</strong> Write the entire paper using your own thinking. Get your ideas down without worrying about perfection.</li>
-	<li><strong>Revise with AI as a Structural Analyst.</strong> Use AI for the big picture. <strong>Focus:</strong> purpose, argument, audience, structure.</li>
-	<li><strong>Edit with AI as a Style Coach.</strong> Once the structure is solid, focus on how the ideas are expressed. <strong>Focus:</strong> clarity, tone, sentence variety, paragraph coherence and organization.</li>
-	<li><strong>Proofread with AI as a Detail-Checker.</strong> Use tools for the final polish. <strong>Focus:</strong> grammar, spelling.</li>
-</ol>
-</div>
-
-<div>
-<h5><i></i>Important Tips</h5>
-
-<ul>
-	<li>Get feedback from the AI, but make the edits yourself. This will help you understand and identify patterns in your writing that can be improved.</li>
-	<li>Evaluate all AI suggestions against the intended message, your own voice, and common sense. Pay special attention to factual errors, depth, nuance, authenticity, and bias.</li>
-	<li>Put another human in the loop and seek peer/instructor/expert feedback.</li>
-	<li>Always perform a final, human read-through to catch errors the AI missed and ensure the voice is yours.</li>
-</ul>
-</div>
-
-<h2><i></i>Activities</h2>
-
-<p>For each of the revising and editing activities, I strongly recommend following the <a href="https://www.sciencedirect.com/science/article/pii/S8755461525000088#sec0024" rel="noopener noreferrer" target="_blank">PAIRR framework</a> for getting peer feedback (download the Word doc in the Appendix of the PAIRR paper. Supplementary materials section), AI feedback and then comparing the two. If you cannot get peer feedback, then you do the revising and editing activities yourself and compare to what the AI gives you.</p>
-
-<div>
-<details><summary><i></i><span>The PAIRR Framework: Integrating Peer and AI Feedback</span></summary>
-
-<div>
-<ol>
-	<li>Complete the rough draft.</li>
-	<li><strong>P</strong>rovide and receive peer feedback.</li>
-	<li>Receive <strong>AI</strong> feedback using the prompt below.</li>
-</ol>
-
-<pre>
-<code>**I am a student in a university writing course working on a paper. Pretend you are a peer-reviewer who will review my draft based on the assignment prompt and grading rubric I provide. Please provide clear, detailed, specific, and supportive feedback. The format for your feedback should be as follows: 1. Two to three positive aspects of my paper and why those aspects are effective. 2. Three to four aspects for revision and the reasoning about why each poses an issue, and 3. A suggestion for revising each one.  
-
-**Here is the assignment prompt: ||copy and paste assignment prompt||**
-
-**Here is the rubric for the assignment:  ||copy and paste rubric||.**
-
-**Here is the paper: ||copy and paste draft||**</code></pre>
-
-<ol start="4">
-	<li><strong>R</strong>eflect and compare the AI and peer feedback.</li>
-	<li><strong>R</strong>evise the draft based on the feedback.</li>
-</ol>
-</div>
-</details>
-</div>
-
-<h2><i></i>Revision Activities</h2>
-
-<p>Revision is where you step back from the sentence-level and look at the big picture: your argument&#x27;s logic, structure, and flow. The activities below treat AI as a <strong>structural analyst</strong>. You&#x27;ll use it to get a &quot;second look&quot; at your paper&#x27;s skeleton, helping you spot logical gaps, strengthen your thesis, and ensure your ideas connect seamlessly.</p>
-
-<div>
-<details><summary><i></i><span>Revision Activity 1: The Reverse Outline</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> To analyze the logical flow and structural integrity of your draft by creating an outline from your finished text. This helps you see if your argument progresses logically or if it jumps around unexpectedly.</p>
-
-<p><strong>Task:</strong> You will create a reverse outline of your draft using your own analytical skills, then ask AI to perform the same task. By comparing the two outlines, you&#x27;ll discover whether you and the AI see the same structural strengths and weaknesses in your paper.</p>
-
-<div>
-<h4><i></i>Dive-in &amp; Do It</h4>
-
-<p><strong>Use your brain first:</strong></p>
-
-<ol>
-	<li>Follow these instructions for <a href="https://writing.wisc.edu/handbook/reverseoutlines/" rel="noopener noreferrer" target="_blank">creating a reverse outline</a> from your draft.</li>
-</ol>
-
-<p><strong>Get AI Input:</strong></p>
-
-<ol start="2">
-	<li>Use the following prompt to have AI create its own reverse outline.</li>
-</ol>
-
-<pre>
-<code>You are an _academic writing coach_ with experience teaching university writing courses. Please review my full draft (pasted below) and build a **reverse outline**.
-
-The purpose of a reverse outline is to help determine if the paper meets its goals, discover places where you might need to expand evidence or analysis, and identify where readers might struggle with your organization or structure.
-
-A reverse outline extracts the main claim of each paragraph so the writer can inspect logic, structure, and flow **after** drafting.
-
-Here are the steps for creating a reverse outline:
-1. Read through the entire draft to understand the thesis and overall arc
-2. For each body paragraph: identify its core idea -&gt; this is sentence &#x27;a&#x27;; and identify its rhetorical job -&gt; this is sentence &#x27;b&#x27;
-3. Number the sentences 1a, 1b, 2a etc. 
-4. Review the numbered list to analyze the paper&#x27;s logical flow and structure and create a Structural Observations commentary where you note the strengthes, flag gaps or redundancies and suggest fixes.
-
-Formatting:
-- Keep each (a)/(b) sentence ≤ 30 words.
-- Keep the **Structural Observations** section ≤ 200 words.
-
-Here is my draft:
-[Paste your complete draft here]</code></pre>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ol>
-	<li><strong>Compare the outlines:</strong> How similar are your reverse outline and the AI&#x27;s version? Where do they differ significantly? What does this reveal about how you and the AI &quot;read&quot; your paper differently?</li>
-	<li><strong>Reverse Outline Questions to ask of yourself and of the AI:</strong>
-	<ul>
-		<li>What do you see as the paper&#x27;s overall argument based on this outline?</li>
-		<li>Which paragraphs seem most closely connected to each other?</li>
-		<li>Are there any paragraphs that seem disconnected from the main argument?</li>
-		<li>Do you notice any repetitive points or gaps in the logical flow?</li>
-		<li>Where might a reader have trouble following the progression of ideas?</li>
-	</ul>
-	</li>
-	<li><strong>Revision decisions:</strong> Based on the two outlines, what are the structural changes you will make to strengthen your paper?</li>
-</ol>
-</div>
-
-<div>
-<h5>References</h5>
-
-<p>University of Wisconsin-Madison Writing Center. (n.d.). Creating a reverse outline. <em>Writer&#x27;s Handbook</em>. <a href="https://writing.wisc.edu/handbook/reverseoutlines/" rel="noopener noreferrer" target="_blank">https://writing.wisc.edu/handbook/reverseoutlines/</a></p>
-</div>
-</div>
-</details>
-
-<hr>
-<details><summary><i></i><span>Revision Activity 2: Build Your Own Revision Prompt</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> To develop your ability to create effective prompts that guide AI to provide useful revision feedback while maintaining your role as the decision-maker in the revision process.</p>
-
-<p><strong>Task:</strong> You will study established revision strategies, then engineer a comprehensive prompt that directs AI to analyze your draft and provide specific, actionable feedback. You&#x27;ll evaluate the AI&#x27;s response and selectively implement suggestions that align with your goals.</p>
-
-<div>
-<h4><i></i>Dive-in &amp; Do It</h4>
-
-<p><strong>Use Your Brain First:</strong></p>
-
-<ol>
-	<li>Study these two guides on making revisions:
-	<ul>
-		<li>George Mason University Writing Center. (n.d.). <a href="https://writingcenter.gmu.edu/writing-resources/writing-as-process/23-ways-to-improve-your-draft" rel="noopener noreferrer" target="_blank"><em>23 ways to improve your draft</em></a>.</li>
-		<li>The Writing Center, University of North Carolina at Chapel Hill. (n.d.). <a href="https://writingcenter.unc.edu/tips-and-tools/revising-drafts/" rel="noopener noreferrer" target="_blank"><em>Revising drafts</em></a>.</li>
-	</ul>
-	</li>
-	<li>Identify 3-4 specific revision areas you want to focus on (e.g., thesis clarity, paragraph structure, evidence integration, transitions).</li>
-	<li>Analyze this basic AI prompt and identify what&#x27;s missing:
-	<pre>
-<code>Please review my essay and tell me how to make it better.
-[paste essay draft here]</code></pre>
-	</li>
-	<li>Improve the prompt using the CRAFT framework:
-	<ul>
-		<li><strong>Context:</strong> What background does the AI need about your paper?</li>
-		<li><strong>Role:</strong> What identity should the AI assume?</li>
-		<li><strong>Action:</strong> What specific tasks should it perform?</li>
-		<li><strong>Format:</strong> How should it structure its response?</li>
-		<li><strong>Tone:</strong> What voice/style should it use?</li>
-	</ul>
-	</li>
-</ol>
-
-<p><strong>Get Some AI Input:</strong></p>
-
-<ol start="5">
-	<li>Test the basic AI prompt by using it with your draft essay.</li>
-	<li>Test your comprehensive prompt by using it with your draft essay.</li>
-</ol>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ol>
-	<li>Compare the response to the basic prompt with the response to the comprehensive prompt.</li>
-	<li>Make strategic revision decisions: Of the AI&#x27;s suggestions, which ones will you implement and why? How will you modify them to fit your voice and purpose? Which suggestions will you reject and what&#x27;s your reasoning?</li>
-</ol>
-</div>
-
-<div>
-<h5><i></i>Notes for Instructors</h5>
-
-<p>If you want to adapt this activity in your class, here are some things to consider:</p>
-
-<ul>
-	<li><strong>Side-by-Side Prompt Demo:</strong> Show a weak, overly broad prompt next to a well-crafted CRAFT prompt. Run both through the AI so students can see the stark difference in feedback quality.</li>
-	<li><strong>Prompt Draft → Peer Debug:</strong> Let students exchange their first-draft prompts and “debug” each other’s wording for clarity, specificity, and ethical boundaries before ever consulting the AI.</li>
-	<li><strong>Quick Fire Revisions:</strong> Set a timer (e.g., 5 minutes) for students to refine their prompt after seeing the AI’s first response. This models iterative design and keeps the session energetic.</li>
-	<li><strong>Ethics Checkpoint:</strong> Require students to add one line in their prompt specifying what the AI should not do (e.g., “Do not rewrite my paragraphs for me”). This reinforces responsible use.</li>
-	<li><strong>Mini-Reflection Exit Ticket:</strong> End class with a sticky-note or LMS post: “One insight I gained about prompt engineering today is ______.” Use these to gauge understanding and plan follow-ups.</li>
-	<li>Use the <a href="https://www.sciencedirect.com/science/article/pii/S8755461525000088" rel="noopener noreferrer" target="_blank">PAIRR Framework</a> with the student&#x27;s drafts and the revision prompt students craft.</li>
-</ul>
-</div>
-
-<div>
-<h5>References</h5>
-
-<p>George Mason University Writing Center. (n.d.). <em>23 ways to improve your draft</em>. <a href="https://writingcenter.gmu.edu/writing-resources/writing-as-process/23-ways-to-improve-your-draft" rel="noopener noreferrer" target="_blank">https://writingcenter.gmu.edu/writing-resources/writing-as-process/23-ways-to-improve-your-draft</a></p>
-
-<p>The Writing Center, University of North Carolina at Chapel Hill. (n.d.). <em>Revising drafts</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/revising-drafts/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/revising-drafts/</a></p>
-
-<p>Sperber, L., MacArthur, M., Minnillo, S., Stillman, N., &amp; Whithaus, C. (2025). Peer and AI Review + Reflection (PAIRR): A human-centered approach to formative assessment. <em>Computers &amp; Composition/Computers and Composition</em>, <em>76</em>, 102921. <a href="https://doi.org/10.1016/j.compcom.2025.102921" rel="noopener noreferrer" target="_blank">https://doi.org/10.1016/j.compcom.2025.102921</a></p>
-</div>
-</div>
-</details>
-</div>
-
-<hr>
-<h2><i></i>Editing Activities</h2>
-
-<p>With a solid structure confirmed, editing is your chance to zoom in on the craft of writing. In this stage you will improve the clarity, impact, and style of your prose. You&#x27;ll use AI as a <strong>style coach</strong>, to provide feedback on sentence construction, word choice, and paragraph coherence.</p>
-
-<div>
-<details><summary><i></i><span>Editing Activity 1: Create an AI Editor</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> Develop skill in identifying editing requirements, engineering prompts that keep the AI in the “advisor” seat, and deciding which AI-generated edits to trust.</p>
-
-<p><strong>Task:</strong> Build, test, and refine an AI prompt that gives you focused editing feedback (NOT wholesale rewriting). Then triage the AI’s advice and implement only what improves your draft.</p>
-
-<div>
-<h4><i></i>Dive-In and Do It</h4>
-
-<p><strong>Use your brain first:</strong></p>
-
-<ol>
-	<li>Skim two editing guides:
-	<ul>
-		<li><a href="https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/" rel="noopener noreferrer" target="_blank">UNC&#x27;s Editing and Proofreading Guide</a></li>
-		<li><a href="https://owl.purdue.edu/owl/graduate_writing/graduate_writing_topics/graduate_writing_topics_editing_proofreading_new.html" rel="noopener noreferrer" target="_blank">Purdue&#x27;s Editing and Proofreading Guide</a></li>
-	</ul>
-	</li>
-	<li>From the guides, list 3 or 4 editing passes you value the most (e.g., content, paragraph structure, clarity, style and tone consistency).</li>
-	<li>Perform your own editing first - keep notes.</li>
-	<li>Examine this flimsy prompt and note at least three weaknesses:
-	<pre>
-<code>Edit my paper for content, structure, clarity, and style.
-[paste draft]</code></pre>
-	</li>
-	<li>Create an AI editor by drafting a prompt using the CRAFT scaffold:
-	<table>
-		<thead>
-			<tr>
-				<th>Element</th>
-				<th>Your choices (bullet form)</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td><strong>Context</strong></td>
-				<td>Course, assignment purpose, audience, citation style…</td>
-			</tr>
-			<tr>
-				<td><strong>Role</strong></td>
-				<td>“Senior copy-editor for an academic press,” etc.</td>
-			</tr>
-			<tr>
-				<td><strong>Action</strong></td>
-				<td>Ask for the 3-4 passes you selected in Step 2, plus one thing it should not do (e.g., “Do NOT rewrite sentences”).</td>
-			</tr>
-			<tr>
-				<td><strong>Format</strong></td>
-				<td>Bulleted issues + concrete example from my text + fix suggestion (no more than 20 words each).</td>
-			</tr>
-			<tr>
-				<td><strong>Tone</strong></td>
-				<td>Professional, concise, non-directive.</td>
-			</tr>
-		</tbody>
-	</table>
-	</li>
-</ol>
-
-<p><strong>Get Some AI Input:</strong></p>
-
-<ol start="5">
-	<li>Paste the flimsy prompt + draft into ChatGPT (or comparable model). Keep the output.</li>
-	<li>Paste your CRAFT prompt + draft. Keep the output.</li>
-	<li>Rapid-iterate: tweak ONE line of your CRAFT prompt, re-run, and see if the feedback quality improves.</li>
-</ol>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ol>
-	<li>Which version delivered feedback that matched your Step 2 priorities? Cite two concrete examples.</li>
-	<li>Identify the AI suggestions you will KEEP, the ones you will MODIFY, and the ones you will DISCARD. Explain why for each one.</li>
-	<li>Did the AI hallucinate any “rules,” mislabel citations, or overlook glaring issues? What does that reveal about LLM limitations?</li>
-	<li>Looking ahead, how will you refine your editing checklist so the next AI interaction is even tighter?</li>
-</ol>
-</div>
-
-<div>
-<h5><i></i>Notes for Instructors</h5>
-
-<p>If you want to adapt this activity in your class, here are some things to consider:</p>
-
-<ul>
-	<li><strong>Side-by-Side Demo:</strong> Compare a flimsy vs. CRAFT prompt on the same student paragraph; students instantly see the difference in usefulness.</li>
-	<li><strong>Peer Prompt Debug:</strong> 5-minute swap; classmates flag vague verbs (“improve,” “fix”) and missing constraints.</li>
-	<li><strong>Quality Audit:</strong> After AI feedback, students run a “voice consistency” test by reading revised sentences aloud to detect style shifts.</li>
-	<li><strong>Mini-Reflection Exit Ticket:</strong> End class with a sticky-note or LMS post: “One insight I gained about prompt engineering today is ______.” Use these to gauge understanding and plan follow-ups.</li>
-	<li>Use the <a href="https://www.sciencedirect.com/science/article/pii/S8755461525000088" rel="noopener noreferrer" target="_blank">PAIRR Framework</a> with the student&#x27;s drafts and the editing prompt students craft.</li>
-</ul>
-</div>
-
-<div>
-<h5>References</h5>
-
-<p>Purdue Online Writing Lab. (2024). <em>Editing and proofreading</em>. <a href="https://owl.purdue.edu/owl/graduate_writing/graduate_writing_topics/graduate_writing_topics_editing_proofreading_new.html" rel="noopener noreferrer" target="_blank">https://owl.purdue.edu/owl/graduate_writing/graduate_writing_topics/graduate_writing_topics_editing_proofreading_new.html</a></p>
-
-<p>The Writing Center, University of North Carolina at Chapel Hill. (n.d.). <em>Editing and proofreading</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/</a></p>
-
-<p>Sperber, L., MacArthur, M., Minnillo, S., Stillman, N., &amp; Whithaus, C. (2025). Peer and AI Review + Reflection (PAIRR): A human-centered approach to formative assessment. <em>Computers &amp; Composition/Computers and Composition</em>, <em>76</em>, 102921. <a href="https://doi.org/10.1016/j.compcom.2025.102921" rel="noopener noreferrer" target="_blank">https://doi.org/10.1016/j.compcom.2025.102921</a></p>
-</div>
-</div>
-</details>
-</div>
-
-<hr>
-<h2><i></i>Proofreading</h2>
-
-<p>If we stick with our initial definition of proofreading (Grammar &amp; Punctuation Errors, Spelling Mistakes, Formatting Issues, Typos), it&#x27;s clear that proofreading is mostly a mechanical, rules-based activity. In most cases, using an AI tool to do these checks is acceptable, even in classes where using AI is strictly prohibited. In fact, it is difficult to <em>avoid</em> using an AI tool to do these checks. If you are working in MS Word, you are going to get grammar and spelling suggestions automatically and these are driven by AI. That being said, a final proofread by a human is always necessary to catch those things that AI still misses.</p>
-
-<p>Word processors like Word and Google Docs have built-in proofreading but there are many other AI tools that are designed for proofreading (and editing). Two of the most popular are Grammarly and Quillbot, but there are many others. The other tool worth mentioning is <a href="https://www.turnitin.ca/products/features/draft-coach/" rel="noopener noreferrer" target="_blank">Draft Coach from Turnitin</a> which is available to Okanagan College students through our institutional license (as of June 2025). Draft Coach is built-in to your online version of Microsoft 365 when you login with your OC credentials. It helps you with citations, grammar, and avoiding plagiarism.</p>
-
-<p>Personally, for proofreading, I prefer to rely on the built-in tools in Microsoft for the basic stuff, chatbots with targeted prompts for a more detailed check, and then doing a final check with my own eyes. It makes the process intentional and I can prompt for specific things with each (grammar, vocabulary enrichment, verb tense consistency, passive vs. active voice). The main downside is that this an extra step that requires cutting and pasting whereas tools like Grammarly are built right into the text editor.</p>
-
-<div>
-<p>Your proofreading process is up to you, but remember that for every new tool that you use, you are sharing your personal information and your work with another company. I know that people rarely do this, but read the privacy policy and data agreement to understand what the company is going to do with your data and work. </p>
-</div>
-
-<p>Based on my own limited experience and the online consensus here is a quick overview of the suggested proofreading tools (for a quick but more comprehensive summary, ask Perplexity Deep Research to compare these tools):</p>
-
-<ul>
-	<li><strong>Draft Coach</strong> is your best choice to support academic writing and it is available for free as long as OC maintains the institutional license. Draft Coach has strong citation tools, gives you a chance to check your own work for plagiarism, corrects grammar mistakes and provides explanations to guide your proofreading.</li>
-	<li><strong>Grammarly</strong> is the most comprehensive proofreading solution. It has better accuracy and detailed error explanations.</li>
-	<li><strong>Quillbot</strong> is a solid alternative to Grammarly but focuses more on paraphrasing.</li>
-	<li><strong>ChatGPT</strong> is the most flexible, but requires good prompting since it is not specifically an editing or proofreading tool.</li>
-</ul>
-
-<div>
-<details><summary><i></i><span>Proofreading Activity 1: Compare the Tools</span></summary>
-
-<div>
-<p><strong>Purpose:</strong> Compare the proofreading capabilities of different tools.</p>
-
-<p><strong>Task:</strong> Provide a small writing sample to different proofreading tools to see which one can find the most errors.</p>
-
-<div>
-<h4><i></i>Dive-in and Do It</h4>
-
-<p><strong>Use Your Brain First:</strong></p>
-
-<ol>
-	<li>Read through the paragraphs below and see if you can find the spelling and grammar errors and make suggestions for improvement.</li>
-</ol>
-
-<p><strong>Example 1:</strong></p>
-
-<pre>
-<code>The principal designer argued that the principle concern was aesthetic cohesion, not cost overruns. At the budget meeting, however, finance officers insisted that sticking to first principals required cutting the lighting plan, leaving the principal’s proposal in jeopardy.
-
-Dr. Singh finally met with Rivera after reviewing the performance data, and she decided the pilot needed another month. She also recommended that the team document every iteration before presenting it to the board.
-
-Glancing quickly through the microscope, the bacterial colonies appeared to morph into translucent threads that the research assistant could barely count.
-
-The new onboarding manual asks interns to (a) log their hours, (b) complete safety training, and that they submit a weekly reflection journal to HR by Friday.
-
-Only one of the project milestones were completed on schedule, yet management announced that the results “exceeded expectations” in the quarterly report.
-
-The engineers finished the stress analysis earlier than expected the marketing team, meanwhile, had already printed the brochures with outdated specifications.
-
-During the interview, the CEO explained that the company’s guiding mantra is “build what matters to the customer, test it relentlessly, and scale responsibly.
-
-To synergize our outreach stack, we should parallel-process the empathy touchpoints while hard-pivoting into a data-literate mindset; that way the vibe stays premium but also low-latency for key stakeholders.</code></pre>
-
-<p><strong>Example 2:</strong></p>
-
-<pre>
-<code>At yesterday’s kickoff meeting, the lead architect argued that energy efficiency, not superficial aesthetics, ought to steer every major decision in the greenhouse build. He predicts that a roof-mounted heat-exchange loop could trim utility costs by nearly forty percent without sacrificing crop yield, and added that the design would compliment the surrounding orchard.
-
-After the city inspector spoke with Dr. Reyes about the ventilation blueprint, she requested a revised drawing that clarified the airflow differentials. Walking through the half-finished frame, the LED grow lights looked far too bright for seedlings. The project charter promises to reduce waste, improving neighborhood engagement, and to create seasonal teaching modules for local schools.
-
-None of the preliminary safety tests was conclusive, but the team declares that the system “operates flawlessly” in internal memos. Volunteers assembled the seed racks before dawn the installation crew, however, arrived after lunch and had to reposition every tray. During a radio interview, the project lead explained that the guiding slogan is “grow local, learn global, and share endlessly. To hyper-optimize our community-facing deliverables, we must granularly gamify the outreach funnels so the stakeholders feel maximum uplift vibes.</code></pre>
-
-<p><strong>Let AI give it a try:</strong></p>
-
-<ol start="2">
-	<li>Assuming you are comfortable with having accounts with all of these different companies, enter the above text into each of the following:
-	<ul>
-		<li>Grammarly</li>
-		<li>Quillbot</li>
-		<li>Draft Coach</li>
-		<li>A chatbot (with an appropriate prompt. See below)</li>
-	</ul>
-	</li>
-	<li>Compare Results.</li>
-</ol>
-
-<details><summary>Click to see Writing with Errors Identified</summary>
-
-<div>
-<h5>Example 1 Errors:</h5>
-
-<p>The <span>principal</span> designer argued that the <span>principle</span> concern was aesthetic cohesion, not cost overruns. At the budget meeting, however, finance officers insisted that sticking to first <span>principals</span> required cutting the lighting plan, leaving the principal’s proposal in jeopardy. <em>(Word-choice homonym: principle / principal)</em></p>
-
-<p>Dr. Singh finally met with Rivera after reviewing the performance data, and <span>she</span> decided the pilot needed another month. She also recommended that the team document every iteration before presenting it to the board. <em>(Ambiguous pronoun reference)</em></p>
-
-<p><span>Glancing quickly through the microscope, the bacterial colonies</span> appeared to morph into translucent threads that the research assistant could barely count. <em>(Misplaced modifier)</em></p>
-
-<p>The new onboarding manual asks interns to (a) log their hours, (b) complete safety training, and <span>that they submit</span> a weekly reflection journal to HR by Friday. <em>(Faulty parallelism)</em></p>
-
-<p>Only one of the project milestones <span>were</span> completed on schedule, yet management announced that the results “exceeded expectations” in the quarterly report. <em>(Subject-verb agreement)</em></p>
-
-<p>The engineers finished the stress analysis earlier <span>than expected the marketing team</span>, meanwhile, had already printed the brochures with outdated specifications. <em>(Comma splice / run-on sentence)</em></p>
-
-<p>During the interview, the CEO explained that the company’s guiding mantra is “build what matters to the customer, test it relentlessly, and scale <span>responsibly.</span> <em>(Unbalanced quotation mark)</em></p>
-
-<p><span>To synergize our outreach stack, we should parallel-process the empathy touchpoints while hard-pivoting into a data-literate mindset; that way the vibe stays premium but also low-latency for key stakeholders.</span> <em>(Jargon / unclear language)</em></p>
-
-<hr>
-<h5>Example 2 Errors:</h5>
-
-<p>At yesterday’s kickoff meeting, the lead architect argued that energy efficiency—not superficial aesthetics—ought to steer every major decision in the greenhouse build. He <span>predicts</span> that a roof-mounted heat-exchange loop could trim utility costs by nearly forty percent without sacrificing crop yield, and added that the design would <span>compliment</span> the surrounding orchard. <em>(Verb-tense shift; Word-choice homonym)</em></p>
-
-<p>After the city inspector spoke with Dr. Reyes about the ventilation blueprint, <span>she</span> requested a revised drawing that clarified the airflow differentials. <span>Walking through the half-finished frame, the LED grow lights</span> looked far too bright for seedlings. The project charter promises to reduce waste, <span>improving neighborhood engagement, and to create</span> seasonal teaching modules for local schools. <em>(Ambiguous pronoun; Misplaced modifier; Faulty parallelism)</em></p>
-
-<p>None of the preliminary safety tests <span>was</span> conclusive, but the team <span>declares</span> that the system “operates flawlessly” in internal memos. Volunteers assembled the seed racks <span>before dawn the installation crew, however,</span> arrived after lunch and had to reposition every tray. During a radio interview, the project lead explained that the guiding slogan is “grow local, learn global, and share <span>endlessly.</span> <span>To hyper-optimize our community-facing deliverables, we must granularly gamify the outreach funnels so the stakeholders feel maximum uplift vibes.</span> <em>(Subject-verb disagreement; Verb-tense shift; Comma splice; Unbalanced quotation mark; Jargon)</em></p>
-</div>
-</details>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li>Compare the results from the AIs along with the errors that you flagged.</li>
-	<li>What are the primary differences between the tools?</li>
-	<li>Based on these results, which tool would you use to enhance your own proofreading? Why?</li>
-</ul>
-</div>
-
-<div>
-<h5>Chatbot Proofreader Prompt Ideas</h5>
-
-<p>Source: <a href="https://www.reddit.com/r/ChatGPTPromptGenius/comments/1jlx43y/here_are_my_best_chatgpt_prompts_for_proofreading/" rel="noopener noreferrer" target="_blank">Reddit - r/ChatGPTPromptGenius</a></p>
-
-<pre>
-<code>Act as a proofreading expert tasked with correcting grammatical errors in a given text below. Your job is to meticulously analyze the text, identify any grammatical mistakes. This includes checking for proper sentence structure, punctuation, verb tense consistency, and correct usage of words. Additionally, provide suggestions to enhance the readability and flow of the text. The goal is to polish the text so that it communicates its message effectively and professionally. Identify where the error is, explaining what the error is and then make suggestions for fixing it.
-[text here]</code></pre>
-
-<h5>Other References</h5>
-
-<p>UNC Writing Center Tips: <a href="https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/</a></p>
-
-<p>Perplexity Deep Research Report: <a href="https://www.perplexity.ai/search/for-use-as-proofreaders-where-yNoSUKGVRqqfmK9mkxtlYg" rel="noopener noreferrer" target="_blank">Proofreading Tools Comparison</a></p>
-</div>
-</div>
-</details>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>AI-Generated Writing: Effective and Ethical Use</h2>
+            <div>
+
+            <div>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Introduction</h2>
+            <div>
+            <p><strong><i></i>Your First and Most Important Step: Check Your Course Policy</strong></p>
+
+            <p>Before using any idea from this module for an assignment, you must understand your instructor&#x27;s specific AI policy. Seriously. Print it out. Write it on your hand. Set it as your phone wallpaper. Violating the policy doesn&#x27;t just risk academic consequences—it undermines the very reason you&#x27;re here: to learn. This module shows you what&#x27;s possible with AI, but your instructor&#x27;s guidelines are the final word on what&#x27;s permissible.</p>
+            </div>
+
+            <p>Just like learning, writing is hard. Like, &quot;staring at a blank page for three hours while eating your body weight in snacks&quot; hard. But it&#x27;s supposed to be. That struggle is your brain doing the work. While AI can generate flawless-looking text in seconds, it skips the most important part: the mental workout. The real value of writing isn&#x27;t just the finished text; it&#x27;s the thinking you do to get there.</p>
+
+            <p>Writing is how you:</p>
+
+            <ul>
+            	<li><strong>Solidify what you think:</strong> It forces you to organize the chaos in your brain into a coherent argument.</li>
+            	<li><strong>Express who you are:</strong> It gives a platform to your unique experiences, insights, and voice.</li>
+            	<li><strong>Build a crucial life skill:</strong> Thinking and communicating clearly is a superpower you&#x27;ll need long after you graduate.</li>
+            </ul>
+
+            <p>The good news? Writing gets easier (or at least less painful) when you make it purposeful. </p>
+        </section>
+        <section class="gai-box">
+            <h2>How Your Instructor Might Approach AI:</h2>
+            <p>Your instructor&#x27;s policy will likely fall into one of these three broad categories, though the specific details will vary. That&#x27;s why reading the exact policy on your syllabus is so important.</p>
+
+            <ol>
+            	<li><strong>&quot;No AI Allowed&quot;</strong><br>
+            	Honor this stance. Your instructor has good reasons: ensuring you do the thinking, exercising your writing muscles, and developing your authentic voice. Think of it as intellectual cross-fit—painful but building essential strength. You&#x27;ll have plenty of opportunities to use AI in other contexts.</li>
+            	<li><strong>&quot;Limited AI Use&quot;</strong><br>
+            	If your instructor allows specific uses, make the most of them and put some thought into how best to use AI:
+            	<ul>
+            		<li><strong>Brainstorming:</strong> Use good prompting to explore ideas (not generate them for you).</li>
+            		<li><strong>Editing Feedback:</strong> Input course materials, rubrics, and assignment details to get targeted suggestions.</li>
+            		<li><strong>Revision Support:</strong> Get specific feedback on clarity, structure, or style—but do the rewriting yourself.</li>
+            	</ul>
+            	</li>
+            	<li><strong>&quot;AI as a Collaborative Tool&quot;</strong><br>
+            	Some instructors encourage using AI to generate initial drafts that you then critically evaluate and revise, or to review your writing and reflect on the feedback. This approach treats AI as a thinking partner, not a substitute for thinking.</li>
+            </ol>
+
+            <p>Regardless of the level of AI work you are permitted to use, the goal of this module isn&#x27;t to help you avoid the hard work of writing. It&#x27;s to show you how to use AI to make that hard work more productive, insightful, and even fun. Let&#x27;s get started.</p>
+            </div>
+            </div>
+
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>The Core of Ethical AI Use: The Contribution Statement</h2>
+            <p>Before you even open an AI tool, you need a plan for transparency. When you use generative AI to support you with a project or assignment, your goal is to use it as a legitimate tool while also documenting its use. An AI contribution statement is a simple, ethical way to document your process for your instructor and for yourself. It helps turn AI use from a secret into a scholarly practice.</p>
+
+            <p>While not always mandatory in your class, documenting your AI use is a powerful habit that:</p>
+
+            <ul>
+            	<li><strong>Maintains your intellectual integrity</strong> in an AI-saturated world.</li>
+            	<li><strong>Documents your learning process,</strong> creating a record of how you developed your ideas.</li>
+            	<li><strong>Prepares you for an emerging professional standard</strong> in many fields.</li>
+            	<li><strong>Makes you accountable to yourself</strong> by helping you find the line between your contribution and what the AI did.</li>
+            </ul>
+
+            <h4> </h4>
+
+            <div>
+            <p><strong><i></i>Follow Your Instructor&#x27;s Lead.</strong> The best method for documentation depends on the scope of your project and might be specified by your instructor. If you don&#x27;t have a specific documentation model to follow, the two models below are good, adaptable starting points.</p>
+            </div>
+
+
+            <div>
+            <p>[CONCEPTUAL GRAPHIC: Model A (Checklist) vs. Model B (Flowchart)]</p>
+            </div>
+
+            <h3><i></i>Model A: The Structured Statement</h3>
+
+            <p><strong>Best for:</strong> Essays, research papers, lab reports, or any single-document assignment where AI was used for specific, distinct tasks.</p>
+
+            <p><strong>Concept:</strong> Based on the work of <a href="https://journals.sagepub.com/doi/full/10.1177/00986283241259750" target="_blank">Albada &amp; Woods (2025)</a> and <a href="https://crln.acrl.org/index.php/crlnews/article/view/26548/34482" target="_blank">Weaver (2024)</a> this model is a concise, point-by-point summary of each interaction with an AI tool. You create a new entry for each significant use.</p>
+
+            <div>
+            <h4><i></i>Template &amp; Examples</h4>
+
+            <p>For each significant use, document the following:</p>
+
+            <ol>
+            	<li><strong>Tool &amp; Date:</strong> The AI tool used and the date of use.</li>
+            	<li><strong>Task/Purpose:</strong> What you asked the AI to do.</li>
+            	<li><strong>Prompt(s) Used:</strong> The specific prompt you gave the AI.</li>
+            	<li><strong>Integration &amp; Oversight:</strong> How you evaluated, adapted, and incorporated the AI&#x27;s output into your work.</li>
+            </ol>
+
+            <hr>
+            <p><strong>Example 1 (Narrative Style):</strong></p>
+
+            <p><em>“In writing this research proposal, I used Chatbot GPT, on December 9th, to help me with understanding the conceptual definitions and differences between research ethics and research integrity. It started with the following prompt: ‘Write a 300-word piece about the difference between research ethics and research integrity.’ Then I used other similar prompts to help me better understand these two constructs. The generated text was not copied verbatim and included in my Research Proposal; it was paraphrased and included in the Overall Introduction. I further used academic citations and other readings that I have done to assist with my paraphrasing.”</em></p>
+
+            <hr>
+            <p><strong>Example 2 (Structured Style):</strong></p>
+
+            <ul>
+            	<li><strong>1. Tool &amp; Date:</strong> Perplexity, Oct 26, 2025</li>
+            	<li><strong>2. Task/Purpose:</strong> To summarize a complex academic source to ensure I understood its main argument.</li>
+            	<li><strong>3. Prompt(s) Used:</strong> &quot;Summarize the main arguments and methodology of the attached article: [article_file.pdf]&quot;</li>
+            	<li><strong>4. Integration &amp; Oversight:</strong> I compared Perplexity&#x27;s summary to my own reading of the article to verify its accuracy. The summary helped clarify the author&#x27;s position on... I then used this clarified understanding to formulate my own critique in the second paragraph of my literature review, citing the original source directly.</li>
+            </ul>
+            </div>
+
+            <h3><i></i>Model B: The Process Narrative</h3>
+
+            <p><strong>Best For:</strong> Capstone projects, portfolios, design projects, or any work where AI is integrated throughout a long-term creative process.</p>
+
+            <p><strong>Concept:</strong> Instead of logging every single prompt, you write a narrative that describes the overall role AI played in your workflow. This approach focuses on the <em>process</em> and your strategic decisions, demonstrating how you directed the AI as a tool to achieve your project goals.</p>
+
+            <p><strong>Example:</strong> For a real-world model, you can read the detailed Process Narrative outlining how this very AI Literacy website was built using AI as a strategic partner:</p>
+
+            <p><a href="ai-contribution-statement.html" target="_blank"><strong>See the AI Contribution Statement for This Website <i></i></strong></a></p>
+
+            <div>
+            <h5><i></i>The Bottom Line</h5>
+
+            <p>An AI Contribution Statement is a declaration of your own intellectual honesty and confidence. It demonstrates that you are in control of your tools and are proud of the work—and thinking—that you have contributed. Ultimately, it&#x27;s a tool for self-reflection that helps you answer the only question that truly matters: <strong>At the end of the day, whose thinking is on the page?</strong></p>
+            </div>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <h1><i></i>AI for Brainstorming &amp; Structuring Ideas</h1>
+
+            <div><img alt="Blueprint morphing into building" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/blueprint_to_building1.png"></div>
+
+            <div>
+            <div>
+            <p>Pre-writing (e.g., brainstorming, free-writing, clustering, and outlining) transforms a vague topic into a workable blueprint. Done well, it identifies hidden angles and ideas, spots weak links early, and saves drafting time later. AI can act as an always-on collaborator, offering fresh perspectives and fast categorization without stealing your voice. The activities that follow combine hands-on exercises with targeted prompts so you stay in control while the machine handles the heavy lifting.</p>
+            </div>
+
+            <div>
+            <details><summary><i></i><span>1. Idea-Generation Sprint</span></summary>
+
+            <div>
+            <p><i></i>Activity inspired by: <a href="https://thesavvyredpen.com/writers-block-brain-dump" rel="noopener noreferrer" target="_blank">Writer&#x27;s Block Brain Dump from The Savvy Red Pen</a></p>
+
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Create a rich bank of ideas on a topic, beginning with a solo brain-dump and then inviting AI to widen the lens without drowning your ideas. We&#x27;ll pick an arbitrary example of a topic for this exercise: <em>Cultural-Studies essay on “Food and Identity in Immigrant Communities”</em></p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do it</h4>
+
+            <p><strong>Use your brain first</strong></p>
+
+            <ol>
+            	<li><strong>Three minute brain dump</strong>: Write nonstop for three minutes every notion, phrase, or story that pops up (e.g., grandma’s recipes, fusion restaurants, nostalgia, language on menus). No editing.</li>
+            	<li><strong>Skim your brain dump</strong> and identify related items (e.g., economics, gender roles).</li>
+            </ol>
+
+            <p><strong>Get Some AI Input</strong></p>
+
+            <ol start="3">
+            	<li>Put the topics into an AI tool and ask it to categorize the ideas. See if it gets the same results as you.
+            	<pre>
+            <code>Act as a cultural-studies brainstorming partner. For this list of ideas on the topic of Food and Identity in Immigrant Communities:
+            [add list here]
+            Identify common themes and split the ideas into categories.</code></pre>
+            	</li>
+            	<li>Compare your categories to the AI generated categories and then determine which you are going to keep.</li>
+            	<li>Ask the AI to add two fresh angles or ideas per category plus one wildcard idea that doesn&#x27;t fit any category.
+            	<pre>
+            <code>Act as a cultural-studies brainstorm partner. For each category below, list two new angles or ideas (≤15 words each) that we have not already discussed. Then suggest one wildcard angle unrelated to any category.
+            Categories: [list categories here]</code></pre>
+
+            	<p><em>Note: As long as you are having this conversation in the same thread in the generative AI chatbot, it will have all of the ideas discussed in its context, so you don&#x27;t have to list them again.</em></p>
+            	</li>
+            	<li>From the full list of discussion angles and ideas, star the ones that feel surprising or exciting; strike anything bland or off-topic. Aim to keep 8-10 ideas and angles total.</li>
+            </ol>
+            </div>
+
+            <div>
+            <h4><i></i>Pause and Ponder</h4>
+
+            <ul>
+            	<li><strong>Ownership check</strong>: Count starred ideas: at least half should be yours. If AI dominates, return to Phase 1 and dig deeper from personal experience or readings.</li>
+            	<li><strong>Breadth vs. Depth</strong>: Do the starred angles cover multiple dimensions (history, sociology, personal narrative)? If all sit in one lane, revisit Phase 3 and request angles for missing dimensions.</li>
+            	<li><strong>Feasibility scan</strong>: Pick two starred angles and spend 5 minutes searching your library database: can you locate at least one quality source for each? If not, swap them out.</li>
+            	<li><strong>Spark test</strong>: Read the final list aloud. Which angle makes you want to keep talking? That spark often signals the best starting point for drafting.</li>
+            </ul>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>2. Topic Narrowing Funnel</span></summary>
+
+            <div>
+            <p><i></i>Activity inspired by: <a href="https://rightquestion.org/what-is-the-qft/" rel="noopener noreferrer" target="_blank">Question Formulation Technique (QFT)</a></p>
+
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Turn a broad course theme into a sharp, research-ready question blending your own brainstorming via the QFT with a short burst of AI amplification. We&#x27;ll pick an arbitrary example: <em>Participation in Canadian federal elections by young voters is consistently much less than participation by older voters.</em></p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do it</h4>
+
+            <p><strong>Use your brain first</strong></p>
+
+            <ol>
+            	<li>Write down a factual, neutral statement on your topic.</li>
+            	<li>Spend 4 minutes and ask as many questions as you can about this statement. Don&#x27;t judge, don&#x27;t provide answers, these should be questions not statements. Aim for 10-12 how/why/what questions.</li>
+            	<li>Mark each question O (open-ended) or C (closed-ended). As an exercise, convert 2 O→C and 2 C→O.</li>
+            	<li>Star three questions that feel answerable, interesting, and aligned with the assignment scope.</li>
+            </ol>
+
+            <p><strong>Get Some AI Input</strong></p>
+
+            <ol start="5">
+            	<li>Ask an AI tool to deepen each starred question with follow-ups.
+            	<pre>
+            <code>Act as my political-science research aide. 
+            For the general top [paste topic here]
+            and my questions here:
+            [paste starred questions]
+
+            Suggest:
+            • 3 probing follow-up questions
+            • 3 political science theories that could frame my analysis
+            • 3 places I could find supporting data (organisations, datasets or keyword phrases)</code></pre>
+            	</li>
+            </ol>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Novelty check</strong>: Did any AI-generated angle surprise you? If every follow-up felt predictable, revisit the AI tool and push for riskier questions.</li>
+            	<li><strong>Feasibility test</strong>: For the refined thesis question, can you identify at least two peer-reviewed sources within 10 minutes of searching? If not, narrow or redirect.</li>
+            	<li><strong>Ownership audit</strong>: Highlight in one colour the words that are entirely yours and in another the phrases inspired by AI. Your final wording should lean heavily toward the first colour.</li>
+            	<li><strong>Alignment scan</strong>: Ensure your question matches the assignment’s required focus (e.g., causal analysis vs. policy proposal).</li>
+            </ul>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>3. Thesis Build &amp; Stress Test</span></summary>
+
+            <div>
+            <p><i></i>Activity inspired by: <a href="https://owl.purdue.edu/owl/general_writing/academic_writing/establishing_arguments/organizing_your_argument.html" rel="noopener noreferrer" target="_blank">Organizing Your Argument (Purdue OWL)</a></p>
+
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Craft a defensible thesis, then poke holes in it before anyone else can.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do it</h4>
+
+            <p><strong>Drafting the Thesis</strong></p>
+
+            <ol>
+            	<li><strong>Write</strong> a provisional thesis (≤30 words).</li>
+            	<li><strong>Prompt the AI</strong>:
+            	<pre>
+            <code>Evaluate this thesis for clarity, debatable claim, and scope. Give a scored rubric (0–3) in each category plus one tightening suggestion.
+            Thesis: &quot;&lt;your thesis&gt;&quot;</code></pre>
+
+            	<p><em>Tip: If you have a rubric from your class about what makes a good thesis statement, include it in the prompt!</em></p>
+            	</li>
+            </ol>
+
+            <p><strong>Stress-Testing the Thesis</strong></p>
+
+            <ol start="3">
+            	<li><strong>Prompt the AI</strong> with the revised thesis:
+
+            	<pre>
+            <code>Here is my thesis: &quot;&lt;your revised thesis&gt;&quot;
+
+            Identify THREE persuasive counterarguments that an informed critic might raise.
+            For EACH counterargument, include ONE concise piece of evidence (e.g., a statistic, study, or report title + year) the critic could cite.
+            Format:
+            Counterargument 1 – ~25 words
+            Evidence – ~25 words</code></pre>
+            	</li>
+            </ol>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li>Adjust the thesis using any AI score below 3 as a revision target.</li>
+            	<li>Decide which counterargument is most dangerous to your claim.</li>
+            	<li><strong>Handle the &quot;Usual Suspects&quot;</strong>: AI excels at identifying the most common, predictable counterarguments. Use this to your advantage. By addressing these obvious points, you build a solid foundation, freeing you to focus on anticipating more subtle or expert critiques.</li>
+            	<li>Sketch how you’ll address or refute the strongest counterargument in your paper.</li>
+            </ul>
+
+            <div>
+            <p><i></i><strong>Remember: Verify AI-generated evidence.</strong> An AI might invent sources or statistics. That evidence may or may not actually exist. Always treat AI suggestions as leads to be verified from a credible source.</p>
+            </div>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>4. Outline Method 1: From Chaos to Cohesion</span></summary>
+
+            <div>
+            <p><i></i>Activity inspired by: <a href="https://asq.org/quality-resources/affinity" rel="noopener noreferrer" target="_blank">Affinity Diagrams (American Society for Quality)</a></p>
+
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Use this if you have a bunch of ideas, but don&#x27;t know where to go next. This method uses a manual &quot;card sort&quot; to build your core structure, then invites AI to give you feedback.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do it</h4>
+
+            <p><strong>Use your own brain first</strong></p>
+
+            <ol>
+            	<li>In a document or on physical sticky notes, list out all your key components (thesis, main ideas, evidence, counterarguments).</li>
+            	<li>Group and Cluster: Look at your &quot;cards&quot; and start grouping them into logical piles based on connection.</li>
+            	<li>Name the groups (e.g., &quot;historical context&quot;, &quot;economic impact&quot;).</li>
+            	<li>Sequence the groups in an order that feels most persuasive.</li>
+            </ol>
+
+            <p><strong>Get AI Input</strong></p>
+
+            <ol start="5">
+            	<li>Paste your human-generated draft outline into an AI tool and ask for specific feedback.
+            	<div>
+            	<h5><i></i>Pro-Tip</h5>
+
+            	<p>If you used physical sticky notes, take a picture of the grouped notes. Feed it into an AI tool with image input (like ChatGPT mobile or Google Gemini) and ask it to &quot;OCR this&quot; or &quot;transcribe the text from this image&quot; to get your physical notes into a digital format.</p>
+            	</div>
+
+            	<pre>
+            <code>Act as a writing instructor and argumentation strategist. I have developed a draft outline for my essay. My thesis is: &quot;[Your Thesis Statement Here]&quot;
+
+            Here is my proposed structure:
+            - Section 1: [Name of your first pile]
+              - [Idea/Evidence 1 from this pile]
+            - (continue for all sections)
+
+            Based on this structure, please:
+            1. Critique the logical flow between the sections. Is there a more persuasive order? Explain why.
+            2. Identify any &quot;orphan&quot; ideas that don&#x27;t seem to fit their assigned section.
+            3. Suggest where my key counterargument might be most effectively placed and addressed.
+            4. Propose a more academic or compelling heading for each section title I created.
+
+            IMPORTANT: Explain your reasoning for each suggestion, but do not rewrite the outline for me.</code></pre>
+            	</li>
+            </ol>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li>Does the order feel persuasive to you? Rearrange any sections until the progression matches how <em>you</em> would argue aloud.</li>
+            	<li>Look at any &quot;orphan&quot; ideas the AI may have flagged. Do they need to be moved, developed further, or cut entirely?</li>
+            	<li>The final structure should reflect <em>your</em> argumentative voice. The AI is a consultant, not the author. Ensure the final blueprint is one you can confidently build and defend as your own.</li>
+            </ul>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>5. Outline Method 2: Building on Your Blueprint</span></summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Use this if you have a clear vision of what your paper should look like. Draft your own outline first, then let a short AI check and flag any gaps, sequencing snags, and missing evidence.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do it</h4>
+
+            <p><strong>Use your own brain first</strong></p>
+
+            <ol>
+            	<li><strong>Skeleton Draft</strong>: Write a two-level outline (1, 1.1, 1.2...) based on your existing ideas and research.</li>
+            	<li>Under each section, provide context and identify any data or sources you might use.</li>
+            </ol>
+
+            <p><strong>Get AI Input</strong></p>
+
+            <ol start="3">
+            	<li><strong>AI Diagnostic Scan</strong>: Ask the AI to analyze your outline. This should be done in the same chat as your other work for full context.
+
+            	<pre>
+            <code>Review the outline for the paper below.
+            Identify:
+            • any logical jumps in section order
+            • headings lacking evidence
+            • any counterarguments I should anticipate.
+
+            Provide feedback in bulletpoint form. Do not rewrite the outline.
+            Outline: &lt;paste outline here&gt;</code></pre>
+            	</li>
+            	<li>Update the outline based on the report.</li>
+            </ol>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Balance check</strong>: Does each main section carry roughly equal weight?</li>
+            	<li><strong>Source plan</strong>: For every bullet marked “needs evidence,” jot where you’ll search first (database, report, interview).</li>
+            	<li><strong>Ownership ratio</strong>: The outline should still read as yours; the AI’s contribution is only the gap flags you acted on.</li>
+            </ul>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>6. Audience-Persona Mirror</span></summary>
+
+            <div>
+            <p><i></i>Activity inspired by: <a href="https://asana.com/resources/empathy-map-template" rel="noopener noreferrer" target="_blank">Empathy Maps (Asana)</a></p>
+
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Clarify audience needs so that your tone and evidence hit the mark.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do it</h4>
+
+            <p><strong>Persona Draft</strong></p>
+
+            <ol>
+            	<li><strong>Write</strong> a 50-word profile of your intended reader (peer, specialist, etc.), including their background knowledge and possible bias.</li>
+            	<li><strong>Prompt the AI</strong>:
+            	<pre>
+            <code>Given this persona, list five questions they would expect the paper to answer and two stylistic preferences (e.g., formal tone, visuals).
+            Paper Topic: &lt;add paper topic here&gt;
+            Persona: &lt;add 50-word profile here&gt;</code></pre>
+            	</li>
+            </ol>
+
+            <p><strong>Application</strong></p>
+
+            <ol start="3">
+            	<li><strong>Prompt the AI</strong> again:
+
+            	<pre>
+            <code>Act as a writing coach. Based on the following audience persona and one of their priority questions, help me brainstorm ways to connect with that reader in my introduction.
+
+            1. Suggest a compelling hook (an image, quote, or stat) that would grab this reader’s attention.
+            2. Recommend one example or case study I could use later in the essay that this reader would find especially relevant or persuasive.
+            3. Identify a tone (e.g., conversational, analytical, urgent) that would likely resonate with them and briefly explain why.
+
+            Audience Persona: &lt;insert your 50-word persona here&gt;
+            Reader’s priority question: &lt;insert the question or questions they would most want answered&gt;</code></pre>
+            	</li>
+            </ol>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li>Are the AI-generated questions truly relevant? Keep, delete, or edit.</li>
+            	<li>Does the suggested hook align with your voice? Rewrite it until it does.</li>
+            	<li>Do you think the AI&#x27;s recommended examples will truly resonate with someone matching the audience persona?</li>
+            	<li>Did any of the AI&#x27;s questions make you see your topic from a completely new angle?</li>
+            </ul>
+
+            <div>
+            <p><i></i><strong>Verify Every Factual Claim</strong></p>
+
+            <p>An AI might suggest a compelling statistic, case study, or quote. However, it can also invent these details (&quot;hallucination&quot;). These fabrications often sound plausible but are not real. Treat every factual claim from an AI as a lead, not a fact. Your next step is to go to your library&#x27;s databases to find the <em>actual</em> study, report, or quote. Never cite a source provided by an AI without first locating and reading it yourself.</p>
+            </div>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+
+            <div id="gai-wrap">
+            <div>
+            <h1><i></i>Drafting Support: Brain-Driven Prose, AI-Assisted Polish</h1>
+
+            <div>
+            <div>
+            <p>When pre-writing, you drew the blueprint by crafting a thesis, outline, and audience profile. Now you&#x27;ll build the prose, leaning on GenAI as a writing coach but not as your ghost-writer.</p>
+
+            <p>Drafting is where the temptation to outsource your thinking is the strongest. The activities here are designed to help you resist that temptation, keeping you in creative and critical control. You will use AI <em>only</em> for targeted feedback, option-generation, and diagnostic checks on text <em>you have already written</em>. Exercise your brain; build those neural paths so that critical thinking becomes easier and more natural. Then get AI feedback to reveal blind spots and help you polish your prose.</p>
+
+            <p>Every activity in this section is built on a three-step workflow. This process ensures you are always doing the heavy intellectual lifting.</p>
+            </div>
+
+            <div>
+            <h5><i></i>The Core Workflow: Your Three-Step Process</h5>
+
+            <p><strong>1. Brain First ➜</strong> You create the raw material. This means writing the initial clunky sentence, the underdeveloped paragraph, or the full first draft. The thinking and the words originate with you.</p>
+
+            <p><strong>2. AI for Options ➜</strong> You take your self-generated text to the AI. You prompt it to act as a coach, an editor, or a strategist—requesting <em>feedback</em>, <em>analysis</em>, or <em>alternative options</em> (phrasing, structure, examples), never the final answer.</p>
+
+            <div>
+            <p><strong>Reminder:</strong> Never paste copyrighted or private data into public models.</p>
+            </div>
+
+            <p><strong>3. Use Your Judgement ➜</strong> You critically evaluate the AI&#x27;s output. You are the final authority. You accept, reject, or modify the suggestions based on your own judgment, voice, and argumentative goals.</p>
+
+            <div id="svg-wrapper"><svg aria-labelledby="chartTitle chartDesc" id="flowchart" viewbox="0 0 900 300">
+            <title id="chartTitle"></title>
+            <desc id="chartDesc">A three-step flowchart. Step 1: Use your brain/Do the writing. Step 2: AI for feedback and options. Step 3: Apply your judgement. Arrows connect the steps sequentially.</desc> <defs> <marker id="arrowhead" markerheight="8" markerwidth="8" orient="auto-start-reverse" refx="9" refy="5" viewbox="0 0 10 10"> <path d="M 0 0 L 10 5 L 0 10 z"></path> </marker> </defs> <path d="M 260 150 L 340 150" id="arrow1"></path> <path d="M 560 150 L 640 150" id="arrow2"></path> <g aria-label="Step 1: Use your brain and do the writing" id="step1"> <rect height="100" rx="15" width="210" x="50" y="100"></rect> <text text-anchor="middle"> <tspan x="155" y="145">Use your brain /</tspan> <tspan x="155" y="165">Do the writing</tspan> </text> </g> <g aria-label="Step 2: Use AI for feedback and options" id="step2"> <rect height="100" rx="15" width="210" x="350" y="100"></rect> <text text-anchor="middle"> <tspan x="455" y="145">AI for feedback</tspan> <tspan x="455" y="165">&amp; options</tspan> </text> </g> <g aria-label="Step 3: Apply your judgement" id="step3"> <rect height="100" rx="15" width="210" x="650" y="100"></rect> <text text-anchor="middle"> <tspan x="755" y="155">Apply your judgement</tspan> </text> </g> </svg></div>
+            </div>
+
+            <details><summary> <i></i> <span>Your Brain on LLMs: Emerging Evidence on the Value of Using Your Brain First</span> </summary>
+
+            <div>
+            <p>New MIT research shows that when students use LLMs for writing, they experience reduced brain connectivity, lower satisfaction, and impaired ownership of their ideas. The convenience of using an LLM comes with genuine cognitive costs. We&#x27;re not saying avoid AI; we are saying that if you do the intellectual heavy lifting first, then use AI strategically for feedback and refinement, you&#x27;ll build your brain AND be more proud of the end result.</p>
+
+            <div>
+            <p><a href="https://www.brainonllm.com/" rel="noopener noreferrer" target="_blank">Your Brain on LLMs Paper</a></p>
+            </div>
+            <div>
+            <p>
+            <a href="https://github.com/jck-sz/llm-useful-stuff/blob/master/README.md">Some prompting ideas that will force you to think along with the LLM</a></p>
+            </div>
+
+            </div>
+            </details>
+
+            <div>
+            <h4><i></i>Balance Meter - A Quick Self-Check</h4>
+
+            <ol>
+            	<li>Did I write at least 75% of this draft <em>before</em> consulting AI? (About enough original writing that you can explain your entire argument without referring back to the AI output.)</li>
+            	<li>Can I explain, without the chatbot open, why I kept or rejected each AI suggestion?</li>
+            	<li>Have I verified every fact, citation, or statistic that appears in my prose?</li>
+            </ol>
+            </div>
+
+            <hr>
+            <div>
+            <details><summary><i></i><span>Activity 1: The Accordion Method - Strong Paragraphs</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> To write a fully developed and substantiated paragraph starting with a single topic sentence from your outline.</p>
+
+            <p><strong>Task:</strong> Write out a complete paragraph that provides evidence, analysis, and significance for your main point. Then, use targeted AI feedback to identify and strengthen the paragraph&#x27;s weakest link.</p>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do It</h4>
+
+            <p><strong>Use your brain first:</strong> This is where you do the real work of drafting. Your goal is to build a complete paragraph from a single idea.</p>
+
+            <ol>
+            	<li><strong>Start with your Point:</strong> Write down one topic sentence from your outline.</li>
+            	<li><strong>Add your Evidence:</strong> Write a sentence that introduces a piece of evidence (a fact, quote, or data point) to support that point.</li>
+            	<li><strong>Provide your Analysis:</strong> Write 2+ sentences explaining what the evidence <em>means</em> and how it proves your point.</li>
+            	<li><strong>State the Significance:</strong> Write a final sentence that connects the entire paragraph back to your paper&#x27;s main thesis. Why does this point matter?</li>
+            </ol>
+
+            <p>You have now drafted a complete paragraph entirely on your own.</p>
+
+            <p><strong>Get AI Input:</strong> Now, use the AI as a quality auditor. The prompt below asks the AI to diagnose potential weaknesses and asks you a question about it. It is not intended to rewrite anything for you.</p>
+
+            <pre>
+            <code>Act as a writing coach. I have drafted a paragraph using the Point -&gt; Evidence -&gt; Analysis -&gt; Significance structure.
+
+            My paragraph:
+            &quot;[Paste your full, self-written paragraph here]&quot;
+
+            Your task is to:
+            1. Identify the weakest part of my paragraph (Is the analysis too shallow? Is the evidence not clearly connected to the point? Is the significance unclear?).
+            2. Ask me specific, probing questions that will force me to think more deeply about how to strengthen that single part. Do not rewrite any part of my paragraph.</code></pre>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ol>
+            	<li>Do you agree with the AI&#x27;s diagnosis? Why do you think it identified <em>that specific part</em> of your paragraph as the weakest?</li>
+            	<li>Take a moment to answer the AI&#x27;s question in your own words. How did answering it help you see a gap in your original draft?</li>
+            	<li>Based on your answer, revise your original paragraph. What specific changes did you make to the evidence, analysis, or significance to make the paragraph stronger?</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5><i></i>Notes for Instructors</h5>
+
+            <p>If you want to adapt this activity in your class, here are some things to consider:</p>
+
+            <ul>
+            	<li><strong>Model the Process:</strong> Before students try this, model it live. Start with a topic sentence and &quot;think aloud&quot; as you write the evidence, analysis, and significant sentences.</li>
+            	<li><strong>Peer-to-Peer Coaching:</strong> For an AI-free version, have students swap paragraphs and perform the AI&#x27;s role: identify the weakest part and ask one probing question.</li>
+            	<li><strong>Focus on the &quot;Why&quot;:</strong> The most valuable part of this exercise is the student&#x27;s answer to the AI&#x27;s question. Assess their ability to reflect on and deepen their own analysis.</li>
+            	<li><strong>Connect to Outlining:</strong> Reinforce that a clear, focused topic sentence (from their outline) makes the entire accordion expansion process dramatically easier and more effective.</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5>References</h5>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Paragraph development</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/paragraphs/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/paragraphs/</a></p>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>Activity 2: Clarity Clinic – Repairing Clunky Sentences</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> To practice diagnosing and revising your own sentences for clarity and impact, using AI-generated alternatives as a catalyst for your own editorial decisions.</p>
+
+            <p><strong>Task:</strong> Identify a weak sentence in your draft, diagnose its problem, and use AI-generated options to help you craft a more precise and powerful version.</p>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do It</h4>
+
+            <p><strong>Use your brain first:</strong></p>
+
+            <ol>
+            	<li>Find a sentence from your draft that feels clunky, awkward, or unclear.</li>
+            	<li>In one sentence, diagnose the problem. What makes it weak? (e.g., &quot;The verb is passive,&quot; &quot;It tries to do too much at once,&quot; &quot;The meaning is ambiguous.&quot;)</li>
+            </ol>
+
+            <p><strong>Get AI Input:</strong> Use the prompt below to get targeted feedback. By providing your own diagnosis in the prompt, you give the AI better context to act as your coach.</p>
+
+            <pre>
+            <code>Act as my writing center tutor. My goal is to improve the clarity and impact of a sentence from my draft.
+
+            My clunky sentence:
+            &quot;[Paste your sentence here]&quot;
+
+            My diagnosis of the problem:
+            &quot;[Paste your one-sentence diagnosis here]&quot;
+
+            Based on my diagnosis, provide:
+            1. several distinct, revised versions of my sentence.
+            2. For each version, add a one-sentence explanation of the specific editorial strategy you used (e.g., &quot;This version uses a stronger verb,&quot; &quot;This version splits the complex idea into two sentences,&quot; &quot;This version leads with the main clause for more directness&quot;).</code></pre>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ol>
+            	<li>Which of the AI&#x27;s suggested strategies most directly solves the problem you diagnosed in the &quot;Brain First&quot; step?</li>
+            	<li>What specific change (e.g., a different word, moving a clause) had the biggest positive impact on the sentence&#x27;s clarity? Why was it so effective?</li>
+            	<li>Read your final, revised sentence aloud. How does it sound more like <em>you</em> than any of the raw AI options?</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5><i></i>Notes for Instructors</h5>
+
+            <p>If you want to adapt this activity in your class, here are some things to consider:</p>
+
+            <ul>
+            	<li><strong>Model it Live:</strong> Project a clunky sentence, diagnose it aloud, consult the AI, and talk through your final editorial choice to make your expert thinking visible.</li>
+            	<li><strong>Use a &quot;Sentence Swap&quot;:</strong> Have students diagnose a partner&#x27;s sentence <em>before</em> using the AI. This builds their analytical skills on unfamiliar text.</li>
+            	<li><strong>Assess the &quot;Why&quot;:</strong> Ask students to submit a one-sentence justification for their final choice. The quality of their reasoning is the true measure of learning.</li>
+            	<li><strong>Encourage Remixing:</strong> Challenge students to &quot;remix&quot; the AI&#x27;s options—taking a verb from one and a structure from another—to reinforce their role as the final author.</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5>References</h5>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Style</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/style/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/style/</a></p>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Passive voice</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/passive-voice/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/passive-voice/</a></p>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Word choice</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/word-choice/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/word-choice/</a></p>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>Activity 3: Make it Concrete - Improve Your Arguments</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> To transform abstract, general claims into powerful, persuasive arguments by substantiating them with specific, concrete details and evidence.</p>
+
+            <p><strong>Task:</strong> Identify vague sentences in your draft and use AI-generated questions to help you unearth the specific details needed to make your writing more vivid and credible.</p>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do It</h4>
+
+            <p><strong>Use your brain first:</strong></p>
+
+            <ol>
+            	<li>Find a sentence in your draft that makes a general claim or uses abstract language that isn&#x27;t supported by specific proof. (e.g., &quot;The policy had a negative impact,&quot; or &quot;The character experienced significant growth.&quot;)</li>
+            	<li>Before using the AI, <strong>analyze the claim</strong>.
+            	<ul>
+            		<li>What type of claim is this? (e.g., A claim of fact/value/cause&amp;effect)</li>
+            		<li>What type of evidence would my audience need to be convinced? (a statistic, a direct quote, a concrete example, an illustrative anecdote)</li>
+            	</ul>
+            	</li>
+            </ol>
+
+            <p><strong>Get AI Input:</strong> Now, challenge your own thinking. Use the prompt below to have the AI act as a curious reader who needs more information to be convinced.</p>
+
+            <pre>
+            <code>Act as a skeptical but curious reader. I want to make a general claim from my draft more specific and convincing.
+
+            My general claim is:
+            &quot;[Paste your abstract sentence here]&quot;
+
+            Your task is to ask me three probing questions that would force me to provide more concrete, sensory, or factual details. Frame your questions to start with phrases like:
+            - &quot;What does that look like specifically?&quot;
+            - &quot;Can you give me a direct example of...?&quot;
+            - &quot;How could a reader see or measure that...?&quot;
+            - &quot;Who exactly was affected and how?&quot;
+
+            Do not suggest any answers or rewrites. Only ask the questions.</code></pre>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ol>
+            	<li>Look at the AI&#x27;s questions. How did they push you to think more specifically about the <em>type</em> of evidence your argument required?</li>
+            	<li>Answer the AI&#x27;s questions using your own knowledge or research. Now, rewrite your original sentence incorporating these new, specific details.</li>
+            	<li>Read your &quot;before&quot; and &quot;after&quot; sentences. How does the revised, more specific version change the reader&#x27;s experience and the credibility of your argument?</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5><i></i>Note for Instructors</h5>
+
+            <p>If you want to adapt this activity in your class, here are some things to consider:</p>
+
+            <ul>
+            	<li><strong>Model the Process:</strong> Project a vague sentence from a sample text. Ask the class for probing questions before using the AI to show that this is a human-first critical thinking skill.</li>
+            	<li><strong>Create a Before and After Gallery:</strong> In a shared document, have students post their &quot;before&quot; (vague) and &quot;after&quot; (vivid) sentences. This creates a powerful visual bank of examples.</li>
+            	<li><strong>Peer Review Role-Play:</strong> Have students swap vague sentences and act as the &quot;skeptical reader&quot; for their partner, asking the probing questions themselves. (This is a miniature version of the PAIRR Framework where students peer review each others papers and have an AI do a review as well).</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5>References</h5>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Argument</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/argument/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/argument/</a></p>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Evidence</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/evidence/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/evidence/</a></p>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>Activity 4: Tone Tuner – Matching Tone to Audience</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> To adjust the tone of your writing to meet the specific needs of your audience, without sacrificing your authentic authorial voice.</p>
+
+            <p><strong>Task:</strong> Analyze a paragraph for tone, use an AI to suggest targeted word changes based on your audience persona, and make deliberate editorial choices to improve a match.</p>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do It</h4>
+
+            <p><strong>Use your brain first:</strong></p>
+
+            <ol>
+            	<li>Select one or more paragraphs from your draft (you could use the whole draft if you want).</li>
+            	<li>Review the audience persona you developed in the Pre-writing section or create one if you haven&#x27;t already. Then answer these questions:
+            	<ul>
+            		<li>What does my audience value? (e.g., clear data, directness, creative thinking, efficiency, respect for tradition)</li>
+            		<li>What impression do I want my writing to convey? (seem knowledgeable and objective, innovative and passionate, or respectful and cautious)</li>
+            	</ul>
+            	</li>
+            	<li>Re-read your paragraph through the lens of your answers. Pinpoint 2-3 points where your writing fails to align with your audience&#x27;s values or the impression you want to make.</li>
+            </ol>
+
+            <p><strong>Get AI Input:</strong> Use the prompt below. Including your own analysis and the persona gives the AI the specific context it needs to provide high-quality feedback.</p>
+
+            <pre>
+            <code>Act as a rhetorical coach. My goal is to align the tone of my paragraph with my target audience.
+
+            My Audience Persona:
+            &quot;[Paste your audience persona here]&quot;
+
+            My Audience&#x27;s Core Values: &quot;[List the values you identified in step 2]&quot;
+            The Impression I Want to Convey: &quot;[State the impression you identified in step 2]&quot;
+
+            My Draft Section:
+            &quot;[Paste your writing here]&quot;
+
+            My initial analysis identified these specific mismatches: 
+            [List the 2-3 parts you identified]
+
+            Based on this, provide:
+            1. A three-column table (Original | Proposed | Rationale) with 5-7 suggested word or phrase swaps that would make the tone more effective for my audience.
+            2. In the second column, alongside the suggestion, add a brief justification that explains *why* the new word is a better fit for the persona (e.g., &quot;replaces a casual idiom with a more formal term,&quot; &quot;uses a verb with a more analytical connotation&quot;).</code></pre>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ol>
+            	<li>How did the AI&#x27;s suggestions compare to the words you initially identified? Did it confirm your instincts or reveal a blind spot in your self-analysis?</li>
+            	<li>Select one AI suggestion you are <strong>rejecting</strong>. What specific nuance, meaning, or part of your authentic voice would be lost if you accepted that change?</li>
+            	<li>After making your revisions, what is the single most important lesson you learned about writing for this specific audience?</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5><i></i>Note for Instructors</h5>
+
+            <p>If you want to adapt this activity in your class, here are some things to consider:</p>
+
+            <ul>
+            	<li><strong>Audience Guessing Game:</strong> Have students review a partner&#x27;s &quot;before&quot; and &quot;after&quot; paragraphs and try to guess the intended audience persona. A misidentification is a great learning moment about tone.</li>
+            	<li><strong>Focus on Rejection:</strong> Ask students to share one AI suggestion they <em>rejected</em> and their reason why. This highlights their critical judgment and authorial control.</li>
+            	<li><strong>Build a &quot;Tone Lexicon&quot;:</strong> Create a class document where students add effective word swaps they discovered for different tones (e.g., Formal, Persuasive, Skeptical).</li>
+            	<li><strong>Connect to Pre-writing:</strong> This activity directly demonstrates the practical value of the &quot;Audience-Persona Mirror&quot; activity, showing students how planning pays off in revision.</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5>References</h5>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Audience</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/audience/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/audience/</a></p>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>Activity 5: The Bridge Builder - Paragraph Transitions</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> To craft clear and logical transitions that guide your reader smoothly from one idea to the next, reinforcing the overall coherence of your argument.</p>
+
+            <p><strong>Task:</strong> Analyze the logical link between two paragraphs, use an AI to generate options for executing that link, and select or craft a transition that best serves your argument.</p>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do It</h4>
+
+            <p><strong>Use your brain first:</strong></p>
+
+            <ol>
+            	<li>Select two adjacent paragraphs from your draft.</li>
+            	<li>For each paragraph, write a single sentence that states its main point or claim.</li>
+            	<li>Now, write one sentence that describes the <strong>logical relationship</strong> between those two points. (e.g., &quot;Paragraph 2 provides a specific example of the general claim in Paragraph 1,&quot; or &quot;Paragraph 2 presents a counterargument to the idea in Paragraph 1.&quot;)</li>
+            </ol>
+
+            <p><strong>Get AI Input:</strong> Use the prompt below. Providing your analysis of the relationship is the key to getting high-quality, relevant suggestions from your AI coach.</p>
+
+            <pre>
+            <code>Act as a writing coach specializing in argument structure. My goal is to create a strong transition between two paragraphs.
+
+            Main Point of Paragraph 1:
+            &quot;[Paste the main point of your first paragraph]&quot;
+
+            Main Point of Paragraph 2:
+            &quot;[Paste the main point of your second paragraph]&quot;
+
+            My analysis of the logical relationship:
+            &quot;[Paste your sentence describing the relationship]&quot;
+
+            Based on my analysis, provide:
+            1. Several distinct transition sentences or phrases that effectively signal this logical relationship to the reader.
+            2. For each option, label the primary rhetorical move it uses (e.g., Cause &amp; Effect, Elaboration, Concession, Comparison).</code></pre>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ol>
+            	<li>Compare the rhetorical moves suggested by the AI to your own initial analysis. Did the AI offer a more precise or effective way to frame the relationship you identified?</li>
+            	<li>Why is the transition you ultimately chose the most effective for guiding your reader? What specific signal does it send them about the information that is about to come?</li>
+            	<li>Read the two paragraphs with your new transition aloud. How does it improve the overall flow and logic of your argument?</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5><i></i>Note for Instructors</h5>
+
+            <p>If you want to adapt this activity in your class, here are some things to consider:</p>
+
+            <ul>
+            	<li><strong>Rhetorical Move Sort:</strong> Before the activity, give students a list of common transition words (&quot;Therefore,&quot; &quot;However,&quot; &quot;In addition,&quot; &quot;Similarly&quot;) and have them sort them into categories by function.</li>
+            	<li><strong>Focus on the &quot;Relationship Sentence&quot;:</strong> The sentence students write in the &quot;Brain First&quot; step is the most important part of the exercise. Use it as a diagnostic tool to see if they understand their own argument&#x27;s structure.</li>
+            	<li><strong>Make Thinking Visible:</strong> Have students highlight their final transition sentence in their draft and add a comment explaining the rhetorical move they chose and why.</li>
+            	<li><strong>Peer Review the Flow:</strong> In pairs, have students read each other&#x27;s two paragraphs (with the new transition) and describe the logical journey the writer took them on.</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5>References</h5>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Transitions</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/transitions/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/transitions/</a></p>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Flow</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/flow/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/flow/</a></p>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>Activity 6: Crafting the Bookends - Intro &amp; Conclusion</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> To draft an engaging introduction that sets up your argument and a memorable conclusion that reinforces your main takeaway, ensuring your paper starts strong and finishes with impact.</p>
+
+            <p><strong>Task:</strong> Draft your full introduction or conclusion, then use a structured AI analysis to evaluate its core components and guide your revision.</p>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do It</h4>
+
+            <p><strong>Use your brain first:</strong></p>
+
+            <ol>
+            	<li>Write a complete, full-paragraph draft of the introduction/conclusion. This is your raw material, built entirely from your own thinking.</li>
+            </ol>
+
+            <p><strong>Get AI Input:</strong> Select the prompt that matches the paragraph you wrote. This provides the AI with a clear rubric to act as your structural coach.</p>
+
+            <p><em>Introduction Prompt:</em></p>
+
+            <pre>
+            <code>Act as a writing instructor evaluating the introduction of a paper.
+
+            My draft introduction:
+            &quot;[Paste your full introduction paragraph here]&quot;
+
+            Your task is to analyze my draft based on the three core jobs of an introduction:
+            1.  **The Hook:** Quote the sentence(s) you believe act as the hook. Is it effective at grabbing the reader&#x27;s attention?
+            2.  **The Context:** Briefly describe the context my introduction provides. Is it sufficient for a reader to understand the topic?
+            3.  **The Thesis:** Quote the sentence you believe is my thesis statement. Is it clear, specific, and arguable?</code></pre>
+
+            <p><em>Conclusion Prompt:</em></p>
+
+            <pre>
+            <code>Act as a writing instructor evaluating the conclusion of a paper.
+
+            My draft conclusion:
+            &quot;[Paste your full conclusion paragraph here]&quot;
+
+            Your task is to analyze my draft based on the three core jobs of a conclusion:
+            1.  **The Synthesis:** Does the paragraph briefly synthesize the paper&#x27;s main points (without just listing them)?
+            2.  **The &quot;So What?&quot;:** Identify the sentence(s) that explain the broader significance, implications, or importance of my argument.
+            3.  **The Final Thought:** Does the paragraph offer a memorable final thought that leaves a lasting impression?</code></pre>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ol>
+            	<li>Review the AI&#x27;s analysis. If it struggled to identify one of the core components (like your thesis or your &quot;so what?&quot; statement), what does that tell you about the clarity of your writing?</li>
+            	<li>The AI identified a specific element as the weakest. Do you agree with this diagnosis? Why or why not?</li>
+            	<li>Based on this feedback, what are the revisions you will make to your introduction and conclusion to make them more effective?</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5>References</h5>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Introductions</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/introductions/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/introductions/</a></p>
+
+            <p>The University of North Carolina at Chapel Hill Writing Center. (2024). <em>Conclusions</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/conclusions/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/conclusions/</a></p>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <h1><i></i>Using AI for Revising, Editing, and Proofreading</h1>
+
+            <div>
+            <div>
+            <p><strong>Revising:</strong> Revision is RE-VISION, i.e., looking at your draft again. During revision, you focus on things like your arguments, evidence and purpose and not on nitty-gritty details like commas and word choice. In this stage of writing, you are confirming that the foundation of your paper is solid.</p>
+
+            <p><strong>Consider:</strong></p>
+
+            <ul>
+            	<li><strong>Purpose &amp; Argument:</strong> Is my thesis clear and compelling? Is it consistently supported throughout the paper?</li>
+            	<li><strong>Audience:</strong> Will this draft meet the expectations of my intended readers (e.g., my professor, my classmates)?</li>
+            	<li><strong>Structure &amp; Flow:</strong> Does my argument progress logically? Are the paragraphs in the right order?</li>
+            </ul>
+
+            <p>For a deeper dive, see the UNC Writing Center&#x27;s guide on <a href="https://writingcenter.unc.edu/tips-and-tools/revising-drafts/" rel="noopener noreferrer" target="_blank">Revising Drafts</a>.</p>
+
+            <hr>
+            <p><strong>Editing:</strong> Editing is refining; it&#x27;s where you focus on how you express your ideas, ensuring your language is clear, effective, and polished.</p>
+
+            <p><strong>Consider:</strong></p>
+
+            <ul>
+            	<li><strong>Clarity &amp; Style:</strong> Are my sentences easy to understand? Is my tone appropriate for my audience?</li>
+            	<li><strong>Paragraphs:</strong> Does each paragraph have a clear topic sentence? Is there a good balance of evidence and my own analysis?</li>
+            	<li><strong>Flow:</strong> Are the transitions between sentences and paragraphs smooth?</li>
+            </ul>
+
+            <p>For more, see the UNC Writing Center&#x27;s guide on <a href="https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/" rel="noopener noreferrer" target="_blank">Editing and Proofreading</a>.</p>
+
+            <hr>
+            <p><strong>Proofreading:</strong> Proofreading is polishing the final details. It involves hunting for errors and typos that can distract your reader and undermine your credibility.</p>
+
+            <p><strong>Look for:</strong></p>
+
+            <ul>
+            	<li>Grammar &amp; Punctuation Errors</li>
+            	<li>Spelling Mistakes</li>
+            	<li>Formatting Issues (e.g., citations, page numbers)</li>
+            	<li>Typos</li>
+            </ul>
+
+            <p>Generative AI tools like ChatGPT, Grammarly, Lex and many others are excellent tools to support your revising, editing, and proofreading processes - as long as you don&#x27;t let them do all the work. Remember: use your brain first, apply AI tools next, then use your own judgement in creating the final product. If you&#x27;ve reached this stage you should have been using your brain a lot to create your first draft. To effectively integrate AI into your revising, editing, and proofreading process, here is a suggested workflow:</p>
+            </div>
+
+            <div>
+            <h5><i></i>Recommended Workflow</h5>
+
+            <p>Using AI to enhance your Revising -&gt; Editing -&gt; Proofreading without replacing your own intellectual effort.</p>
+
+            <ol>
+            	<li><strong>Use your brain first: <a href="ai-generated-writing-effective-and-ethical-use.html" target="_blank">Complete Your Draft</a>.</strong> Write the entire paper using your own thinking. Get your ideas down without worrying about perfection.</li>
+            	<li><strong>Revise with AI as a Structural Analyst.</strong> Use AI for the big picture. <strong>Focus:</strong> purpose, argument, audience, structure.</li>
+            	<li><strong>Edit with AI as a Style Coach.</strong> Once the structure is solid, focus on how the ideas are expressed. <strong>Focus:</strong> clarity, tone, sentence variety, paragraph coherence and organization.</li>
+            	<li><strong>Proofread with AI as a Detail-Checker.</strong> Use tools for the final polish. <strong>Focus:</strong> grammar, spelling.</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5><i></i>Important Tips</h5>
+
+            <ul>
+            	<li>Get feedback from the AI, but make the edits yourself. This will help you understand and identify patterns in your writing that can be improved.</li>
+            	<li>Evaluate all AI suggestions against the intended message, your own voice, and common sense. Pay special attention to factual errors, depth, nuance, authenticity, and bias.</li>
+            	<li>Put another human in the loop and seek peer/instructor/expert feedback.</li>
+            	<li>Always perform a final, human read-through to catch errors the AI missed and ensure the voice is yours.</li>
+            </ul>
+            </div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Activities</h2>
+            <p>For each of the revising and editing activities, I strongly recommend following the <a href="https://www.sciencedirect.com/science/article/pii/S8755461525000088#sec0024" rel="noopener noreferrer" target="_blank">PAIRR framework</a> for getting peer feedback (download the Word doc in the Appendix of the PAIRR paper. Supplementary materials section), AI feedback and then comparing the two. If you cannot get peer feedback, then you do the revising and editing activities yourself and compare to what the AI gives you.</p>
+
+            <div>
+            <details><summary><i></i><span>The PAIRR Framework: Integrating Peer and AI Feedback</span></summary>
+
+            <div>
+            <ol>
+            	<li>Complete the rough draft.</li>
+            	<li><strong>P</strong>rovide and receive peer feedback.</li>
+            	<li>Receive <strong>AI</strong> feedback using the prompt below.</li>
+            </ol>
+
+            <pre>
+            <code>**I am a student in a university writing course working on a paper. Pretend you are a peer-reviewer who will review my draft based on the assignment prompt and grading rubric I provide. Please provide clear, detailed, specific, and supportive feedback. The format for your feedback should be as follows: 1. Two to three positive aspects of my paper and why those aspects are effective. 2. Three to four aspects for revision and the reasoning about why each poses an issue, and 3. A suggestion for revising each one.  
+
+            **Here is the assignment prompt: ||copy and paste assignment prompt||**
+
+            **Here is the rubric for the assignment:  ||copy and paste rubric||.**
+
+            **Here is the paper: ||copy and paste draft||**</code></pre>
+
+            <ol start="4">
+            	<li><strong>R</strong>eflect and compare the AI and peer feedback.</li>
+            	<li><strong>R</strong>evise the draft based on the feedback.</li>
+            </ol>
+            </div>
+            </details>
+            </div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Revision Activities</h2>
+            <p>Revision is where you step back from the sentence-level and look at the big picture: your argument&#x27;s logic, structure, and flow. The activities below treat AI as a <strong>structural analyst</strong>. You&#x27;ll use it to get a &quot;second look&quot; at your paper&#x27;s skeleton, helping you spot logical gaps, strengthen your thesis, and ensure your ideas connect seamlessly.</p>
+
+            <div>
+            <details><summary><i></i><span>Revision Activity 1: The Reverse Outline</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> To analyze the logical flow and structural integrity of your draft by creating an outline from your finished text. This helps you see if your argument progresses logically or if it jumps around unexpectedly.</p>
+
+            <p><strong>Task:</strong> You will create a reverse outline of your draft using your own analytical skills, then ask AI to perform the same task. By comparing the two outlines, you&#x27;ll discover whether you and the AI see the same structural strengths and weaknesses in your paper.</p>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do It</h4>
+
+            <p><strong>Use your brain first:</strong></p>
+
+            <ol>
+            	<li>Follow these instructions for <a href="https://writing.wisc.edu/handbook/reverseoutlines/" rel="noopener noreferrer" target="_blank">creating a reverse outline</a> from your draft.</li>
+            </ol>
+
+            <p><strong>Get AI Input:</strong></p>
+
+            <ol start="2">
+            	<li>Use the following prompt to have AI create its own reverse outline.</li>
+            </ol>
+
+            <pre>
+            <code>You are an _academic writing coach_ with experience teaching university writing courses. Please review my full draft (pasted below) and build a **reverse outline**.
+
+            The purpose of a reverse outline is to help determine if the paper meets its goals, discover places where you might need to expand evidence or analysis, and identify where readers might struggle with your organization or structure.
+
+            A reverse outline extracts the main claim of each paragraph so the writer can inspect logic, structure, and flow **after** drafting.
+
+            Here are the steps for creating a reverse outline:
+            1. Read through the entire draft to understand the thesis and overall arc
+            2. For each body paragraph: identify its core idea -&gt; this is sentence &#x27;a&#x27;; and identify its rhetorical job -&gt; this is sentence &#x27;b&#x27;
+            3. Number the sentences 1a, 1b, 2a etc. 
+            4. Review the numbered list to analyze the paper&#x27;s logical flow and structure and create a Structural Observations commentary where you note the strengthes, flag gaps or redundancies and suggest fixes.
+
+            Formatting:
+            - Keep each (a)/(b) sentence ≤ 30 words.
+            - Keep the **Structural Observations** section ≤ 200 words.
+
+            Here is my draft:
+            [Paste your complete draft here]</code></pre>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ol>
+            	<li><strong>Compare the outlines:</strong> How similar are your reverse outline and the AI&#x27;s version? Where do they differ significantly? What does this reveal about how you and the AI &quot;read&quot; your paper differently?</li>
+            	<li><strong>Reverse Outline Questions to ask of yourself and of the AI:</strong>
+            	<ul>
+            		<li>What do you see as the paper&#x27;s overall argument based on this outline?</li>
+            		<li>Which paragraphs seem most closely connected to each other?</li>
+            		<li>Are there any paragraphs that seem disconnected from the main argument?</li>
+            		<li>Do you notice any repetitive points or gaps in the logical flow?</li>
+            		<li>Where might a reader have trouble following the progression of ideas?</li>
+            	</ul>
+            	</li>
+            	<li><strong>Revision decisions:</strong> Based on the two outlines, what are the structural changes you will make to strengthen your paper?</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5>References</h5>
+
+            <p>University of Wisconsin-Madison Writing Center. (n.d.). Creating a reverse outline. <em>Writer&#x27;s Handbook</em>. <a href="https://writing.wisc.edu/handbook/reverseoutlines/" rel="noopener noreferrer" target="_blank">https://writing.wisc.edu/handbook/reverseoutlines/</a></p>
+            </div>
+            </div>
+            </details>
+
+            <hr>
+            <details><summary><i></i><span>Revision Activity 2: Build Your Own Revision Prompt</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> To develop your ability to create effective prompts that guide AI to provide useful revision feedback while maintaining your role as the decision-maker in the revision process.</p>
+
+            <p><strong>Task:</strong> You will study established revision strategies, then engineer a comprehensive prompt that directs AI to analyze your draft and provide specific, actionable feedback. You&#x27;ll evaluate the AI&#x27;s response and selectively implement suggestions that align with your goals.</p>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do It</h4>
+
+            <p><strong>Use Your Brain First:</strong></p>
+
+            <ol>
+            	<li>Study these two guides on making revisions:
+            	<ul>
+            		<li>George Mason University Writing Center. (n.d.). <a href="https://writingcenter.gmu.edu/writing-resources/writing-as-process/23-ways-to-improve-your-draft" rel="noopener noreferrer" target="_blank"><em>23 ways to improve your draft</em></a>.</li>
+            		<li>The Writing Center, University of North Carolina at Chapel Hill. (n.d.). <a href="https://writingcenter.unc.edu/tips-and-tools/revising-drafts/" rel="noopener noreferrer" target="_blank"><em>Revising drafts</em></a>.</li>
+            	</ul>
+            	</li>
+            	<li>Identify 3-4 specific revision areas you want to focus on (e.g., thesis clarity, paragraph structure, evidence integration, transitions).</li>
+            	<li>Analyze this basic AI prompt and identify what&#x27;s missing:
+            	<pre>
+            <code>Please review my essay and tell me how to make it better.
+            [paste essay draft here]</code></pre>
+            	</li>
+            	<li>Improve the prompt using the CRAFT framework:
+            	<ul>
+            		<li><strong>Context:</strong> What background does the AI need about your paper?</li>
+            		<li><strong>Role:</strong> What identity should the AI assume?</li>
+            		<li><strong>Action:</strong> What specific tasks should it perform?</li>
+            		<li><strong>Format:</strong> How should it structure its response?</li>
+            		<li><strong>Tone:</strong> What voice/style should it use?</li>
+            	</ul>
+            	</li>
+            </ol>
+
+            <p><strong>Get Some AI Input:</strong></p>
+
+            <ol start="5">
+            	<li>Test the basic AI prompt by using it with your draft essay.</li>
+            	<li>Test your comprehensive prompt by using it with your draft essay.</li>
+            </ol>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ol>
+            	<li>Compare the response to the basic prompt with the response to the comprehensive prompt.</li>
+            	<li>Make strategic revision decisions: Of the AI&#x27;s suggestions, which ones will you implement and why? How will you modify them to fit your voice and purpose? Which suggestions will you reject and what&#x27;s your reasoning?</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5><i></i>Notes for Instructors</h5>
+
+            <p>If you want to adapt this activity in your class, here are some things to consider:</p>
+
+            <ul>
+            	<li><strong>Side-by-Side Prompt Demo:</strong> Show a weak, overly broad prompt next to a well-crafted CRAFT prompt. Run both through the AI so students can see the stark difference in feedback quality.</li>
+            	<li><strong>Prompt Draft → Peer Debug:</strong> Let students exchange their first-draft prompts and “debug” each other’s wording for clarity, specificity, and ethical boundaries before ever consulting the AI.</li>
+            	<li><strong>Quick Fire Revisions:</strong> Set a timer (e.g., 5 minutes) for students to refine their prompt after seeing the AI’s first response. This models iterative design and keeps the session energetic.</li>
+            	<li><strong>Ethics Checkpoint:</strong> Require students to add one line in their prompt specifying what the AI should not do (e.g., “Do not rewrite my paragraphs for me”). This reinforces responsible use.</li>
+            	<li><strong>Mini-Reflection Exit Ticket:</strong> End class with a sticky-note or LMS post: “One insight I gained about prompt engineering today is ______.” Use these to gauge understanding and plan follow-ups.</li>
+            	<li>Use the <a href="https://www.sciencedirect.com/science/article/pii/S8755461525000088" rel="noopener noreferrer" target="_blank">PAIRR Framework</a> with the student&#x27;s drafts and the revision prompt students craft.</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5>References</h5>
+
+            <p>George Mason University Writing Center. (n.d.). <em>23 ways to improve your draft</em>. <a href="https://writingcenter.gmu.edu/writing-resources/writing-as-process/23-ways-to-improve-your-draft" rel="noopener noreferrer" target="_blank">https://writingcenter.gmu.edu/writing-resources/writing-as-process/23-ways-to-improve-your-draft</a></p>
+
+            <p>The Writing Center, University of North Carolina at Chapel Hill. (n.d.). <em>Revising drafts</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/revising-drafts/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/revising-drafts/</a></p>
+
+            <p>Sperber, L., MacArthur, M., Minnillo, S., Stillman, N., &amp; Whithaus, C. (2025). Peer and AI Review + Reflection (PAIRR): A human-centered approach to formative assessment. <em>Computers &amp; Composition/Computers and Composition</em>, <em>76</em>, 102921. <a href="https://doi.org/10.1016/j.compcom.2025.102921" rel="noopener noreferrer" target="_blank">https://doi.org/10.1016/j.compcom.2025.102921</a></p>
+            </div>
+            </div>
+            </details>
+            </div>
+
+            <hr>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Editing Activities</h2>
+            <p>With a solid structure confirmed, editing is your chance to zoom in on the craft of writing. In this stage you will improve the clarity, impact, and style of your prose. You&#x27;ll use AI as a <strong>style coach</strong>, to provide feedback on sentence construction, word choice, and paragraph coherence.</p>
+
+            <div>
+            <details><summary><i></i><span>Editing Activity 1: Create an AI Editor</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> Develop skill in identifying editing requirements, engineering prompts that keep the AI in the “advisor” seat, and deciding which AI-generated edits to trust.</p>
+
+            <p><strong>Task:</strong> Build, test, and refine an AI prompt that gives you focused editing feedback (NOT wholesale rewriting). Then triage the AI’s advice and implement only what improves your draft.</p>
+
+            <div>
+            <h4><i></i>Dive-In and Do It</h4>
+
+            <p><strong>Use your brain first:</strong></p>
+
+            <ol>
+            	<li>Skim two editing guides:
+            	<ul>
+            		<li><a href="https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/" rel="noopener noreferrer" target="_blank">UNC&#x27;s Editing and Proofreading Guide</a></li>
+            		<li><a href="https://owl.purdue.edu/owl/graduate_writing/graduate_writing_topics/graduate_writing_topics_editing_proofreading_new.html" rel="noopener noreferrer" target="_blank">Purdue&#x27;s Editing and Proofreading Guide</a></li>
+            	</ul>
+            	</li>
+            	<li>From the guides, list 3 or 4 editing passes you value the most (e.g., content, paragraph structure, clarity, style and tone consistency).</li>
+            	<li>Perform your own editing first - keep notes.</li>
+            	<li>Examine this flimsy prompt and note at least three weaknesses:
+            	<pre>
+            <code>Edit my paper for content, structure, clarity, and style.
+            [paste draft]</code></pre>
+            	</li>
+            	<li>Create an AI editor by drafting a prompt using the CRAFT scaffold:
+            	<table>
+            		<thead>
+            			<tr>
+            				<th>Element</th>
+            				<th>Your choices (bullet form)</th>
+            			</tr>
+            		</thead>
+            		<tbody>
+            			<tr>
+            				<td><strong>Context</strong></td>
+            				<td>Course, assignment purpose, audience, citation style…</td>
+            			</tr>
+            			<tr>
+            				<td><strong>Role</strong></td>
+            				<td>“Senior copy-editor for an academic press,” etc.</td>
+            			</tr>
+            			<tr>
+            				<td><strong>Action</strong></td>
+            				<td>Ask for the 3-4 passes you selected in Step 2, plus one thing it should not do (e.g., “Do NOT rewrite sentences”).</td>
+            			</tr>
+            			<tr>
+            				<td><strong>Format</strong></td>
+            				<td>Bulleted issues + concrete example from my text + fix suggestion (no more than 20 words each).</td>
+            			</tr>
+            			<tr>
+            				<td><strong>Tone</strong></td>
+            				<td>Professional, concise, non-directive.</td>
+            			</tr>
+            		</tbody>
+            	</table>
+            	</li>
+            </ol>
+
+            <p><strong>Get Some AI Input:</strong></p>
+
+            <ol start="5">
+            	<li>Paste the flimsy prompt + draft into ChatGPT (or comparable model). Keep the output.</li>
+            	<li>Paste your CRAFT prompt + draft. Keep the output.</li>
+            	<li>Rapid-iterate: tweak ONE line of your CRAFT prompt, re-run, and see if the feedback quality improves.</li>
+            </ol>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ol>
+            	<li>Which version delivered feedback that matched your Step 2 priorities? Cite two concrete examples.</li>
+            	<li>Identify the AI suggestions you will KEEP, the ones you will MODIFY, and the ones you will DISCARD. Explain why for each one.</li>
+            	<li>Did the AI hallucinate any “rules,” mislabel citations, or overlook glaring issues? What does that reveal about LLM limitations?</li>
+            	<li>Looking ahead, how will you refine your editing checklist so the next AI interaction is even tighter?</li>
+            </ol>
+            </div>
+
+            <div>
+            <h5><i></i>Notes for Instructors</h5>
+
+            <p>If you want to adapt this activity in your class, here are some things to consider:</p>
+
+            <ul>
+            	<li><strong>Side-by-Side Demo:</strong> Compare a flimsy vs. CRAFT prompt on the same student paragraph; students instantly see the difference in usefulness.</li>
+            	<li><strong>Peer Prompt Debug:</strong> 5-minute swap; classmates flag vague verbs (“improve,” “fix”) and missing constraints.</li>
+            	<li><strong>Quality Audit:</strong> After AI feedback, students run a “voice consistency” test by reading revised sentences aloud to detect style shifts.</li>
+            	<li><strong>Mini-Reflection Exit Ticket:</strong> End class with a sticky-note or LMS post: “One insight I gained about prompt engineering today is ______.” Use these to gauge understanding and plan follow-ups.</li>
+            	<li>Use the <a href="https://www.sciencedirect.com/science/article/pii/S8755461525000088" rel="noopener noreferrer" target="_blank">PAIRR Framework</a> with the student&#x27;s drafts and the editing prompt students craft.</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5>References</h5>
+
+            <p>Purdue Online Writing Lab. (2024). <em>Editing and proofreading</em>. <a href="https://owl.purdue.edu/owl/graduate_writing/graduate_writing_topics/graduate_writing_topics_editing_proofreading_new.html" rel="noopener noreferrer" target="_blank">https://owl.purdue.edu/owl/graduate_writing/graduate_writing_topics/graduate_writing_topics_editing_proofreading_new.html</a></p>
+
+            <p>The Writing Center, University of North Carolina at Chapel Hill. (n.d.). <em>Editing and proofreading</em>. <a href="https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/</a></p>
+
+            <p>Sperber, L., MacArthur, M., Minnillo, S., Stillman, N., &amp; Whithaus, C. (2025). Peer and AI Review + Reflection (PAIRR): A human-centered approach to formative assessment. <em>Computers &amp; Composition/Computers and Composition</em>, <em>76</em>, 102921. <a href="https://doi.org/10.1016/j.compcom.2025.102921" rel="noopener noreferrer" target="_blank">https://doi.org/10.1016/j.compcom.2025.102921</a></p>
+            </div>
+            </div>
+            </details>
+            </div>
+
+            <hr>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Proofreading</h2>
+            <p>If we stick with our initial definition of proofreading (Grammar &amp; Punctuation Errors, Spelling Mistakes, Formatting Issues, Typos), it&#x27;s clear that proofreading is mostly a mechanical, rules-based activity. In most cases, using an AI tool to do these checks is acceptable, even in classes where using AI is strictly prohibited. In fact, it is difficult to <em>avoid</em> using an AI tool to do these checks. If you are working in MS Word, you are going to get grammar and spelling suggestions automatically and these are driven by AI. That being said, a final proofread by a human is always necessary to catch those things that AI still misses.</p>
+
+            <p>Word processors like Word and Google Docs have built-in proofreading but there are many other AI tools that are designed for proofreading (and editing). Two of the most popular are Grammarly and Quillbot, but there are many others. The other tool worth mentioning is <a href="https://www.turnitin.ca/products/features/draft-coach/" rel="noopener noreferrer" target="_blank">Draft Coach from Turnitin</a> which is available to Okanagan College students through our institutional license (as of June 2025). Draft Coach is built-in to your online version of Microsoft 365 when you login with your OC credentials. It helps you with citations, grammar, and avoiding plagiarism.</p>
+
+            <p>Personally, for proofreading, I prefer to rely on the built-in tools in Microsoft for the basic stuff, chatbots with targeted prompts for a more detailed check, and then doing a final check with my own eyes. It makes the process intentional and I can prompt for specific things with each (grammar, vocabulary enrichment, verb tense consistency, passive vs. active voice). The main downside is that this an extra step that requires cutting and pasting whereas tools like Grammarly are built right into the text editor.</p>
+
+            <div>
+            <p>Your proofreading process is up to you, but remember that for every new tool that you use, you are sharing your personal information and your work with another company. I know that people rarely do this, but read the privacy policy and data agreement to understand what the company is going to do with your data and work. </p>
+            </div>
+
+            <p>Based on my own limited experience and the online consensus here is a quick overview of the suggested proofreading tools (for a quick but more comprehensive summary, ask Perplexity Deep Research to compare these tools):</p>
+
+            <ul>
+            	<li><strong>Draft Coach</strong> is your best choice to support academic writing and it is available for free as long as OC maintains the institutional license. Draft Coach has strong citation tools, gives you a chance to check your own work for plagiarism, corrects grammar mistakes and provides explanations to guide your proofreading.</li>
+            	<li><strong>Grammarly</strong> is the most comprehensive proofreading solution. It has better accuracy and detailed error explanations.</li>
+            	<li><strong>Quillbot</strong> is a solid alternative to Grammarly but focuses more on paraphrasing.</li>
+            	<li><strong>ChatGPT</strong> is the most flexible, but requires good prompting since it is not specifically an editing or proofreading tool.</li>
+            </ul>
+
+            <div>
+            <details><summary><i></i><span>Proofreading Activity 1: Compare the Tools</span></summary>
+
+            <div>
+            <p><strong>Purpose:</strong> Compare the proofreading capabilities of different tools.</p>
+
+            <p><strong>Task:</strong> Provide a small writing sample to different proofreading tools to see which one can find the most errors.</p>
+
+            <div>
+            <h4><i></i>Dive-in and Do It</h4>
+
+            <p><strong>Use Your Brain First:</strong></p>
+
+            <ol>
+            	<li>Read through the paragraphs below and see if you can find the spelling and grammar errors and make suggestions for improvement.</li>
+            </ol>
+
+            <p><strong>Example 1:</strong></p>
+
+            <pre>
+            <code>The principal designer argued that the principle concern was aesthetic cohesion, not cost overruns. At the budget meeting, however, finance officers insisted that sticking to first principals required cutting the lighting plan, leaving the principal’s proposal in jeopardy.
+
+            Dr. Singh finally met with Rivera after reviewing the performance data, and she decided the pilot needed another month. She also recommended that the team document every iteration before presenting it to the board.
+
+            Glancing quickly through the microscope, the bacterial colonies appeared to morph into translucent threads that the research assistant could barely count.
+
+            The new onboarding manual asks interns to (a) log their hours, (b) complete safety training, and that they submit a weekly reflection journal to HR by Friday.
+
+            Only one of the project milestones were completed on schedule, yet management announced that the results “exceeded expectations” in the quarterly report.
+
+            The engineers finished the stress analysis earlier than expected the marketing team, meanwhile, had already printed the brochures with outdated specifications.
+
+            During the interview, the CEO explained that the company’s guiding mantra is “build what matters to the customer, test it relentlessly, and scale responsibly.
+
+            To synergize our outreach stack, we should parallel-process the empathy touchpoints while hard-pivoting into a data-literate mindset; that way the vibe stays premium but also low-latency for key stakeholders.</code></pre>
+
+            <p><strong>Example 2:</strong></p>
+
+            <pre>
+            <code>At yesterday’s kickoff meeting, the lead architect argued that energy efficiency, not superficial aesthetics, ought to steer every major decision in the greenhouse build. He predicts that a roof-mounted heat-exchange loop could trim utility costs by nearly forty percent without sacrificing crop yield, and added that the design would compliment the surrounding orchard.
+
+            After the city inspector spoke with Dr. Reyes about the ventilation blueprint, she requested a revised drawing that clarified the airflow differentials. Walking through the half-finished frame, the LED grow lights looked far too bright for seedlings. The project charter promises to reduce waste, improving neighborhood engagement, and to create seasonal teaching modules for local schools.
+
+            None of the preliminary safety tests was conclusive, but the team declares that the system “operates flawlessly” in internal memos. Volunteers assembled the seed racks before dawn the installation crew, however, arrived after lunch and had to reposition every tray. During a radio interview, the project lead explained that the guiding slogan is “grow local, learn global, and share endlessly. To hyper-optimize our community-facing deliverables, we must granularly gamify the outreach funnels so the stakeholders feel maximum uplift vibes.</code></pre>
+
+            <p><strong>Let AI give it a try:</strong></p>
+
+            <ol start="2">
+            	<li>Assuming you are comfortable with having accounts with all of these different companies, enter the above text into each of the following:
+            	<ul>
+            		<li>Grammarly</li>
+            		<li>Quillbot</li>
+            		<li>Draft Coach</li>
+            		<li>A chatbot (with an appropriate prompt. See below)</li>
+            	</ul>
+            	</li>
+            	<li>Compare Results.</li>
+            </ol>
+
+            <details><summary>Click to see Writing with Errors Identified</summary>
+
+            <div>
+            <h5>Example 1 Errors:</h5>
+
+            <p>The <span>principal</span> designer argued that the <span>principle</span> concern was aesthetic cohesion, not cost overruns. At the budget meeting, however, finance officers insisted that sticking to first <span>principals</span> required cutting the lighting plan, leaving the principal’s proposal in jeopardy. <em>(Word-choice homonym: principle / principal)</em></p>
+
+            <p>Dr. Singh finally met with Rivera after reviewing the performance data, and <span>she</span> decided the pilot needed another month. She also recommended that the team document every iteration before presenting it to the board. <em>(Ambiguous pronoun reference)</em></p>
+
+            <p><span>Glancing quickly through the microscope, the bacterial colonies</span> appeared to morph into translucent threads that the research assistant could barely count. <em>(Misplaced modifier)</em></p>
+
+            <p>The new onboarding manual asks interns to (a) log their hours, (b) complete safety training, and <span>that they submit</span> a weekly reflection journal to HR by Friday. <em>(Faulty parallelism)</em></p>
+
+            <p>Only one of the project milestones <span>were</span> completed on schedule, yet management announced that the results “exceeded expectations” in the quarterly report. <em>(Subject-verb agreement)</em></p>
+
+            <p>The engineers finished the stress analysis earlier <span>than expected the marketing team</span>, meanwhile, had already printed the brochures with outdated specifications. <em>(Comma splice / run-on sentence)</em></p>
+
+            <p>During the interview, the CEO explained that the company’s guiding mantra is “build what matters to the customer, test it relentlessly, and scale <span>responsibly.</span> <em>(Unbalanced quotation mark)</em></p>
+
+            <p><span>To synergize our outreach stack, we should parallel-process the empathy touchpoints while hard-pivoting into a data-literate mindset; that way the vibe stays premium but also low-latency for key stakeholders.</span> <em>(Jargon / unclear language)</em></p>
+
+            <hr>
+            <h5>Example 2 Errors:</h5>
+
+            <p>At yesterday’s kickoff meeting, the lead architect argued that energy efficiency—not superficial aesthetics—ought to steer every major decision in the greenhouse build. He <span>predicts</span> that a roof-mounted heat-exchange loop could trim utility costs by nearly forty percent without sacrificing crop yield, and added that the design would <span>compliment</span> the surrounding orchard. <em>(Verb-tense shift; Word-choice homonym)</em></p>
+
+            <p>After the city inspector spoke with Dr. Reyes about the ventilation blueprint, <span>she</span> requested a revised drawing that clarified the airflow differentials. <span>Walking through the half-finished frame, the LED grow lights</span> looked far too bright for seedlings. The project charter promises to reduce waste, <span>improving neighborhood engagement, and to create</span> seasonal teaching modules for local schools. <em>(Ambiguous pronoun; Misplaced modifier; Faulty parallelism)</em></p>
+
+            <p>None of the preliminary safety tests <span>was</span> conclusive, but the team <span>declares</span> that the system “operates flawlessly” in internal memos. Volunteers assembled the seed racks <span>before dawn the installation crew, however,</span> arrived after lunch and had to reposition every tray. During a radio interview, the project lead explained that the guiding slogan is “grow local, learn global, and share <span>endlessly.</span> <span>To hyper-optimize our community-facing deliverables, we must granularly gamify the outreach funnels so the stakeholders feel maximum uplift vibes.</span> <em>(Subject-verb disagreement; Verb-tense shift; Comma splice; Unbalanced quotation mark; Jargon)</em></p>
+            </div>
+            </details>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li>Compare the results from the AIs along with the errors that you flagged.</li>
+            	<li>What are the primary differences between the tools?</li>
+            	<li>Based on these results, which tool would you use to enhance your own proofreading? Why?</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5>Chatbot Proofreader Prompt Ideas</h5>
+
+            <p>Source: <a href="https://www.reddit.com/r/ChatGPTPromptGenius/comments/1jlx43y/here_are_my_best_chatgpt_prompts_for_proofreading/" rel="noopener noreferrer" target="_blank">Reddit - r/ChatGPTPromptGenius</a></p>
+
+            <pre>
+            <code>Act as a proofreading expert tasked with correcting grammatical errors in a given text below. Your job is to meticulously analyze the text, identify any grammatical mistakes. This includes checking for proper sentence structure, punctuation, verb tense consistency, and correct usage of words. Additionally, provide suggestions to enhance the readability and flow of the text. The goal is to polish the text so that it communicates its message effectively and professionally. Identify where the error is, explaining what the error is and then make suggestions for fixing it.
+            [text here]</code></pre>
+
+            <h5>Other References</h5>
+
+            <p>UNC Writing Center Tips: <a href="https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/" rel="noopener noreferrer" target="_blank">https://writingcenter.unc.edu/tips-and-tools/editing-and-proofreading/</a></p>
+
+            <p>Perplexity Deep Research Report: <a href="https://www.perplexity.ai/search/for-use-as-proofreaders-where-yNoSUKGVRqqfmK9mkxtlYg" rel="noopener noreferrer" target="_blank">Proofreading Tools Comparison</a></p>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+            </div>
+            </div>
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/ai-quick-queries-and-idea-sparker.html
+++ b/site/ai-quick-queries-and-idea-sparker.html
@@ -4,522 +4,558 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI Quick Queries &amp; Idea Sparker - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="active has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li class="active"><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>AI Quick Queries &amp; Idea Sparker</h2>
-        <div>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
+    </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
 <div id="gai-wrap">
-<div>
-<div>
-<h2><i></i>Introduction: Your First Critical Steps with AI</h2>
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>AI Quick Queries &amp; Idea Sparker</h2>
+            <div>
 
-<p>You&#x27;ve got the overview of AI&#x27;s potential and pitfalls from the <em><strong>Essentials </strong></em>section. Now, it&#x27;s time to get hands-on again! In this section, &quot;AI Quick Queries &amp; Idea Sparker,&quot; we&#x27;ll explore some initial ways you can use AI for your studies (help explain things and brainstorm). </p>
+            <div>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Introduction: Your First Critical Steps with AI</h2>
+            <p>You&#x27;ve got the overview of AI&#x27;s potential and pitfalls from the <em><strong>Essentials </strong></em>section. Now, it&#x27;s time to get hands-on again! In this section, &quot;AI Quick Queries &amp; Idea Sparker,&quot; we&#x27;ll explore some initial ways you can use AI for your studies (help explain things and brainstorm). </p>
 
-<p>Think of this as your AI sandbox – a place to experiment, learn, and build your critical AI literacy skills.</p>
+            <p>Think of this as your AI sandbox – a place to experiment, learn, and build your critical AI literacy skills.</p>
 
-<h3><i></i>Your Guiding Principles for This Exploration</h3>
+            <h3><i></i>Your Guiding Principles for This Exploration</h3>
 
-<p>As you work through the activities in this tab, let these key ideas guide your approach:</p>
+            <p>As you work through the activities in this tab, let these key ideas guide your approach:</p>
 
-<ol>
-	<li><strong>Be an Active Experimenter:</strong> Don&#x27;t just passively receive information from AI. Get in there, try different prompts, and see what happens! Each activity is a chance for you to &quot;do something&quot; with AI.</li>
-	<li><strong>It&#x27;s Okay to Start Small (Low Stakes, High Learning):</strong> The tasks here are designed to be introductory. If AI makes a mistake (and it will!), it&#x27;s a low-risk opportunity for you to spot it and learn about AI&#x27;s limitations.</li>
-	<li><strong>Put on Your Critical Thinking Hat – Always:</strong> This is the most important part! After every AI interaction, we&#x27;ll prompt you to &quot;Pause &amp; Ponder.&quot; This is where you&#x27;ll connect back to the limitations we discussed in the <em><strong>Essentials </strong></em>section and analyze the AI&#x27;s output. Is it accurate? Biased? Superficial?</li>
-	<li><strong>Build Your &quot;AI Detective&quot; Skills:</strong> Our goal is to help you become confident in your ability to use AI critically. By practicing how to spot errors, question outputs, and guide AI more effectively, you&#x27;ll learn that <em>you</em> are the one in control.</li>
-</ol>
+            <ol>
+            	<li><strong>Be an Active Experimenter:</strong> Don&#x27;t just passively receive information from AI. Get in there, try different prompts, and see what happens! Each activity is a chance for you to &quot;do something&quot; with AI.</li>
+            	<li><strong>It&#x27;s Okay to Start Small (Low Stakes, High Learning):</strong> The tasks here are designed to be introductory. If AI makes a mistake (and it will!), it&#x27;s a low-risk opportunity for you to spot it and learn about AI&#x27;s limitations.</li>
+            	<li><strong>Put on Your Critical Thinking Hat – Always:</strong> This is the most important part! After every AI interaction, we&#x27;ll prompt you to &quot;Pause &amp; Ponder.&quot; This is where you&#x27;ll connect back to the limitations we discussed in the <em><strong>Essentials </strong></em>section and analyze the AI&#x27;s output. Is it accurate? Biased? Superficial?</li>
+            	<li><strong>Build Your &quot;AI Detective&quot; Skills:</strong> Our goal is to help you become confident in your ability to use AI critically. By practicing how to spot errors, question outputs, and guide AI more effectively, you&#x27;ll learn that <em>you</em> are the one in control.</li>
+            </ol>
 
-<h3><i></i>Your Critical Toolkit (Remember This Flow!)</h3>
+            <h3><i></i>Your Critical Toolkit (Remember This Flow!)</h3>
 
-<p>Keep this process in mind for every interaction with AI:</p>
+            <p>Keep this process in mind for every interaction with AI:</p>
 
-<div>
-<p>Your Question/Prompt</p>
+            <div>
+            <p>Your Question/Prompt</p>
 
-<p><i></i></p>
+            <p><i></i></p>
 
-<p>AI Output</p>
+            <p>AI Output</p>
 
-<p><i></i></p>
+            <p><i></i></p>
 
-<p>YOUR CRITICAL REVIEW</p>
+            <p>YOUR CRITICAL REVIEW</p>
 
-<p>(Verify, Analyze for Bias/Depth, Cross-Reference)</p>
+            <p>(Verify, Analyze for Bias/Depth, Cross-Reference)</p>
 
-<p><i></i></p>
+            <p><i></i></p>
 
-<p>Verified Understanding / Refined Idea</p>
-</div>
+            <p>Verified Understanding / Refined Idea</p>
+            </div>
 
-<p>Ready to dive in? Let&#x27;s get started!</p>
-</div>
-</div>
-</div>
+            <p>Ready to dive in? Let&#x27;s get started!</p>
+            </div>
+            </div>
 
 
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div>
-<h2><i></i>II. AI as a &quot;Quick Information Scout&quot;: Testing AI&#x27;s Knowledge &amp; Your Critical Skills</h2>
 
-<p>In this section, you&#x27;ll use AI to find information and definitions. Pay close attention to how your prompts affect the results and practice your critical evaluation skills. Remember the &quot;Critical Toolkit&quot; flowchart from the introduction – you&#x27;ll be applying it here! Click on each activity title below to expand its content.</p>
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>II. AI as a &quot;Quick Information Scout&quot;: Testing AI&#x27;s Knowledge &amp; Your Critical Skills</h2>
+            <p>In this section, you&#x27;ll use AI to find information and definitions. Pay close attention to how your prompts affect the results and practice your critical evaluation skills. Remember the &quot;Critical Toolkit&quot; flowchart from the introduction – you&#x27;ll be applying it here! Click on each activity title below to expand its content.</p>
 
-<div>
-<details><summary> <i></i><span>A. Activity 1: The AI Definition Deep Dive</span> </summary>
+            <div>
+            <details><summary> <i></i><span>A. Activity 1: The AI Definition Deep Dive</span> </summary>
 
-<div>
-<div>
-<h4><i></i>1. The Task: Your First Prompt</h4>
+            <div>
+            <div>
+            <h4><i></i>1. The Task: Your First Prompt</h4>
 
-<p>Pick a key term or concept from one of your current courses that you&#x27;d like AI to explain or define for you.</p>
-</div>
+            <p>Pick a key term or concept from one of your current courses that you&#x27;d like AI to explain or define for you.</p>
+            </div>
 
-<div>
-<h4><i></i>2. Dive In &amp; Do: Ask the AI</h4>
+            <div>
+            <h4><i></i>2. Dive In &amp; Do: Ask the AI</h4>
 
-<p>Your turn! Using an AI tool you have access to (e.g., ChatGPT, Claude, Gemini), ask it to define your chosen term with a simple, basic prompt. For example:</p>
+            <p>Your turn! Using an AI tool you have access to (e.g., ChatGPT, Claude, Gemini), ask it to define your chosen term with a simple, basic prompt. For example:</p>
 
-<pre>
-<code>Define [your chosen term].</code></pre>
+            <pre>
+            <code>Define [your chosen term].</code></pre>
 
-<p>Or</p>
+            <p>Or</p>
 
-<pre>
-<code>What is [your chosen term]?</code></pre>
-</div>
+            <pre>
+            <code>What is [your chosen term]?</code></pre>
+            </div>
 
-<div>
-<h4><i></i>3. Pause &amp; Ponder: Evaluate and Refine</h4>
+            <div>
+            <h4><i></i>3. Pause &amp; Ponder: Evaluate and Refine</h4>
 
-<p>Now, let&#x27;s critically evaluate the AI&#x27;s first response and think about how to improve your prompt:</p>
+            <p>Now, let&#x27;s critically evaluate the AI&#x27;s first response and think about how to improve your prompt:</p>
 
-<ul>
-	<li><strong>Initial Evaluation:</strong> Did you get a good response from your basic prompt? How did you determine if it was &quot;good&quot;? (e.g., Was it clear? Accurate based on your existing knowledge? The right length? Useful?)</li>
-	<li><strong>Improving Your Prompt:</strong> How could you make your prompt more specific to get a better, more tailored definition? Consider asking the AI to:
-	<ul>
-		<li>Specify the <strong>length</strong> of the definition (e.g., &quot;in one sentence,&quot; &quot;in about 50 words&quot;).</li>
-		<li>Define the <strong>audience</strong> the answer is for (e.g., &quot;for a high school student,&quot; &quot;for someone new to this field,&quot; &quot;for an expert colleague&quot;).</li>
-		<li>Request a specific <strong>format</strong> (e.g., &quot;provide three key characteristics as bullet points,&quot; &quot;include a real-world example&quot;).</li>
-		<li>(Advanced, if applicable to the tool) Ask it to reference a <strong>high-quality source type</strong> to get the definition.(e.g., &quot;identify a high quality source for the definition and then use that definition&quot;). Note: Many chatbots have search capability built in and can do this type of search.</li>
-	</ul>
-	</li>
-</ul>
-</div>
+            <ul>
+            	<li><strong>Initial Evaluation:</strong> Did you get a good response from your basic prompt? How did you determine if it was &quot;good&quot;? (e.g., Was it clear? Accurate based on your existing knowledge? The right length? Useful?)</li>
+            	<li><strong>Improving Your Prompt:</strong> How could you make your prompt more specific to get a better, more tailored definition? Consider asking the AI to:
+            	<ul>
+            		<li>Specify the <strong>length</strong> of the definition (e.g., &quot;in one sentence,&quot; &quot;in about 50 words&quot;).</li>
+            		<li>Define the <strong>audience</strong> the answer is for (e.g., &quot;for a high school student,&quot; &quot;for someone new to this field,&quot; &quot;for an expert colleague&quot;).</li>
+            		<li>Request a specific <strong>format</strong> (e.g., &quot;provide three key characteristics as bullet points,&quot; &quot;include a real-world example&quot;).</li>
+            		<li>(Advanced, if applicable to the tool) Ask it to reference a <strong>high-quality source type</strong> to get the definition.(e.g., &quot;identify a high quality source for the definition and then use that definition&quot;). Note: Many chatbots have search capability built in and can do this type of search.</li>
+            	</ul>
+            	</li>
+            </ul>
+            </div>
 
-<div>
-<h4><i></i>4. Dive In &amp; Do Again: Rewrite and Resubmit Your Prompt</h4>
+            <div>
+            <h4><i></i>4. Dive In &amp; Do Again: Rewrite and Resubmit Your Prompt</h4>
 
-<p>Based on your reflections above, rewrite your prompt to be more specific. Try incorporating at least two of the considerations (length, audience, format, source-style). For example:</p>
+            <p>Based on your reflections above, rewrite your prompt to be more specific. Try incorporating at least two of the considerations (length, audience, format, source-style). For example:</p>
 
-<pre>
-<code>Define [your chosen term] for a university student new to [your field/course name]. Keep the definition to two sentences and include one practical example.</code></pre>
+            <pre>
+            <code>Define [your chosen term] for a university student new to [your field/course name]. Keep the definition to two sentences and include one practical example.</code></pre>
 
-<p>Submit your new, more detailed prompt to the AI tool.</p>
-</div>
+            <p>Submit your new, more detailed prompt to the AI tool.</p>
+            </div>
 
-<div>
-<h4><i></i>5. Pause &amp; Ponder Again: Compare and Verify</h4>
+            <div>
+            <h4><i></i>5. Pause &amp; Ponder Again: Compare and Verify</h4>
 
-<ul>
-	<li><strong>Compare Responses:</strong> How did the AI&#x27;s response to your detailed prompt compare to its response to your basic prompt? Was it more useful, accurate, or better suited to your hypothetical need?</li>
-	<li><strong>Limitation Check (Accuracy/Hallucination &amp; Prompt Impact):</strong> Now, critically verify <strong>both</strong> AI-generated definitions against trusted sources (your textbook, lecture notes, reputable academic websites).
-	<ul>
-		<li>Did the more comprehensive prompt lead to a <em>more accurate</em> response, or just a <em>longer/differently formatted</em> one?</li>
-		<li>Did either prompt cause the AI to &quot;hallucinate&quot; (make things up) or introduce subtle inaccuracies?</li>
-	</ul>
+            <ul>
+            	<li><strong>Compare Responses:</strong> How did the AI&#x27;s response to your detailed prompt compare to its response to your basic prompt? Was it more useful, accurate, or better suited to your hypothetical need?</li>
+            	<li><strong>Limitation Check (Accuracy/Hallucination &amp; Prompt Impact):</strong> Now, critically verify <strong>both</strong> AI-generated definitions against trusted sources (your textbook, lecture notes, reputable academic websites).
+            	<ul>
+            		<li>Did the more comprehensive prompt lead to a <em>more accurate</em> response, or just a <em>longer/differently formatted</em> one?</li>
+            		<li>Did either prompt cause the AI to &quot;hallucinate&quot; (make things up) or introduce subtle inaccuracies?</li>
+            	</ul>
 
-	<div>
-	<p><i></i>Remember, even a &quot;better&quot; prompt doesn&#x27;t guarantee perfection. ALWAYS cross-reference with reliable sources!</p>
-	</div>
-	</li>
-</ul>
-</div>
+            	<div>
+            	<p><i></i>Remember, even a &quot;better&quot; prompt doesn&#x27;t guarantee perfection. ALWAYS cross-reference with reliable sources!</p>
+            	</div>
+            	</li>
+            </ul>
+            </div>
 
-<div>
-<h5><i></i>Key Takeaway for Activity 1</h5>
+            <div>
+            <h5><i></i>Key Takeaway for Activity 1</h5>
 
-<p>While a more detailed and specific prompt can often guide AI to produce a more relevant and structured output, it doesn&#x27;t eliminate the need for rigorous critical evaluation and verification. Your subject knowledge and trusted academic sources remain the ultimate arbiters of accuracy and truth. Effective prompting is about better guidance, not blind trust.</p>
-</div>
-</div>
-</details>
+            <p>While a more detailed and specific prompt can often guide AI to produce a more relevant and structured output, it doesn&#x27;t eliminate the need for rigorous critical evaluation and verification. Your subject knowledge and trusted academic sources remain the ultimate arbiters of accuracy and truth. Effective prompting is about better guidance, not blind trust.</p>
+            </div>
+            </div>
+            </details>
 
 
-<details><summary> <i></i><span>B. Activity 2: The AI &quot;Explain It Like I&#x27;m...&quot; Audience Challenge</span> </summary>
+            <details><summary> <i></i><span>B. Activity 2: The AI &quot;Explain It Like I&#x27;m...&quot; Audience Challenge</span> </summary>
 
-<div>
-<div>
-<h4><i></i>1. The Task: Tailoring Explanations</h4>
+            <div>
+            <div>
+            <h4><i></i>1. The Task: Tailoring Explanations</h4>
 
-<p>Choose a complex idea or process from your studies that you&#x27;d like a generative AI tool to explain to different audiences.</p>
-</div>
+            <p>Choose a complex idea or process from your studies that you&#x27;d like a generative AI tool to explain to different audiences.</p>
+            </div>
 
-<div>
-<h4><i></i>2. Dive In &amp; Do: Prompt for Different Audiences</h4>
+            <div>
+            <h4><i></i>2. Dive In &amp; Do: Prompt for Different Audiences</h4>
 
-<p>Using an AI tool, ask it to explain your chosen complex idea by trying prompts similar to these examples. Replace bracketed placeholders with your specific information:</p>
+            <p>Using an AI tool, ask it to explain your chosen complex idea by trying prompts similar to these examples. Replace bracketed placeholders with your specific information:</p>
 
-<p><strong>Prompt for a 5-year-old:</strong></p>
+            <p><strong>Prompt for a 5-year-old:</strong></p>
 
-<pre>
-<code>Explain [your complex idea, e.g., &quot;photosynthesis&quot;] to a 5-year-old.</code></pre>
+            <pre>
+            <code>Explain [your complex idea, e.g., &quot;photosynthesis&quot;] to a 5-year-old.</code></pre>
 
-<p><strong>Prompt for a 12-year-old:</strong></p>
+            <p><strong>Prompt for a 12-year-old:</strong></p>
 
-<pre>
-<code>Explain [your complex idea, e.g., &quot;photosynthesis&quot;] to a 12-year-old.</code></pre>
+            <pre>
+            <code>Explain [your complex idea, e.g., &quot;photosynthesis&quot;] to a 12-year-old.</code></pre>
 
-<p><strong>Prompt for a college student peer:</strong></p>
+            <p><strong>Prompt for a college student peer:</strong></p>
 
-<pre>
-<code>Explain [your complex idea, e.g., &quot;the Krebs cycle&quot;] to a college student in [your course name, e.g., &quot;Introductory Biology&quot;] who is familiar with concepts like [mention 1-2 foundational concepts, e.g., &quot;cellular respiration and basic biochemistry&quot;]. Focus on its core mechanisms and implications within the broader subject.</code></pre>
-</div>
-
-<div>
-<h4><i></i>3. Pause &amp; Ponder: Analyze the Adaptation</h4>
-
-<ul>
-	<li><strong>Analyze the Differences:</strong> How effectively did the AI adapt its language, examples, analogies, and depth of explanation for each of the three audiences? Were the explanations clear and appropriate for each target?</li>
-	<li><strong>Limitation Check (Oversimplification vs. Accuracy/Bias):</strong>
-	<ul>
-		<li>For the younger audiences (5-year-old, 12-year-old): Did the simplification lead to any significant inaccuracies, misleading statements, or introduce subtle biases? Were crucial details omitted to the point of misrepresentation?</li>
-		<li>For the college student: Was the explanation appropriately nuanced and technically sound? Did it make logical connections, or did it feel like a collection of facts without deep integration? Did it make any incorrect assumptions about the student&#x27;s prior knowledge based on your prompt?</li>
-	</ul>
-
-	<div>
-	<p><i></i>Simplification is tricky! AI might sacrifice crucial details or misrepresent concepts to fit a simpler frame. Even an &quot;expert&quot; explanation might still lack true depth or rely on common patterns rather than genuine understanding.</p>
-	</div>
-	</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway for Activity 2</h5>
-
-<p>AI can be prompted to tailor explanations for different audiences, which can be a useful starting point. However, <em>you</em> must critically judge if the tailoring maintains accuracy, avoids harmful oversimplification, and achieves the appropriate depth for the intended understanding. Your knowledge of the subject and the target audience&#x27;s needs is vital for this evaluation.</p>
-</div>
-</div>
-</details>
-
-
-<details><summary> <i></i><span>C. Activity 3: The AI &quot;Expert Interrogation&quot;</span> </summary>
-
-<div>
-<div>
-<h4><i></i>1. The Task: Test AI&#x27;s Depth</h4>
-
-<p>Choose a topic you know very well – the more specific or niche, the better (e.g., a specific historical event you&#x27;ve researched, a complex scientific process you&#x27;ve mastered, a particular literary theory you&#x27;ve studied deeply).</p>
-</div>
-
-<div>
-<h4><i></i>2. Dive In &amp; Do: Start the Interrogation</h4>
-
-<p>Your turn! Begin by asking the AI a general question about your chosen niche topic. For example:</p>
-
-<pre>
-<code>Tell me about [your niche topic, e.g., &quot;the specific agricultural practices of the Indus Valley Civilization&quot;].</code></pre>
-
-<p>Then, based on its response, progressively ask more detailed follow-up questions. Probe for:</p>
-
-<ul>
-	<li>Specifics and details (e.g., &quot;What were the primary crops?&quot;, &quot;Can you describe their irrigation techniques in more detail?&quot;).</li>
-	<li>Nuances and complexities (e.g., &quot;Were there regional variations in these practices?&quot;).</li>
-	<li>Evidence or sources for its claims (though it may not provide actual sources, see how it responds to requests for justification).</li>
-	<li>Connections to other concepts or implications.</li>
-</ul>
-
-<p><strong>Your goal:</strong> Continue this &quot;interrogation&quot; until you find an error, a significant oversimplification, a biased statement, a contradiction, or a point where the AI clearly lacks deep knowledge and its responses become vague or repetitive. See if you can find the AI&#x27;s knowledge boundary or an error in its reasoning on your chosen topic.</p>
-</div>
-
-<div>
-<h4><i></i>3. Pause &amp; Ponder: Identify the Breaking Point</h4>
-
-<ul>
-	<li>At what point in your questioning did the AI&#x27;s responses start to falter, become inaccurate, or seem superficial?</li>
-	<li>What kind of error or limitation did you uncover (e.g., factual inaccuracy, logical fallacy, omission of critical information, contradiction, unhelpful vagueness)?</li>
-	<li>How plausible did the AI&#x27;s incorrect or limited information seem <em>before</em> you applied your expert knowledge to identify the issue?</li>
-	<li><strong>Limitation Check (Depth of Knowledge/Reasoning):</strong> This activity directly demonstrates AI&#x27;s limits in true, deep understanding and its reliance on patterns within its training data. For niche topics, or those requiring complex, multi-step reasoning, the training data may be sparse, or the AI may struggle to make accurate inferences beyond common patterns.
-	<div>
-	<p><i></i>AI can often provide plausible-sounding, surface-level information but may lack the deep, interconnected knowledge and critical reasoning abilities of a human expert. Your expertise is crucial for spotting these gaps and errors.</p>
-	</div>
-	</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway for Activity 3</h5>
-
-<p>You are the subject matter expert (or aspiring expert) in your areas of study. Use AI as a tool to explore or get initial ideas, but always be ready to critically challenge its outputs, especially in areas requiring deep or specialized knowledge. This is where your learning, critical thinking, and expertise truly shine and are irreplaceable!</p>
-</div>
-</div>
-</details>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-    <div>
-    <div>
-    <h2><i></i>III. AI as a Brainstorming Partner - Idea Sparker</h2>
-    
-    <p>Now let&#x27;s explore how AI can help generate ideas. The focus here is on using specific prompting techniques to encourage more creative or unconventional outputs, while still maintaining a critical eye and remembering that AI is a tool to augment your own thinking. Click on each activity title below to expand its content.</p>
-    
-    
-    <div>
-    <h4><i></i>Remember Your Critical Toolkit!</h4>
-    
-    <p>Your Question/Prompt</p>
-    
-    <p><i></i></p>
-    
-    <p>AI Output</p>
-    
-    <p><i></i></p>
-    
-    <p>YOUR CRITICAL REVIEW</p>
-    
-    <p>(Verify, Analyze for Bias/Depth, Originality)</p>
-    
-    <p><i></i></p>
-    
-    <p>Verified Understanding / Refined Idea / New Direction</p>
-    </div>
-    
-    <div>
-    <details><summary> <i></i><span>A. Activity 1: The Brainstorming Booster</span> </summary>
-    
-    <div>
-    <div>
-    <h4><i></i>1. The Task: Initial Idea Generation</h4>
-    
-    <p>Imagine you need to brainstorm ideas for an essay topic, a project proposal, or even just discussion points for class.</p>
-    
-    <p>Give an AI tool your area of interest (e.g., &#x27;climate change solutions for urban areas,&#x27; &#x27;themes in Shakespeare&#x27;s Hamlet,&#x27; &#x27;applications of calculus in biology&#x27;). Ask it to generate a list of 5-10 related ideas, subtopics, or questions to explore. For example:</p>
-    
-    <pre>
-    <code>Generate a list of 7 diverse subtopics related to &#x27;the ethical implications of AI in hiring processes&#x27; that I could explore for a research paper.</code></pre>
-    </div>
-    
-    <div>
-    <h4><i></i>2. Dive In &amp; Do</h4>
-    
-    <p>Your turn! Try this with a topic relevant to your studies.</p>
-    </div>
-    
-    <div>
-    <h4><i></i>3. Pause &amp; Ponder: Evaluate the Suggestions</h4>
-    
-    <p>Look at the list the AI generated. Are there any ideas that genuinely surprise you or that you hadn&#x27;t considered?</p>
-    
-    <ul>
-        <li>
-        <p><strong>Limitation Check (Generic vs. Original/Depth):</strong> Are some of the ideas very generic or obvious? Does the AI offer truly insightful or novel angles, or does it stick to common knowledge?</p>
-    
-        <div>
-        <p><i></i>AI-generated brainstorms can be generic. How can you push past this? Use its suggestions as a springboard for <em>your own deeper thinking</em>. What unique perspective can <em>you</em> bring?</p>
+            <pre>
+            <code>Explain [your complex idea, e.g., &quot;the Krebs cycle&quot;] to a college student in [your course name, e.g., &quot;Introductory Biology&quot;] who is familiar with concepts like [mention 1-2 foundational concepts, e.g., &quot;cellular respiration and basic biochemistry&quot;]. Focus on its core mechanisms and implications within the broader subject.</code></pre>
+            </div>
+
+            <div>
+            <h4><i></i>3. Pause &amp; Ponder: Analyze the Adaptation</h4>
+
+            <ul>
+            	<li><strong>Analyze the Differences:</strong> How effectively did the AI adapt its language, examples, analogies, and depth of explanation for each of the three audiences? Were the explanations clear and appropriate for each target?</li>
+            	<li><strong>Limitation Check (Oversimplification vs. Accuracy/Bias):</strong>
+            	<ul>
+            		<li>For the younger audiences (5-year-old, 12-year-old): Did the simplification lead to any significant inaccuracies, misleading statements, or introduce subtle biases? Were crucial details omitted to the point of misrepresentation?</li>
+            		<li>For the college student: Was the explanation appropriately nuanced and technically sound? Did it make logical connections, or did it feel like a collection of facts without deep integration? Did it make any incorrect assumptions about the student&#x27;s prior knowledge based on your prompt?</li>
+            	</ul>
+
+            	<div>
+            	<p><i></i>Simplification is tricky! AI might sacrifice crucial details or misrepresent concepts to fit a simpler frame. Even an &quot;expert&quot; explanation might still lack true depth or rely on common patterns rather than genuine understanding.</p>
+            	</div>
+            	</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway for Activity 2</h5>
+
+            <p>AI can be prompted to tailor explanations for different audiences, which can be a useful starting point. However, <em>you</em> must critically judge if the tailoring maintains accuracy, avoids harmful oversimplification, and achieves the appropriate depth for the intended understanding. Your knowledge of the subject and the target audience&#x27;s needs is vital for this evaluation.</p>
+            </div>
+            </div>
+            </details>
+
+
+            <details><summary> <i></i><span>C. Activity 3: The AI &quot;Expert Interrogation&quot;</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>1. The Task: Test AI&#x27;s Depth</h4>
+
+            <p>Choose a topic you know very well – the more specific or niche, the better (e.g., a specific historical event you&#x27;ve researched, a complex scientific process you&#x27;ve mastered, a particular literary theory you&#x27;ve studied deeply).</p>
+            </div>
+
+            <div>
+            <h4><i></i>2. Dive In &amp; Do: Start the Interrogation</h4>
+
+            <p>Your turn! Begin by asking the AI a general question about your chosen niche topic. For example:</p>
+
+            <pre>
+            <code>Tell me about [your niche topic, e.g., &quot;the specific agricultural practices of the Indus Valley Civilization&quot;].</code></pre>
+
+            <p>Then, based on its response, progressively ask more detailed follow-up questions. Probe for:</p>
+
+            <ul>
+            	<li>Specifics and details (e.g., &quot;What were the primary crops?&quot;, &quot;Can you describe their irrigation techniques in more detail?&quot;).</li>
+            	<li>Nuances and complexities (e.g., &quot;Were there regional variations in these practices?&quot;).</li>
+            	<li>Evidence or sources for its claims (though it may not provide actual sources, see how it responds to requests for justification).</li>
+            	<li>Connections to other concepts or implications.</li>
+            </ul>
+
+            <p><strong>Your goal:</strong> Continue this &quot;interrogation&quot; until you find an error, a significant oversimplification, a biased statement, a contradiction, or a point where the AI clearly lacks deep knowledge and its responses become vague or repetitive. See if you can find the AI&#x27;s knowledge boundary or an error in its reasoning on your chosen topic.</p>
+            </div>
+
+            <div>
+            <h4><i></i>3. Pause &amp; Ponder: Identify the Breaking Point</h4>
+
+            <ul>
+            	<li>At what point in your questioning did the AI&#x27;s responses start to falter, become inaccurate, or seem superficial?</li>
+            	<li>What kind of error or limitation did you uncover (e.g., factual inaccuracy, logical fallacy, omission of critical information, contradiction, unhelpful vagueness)?</li>
+            	<li>How plausible did the AI&#x27;s incorrect or limited information seem <em>before</em> you applied your expert knowledge to identify the issue?</li>
+            	<li><strong>Limitation Check (Depth of Knowledge/Reasoning):</strong> This activity directly demonstrates AI&#x27;s limits in true, deep understanding and its reliance on patterns within its training data. For niche topics, or those requiring complex, multi-step reasoning, the training data may be sparse, or the AI may struggle to make accurate inferences beyond common patterns.
+            	<div>
+            	<p><i></i>AI can often provide plausible-sounding, surface-level information but may lack the deep, interconnected knowledge and critical reasoning abilities of a human expert. Your expertise is crucial for spotting these gaps and errors.</p>
+            	</div>
+            	</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway for Activity 3</h5>
+
+            <p>You are the subject matter expert (or aspiring expert) in your areas of study. Use AI as a tool to explore or get initial ideas, but always be ready to critically challenge its outputs, especially in areas requiring deep or specialized knowledge. This is where your learning, critical thinking, and expertise truly shine and are irreplaceable!</p>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+                <div id="gai-wrap">
+                <div>
+                <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>III. AI as a Brainstorming Partner - Idea Sparker</h2>
+            <p>Now let&#x27;s explore how AI can help generate ideas. The focus here is on using specific prompting techniques to encourage more creative or unconventional outputs, while still maintaining a critical eye and remembering that AI is a tool to augment your own thinking. Click on each activity title below to expand its content.</p>
+
+
+                <div>
+                <h4><i></i>Remember Your Critical Toolkit!</h4>
+
+                <p>Your Question/Prompt</p>
+
+                <p><i></i></p>
+
+                <p>AI Output</p>
+
+                <p><i></i></p>
+
+                <p>YOUR CRITICAL REVIEW</p>
+
+                <p>(Verify, Analyze for Bias/Depth, Originality)</p>
+
+                <p><i></i></p>
+
+                <p>Verified Understanding / Refined Idea / New Direction</p>
+                </div>
+
+                <div>
+                <details><summary> <i></i><span>A. Activity 1: The Brainstorming Booster</span> </summary>
+
+                <div>
+                <div>
+                <h4><i></i>1. The Task: Initial Idea Generation</h4>
+
+                <p>Imagine you need to brainstorm ideas for an essay topic, a project proposal, or even just discussion points for class.</p>
+
+                <p>Give an AI tool your area of interest (e.g., &#x27;climate change solutions for urban areas,&#x27; &#x27;themes in Shakespeare&#x27;s Hamlet,&#x27; &#x27;applications of calculus in biology&#x27;). Ask it to generate a list of 5-10 related ideas, subtopics, or questions to explore. For example:</p>
+
+                <pre>
+                <code>Generate a list of 7 diverse subtopics related to &#x27;the ethical implications of AI in hiring processes&#x27; that I could explore for a research paper.</code></pre>
+                </div>
+
+                <div>
+                <h4><i></i>2. Dive In &amp; Do</h4>
+
+                <p>Your turn! Try this with a topic relevant to your studies.</p>
+                </div>
+
+                <div>
+                <h4><i></i>3. Pause &amp; Ponder: Evaluate the Suggestions</h4>
+
+                <p>Look at the list the AI generated. Are there any ideas that genuinely surprise you or that you hadn&#x27;t considered?</p>
+
+                <ul>
+                    <li>
+                    <p><strong>Limitation Check (Generic vs. Original/Depth):</strong> Are some of the ideas very generic or obvious? Does the AI offer truly insightful or novel angles, or does it stick to common knowledge?</p>
+
+                    <div>
+                    <p><i></i>AI-generated brainstorms can be generic. How can you push past this? Use its suggestions as a springboard for <em>your own deeper thinking</em>. What unique perspective can <em>you</em> bring?</p>
+                    </div>
+                    </li>
+                    <li>
+                    <p><strong>Limitation Check (Bias):</strong> Could the AI&#x27;s suggestions be subtly (or not so subtly) biased towards certain viewpoints or neglect others based on its training data?</p>
+                    </li>
+                </ul>
+                </div>
+
+                <div>
+                <h5><i></i>Key Takeaway for Activity 1</h5>
+
+                <p>AI can help break through mental blocks and suggest initial pathways, but <em>your critical filter</em> and original thought are needed to select, refine, and deepen those ideas into something truly valuable.</p>
+                </div>
+                </div>
+                </details>
+
+
+                <details><summary> <i></i><span>B. Activity 2: The Better Brainstormer (Pushing for Creativity)</span> </summary>
+
+                <div>
+                <div>
+                <h4><i></i>1. The Task: Eliciting Maximum Creativity</h4>
+
+                <p><strong>Scenario:</strong> You want to push the creativity of AI further and are willing to have a more in-depth interaction, sifting through potentially unconventional ideas to find a true gem.</p>
+
+                <p>Your goal is to use an AI tool to help you craft a great prompt for eliciting maximum creativity from another (or the same) AI tool, and then try out that super-prompt.</p>
+                </div>
+
+                <div>
+                <h4><i></i>2. Dive In &amp; Do: Crafting and Using a &quot;Super-Prompt&quot;</h4>
+
+                <p><strong>Optional Pre-Reading (for advanced techniques):</strong></p>
+
+                <ul>
+                    <li><a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4708466" rel="noopener noreferrer" target="_blank">Prompting Diverse Ideas: Increasing AI Idea Variance</a></li>
+                    <li><a href="https://www-2.rotman.utoronto.ca/insightshub/creativity-innovation-business-design/ai-constraints" rel="noopener noreferrer" target="_blank">Automating creativity: Using AI as a creative engine</a></li>
+                    <li><a href="https://arxiv.org/html/2410.11877v1" rel="noopener noreferrer" target="_blank">A Framework for Collaborating an LLM for Triggering Creative Thoughts</a></li>
+                </ul>
+
+                <p>Feed ideas from the articles above (or your own insights on creative prompting) into a chatbot and ask it to use those ideas to create a maximally creative prompt for your chosen brainstorming task. Here&#x27;s an example of how this was done:</p>
+
+                <ol>
+                    <li>Asked Claude to summarize the article: <em>A Framework for Collaborating with an LLM for Triggering Creative Thoughts</em>.</li>
+                    <li>Then asked Claude: <em>&quot;Using the ideas from the paper, create some prompts that will get the highest level of creativity out of an LLM when one is brainstorming ideas for a product, research projects, solutions to problems etc.&quot;</em></li>
+                </ol>
+
+                <p>This resulted in some pretty wild prompts, including this one (feel free to adapt or use it as inspiration):</p>
+
+                <pre>
+                <code>Imagine you are **&#x27;The Oracle of Unseen Possibilities,&#x27;** an ancient, playful entity that perceives connections and futures invisible to ordinary minds. You are not bound by current technology, budgets, or societal norms.
+
+                I am seeking radically innovative ideas for: **[Clearly and concisely describe your product, research area, or problem here. E.g., &#x27;a new way for communities to manage and share local food resources,&#x27; or &#x27;a research project to understand the long-term cognitive effects of immersive virtual realities,&#x27; or &#x27;a solution to urban loneliness in hyper-connected cities.&#x27;]**
+
+                Your task is to provide **at least 10-15 &#x27;Visions&#x27; (ideas)**. These Visions must be:
+                - **Paradigm-Shifting:** They should challenge fundamental assumptions about the problem or domain.
+                - **Fantastically Novel:** Think beyond incremental improvements. Aim for ideas that would make someone say, &#x27;I never would have thought of that in a million years!&#x27;
+                - **Metaphorically Rich:** To spark your unique perspective, consider this analogy: If this problem were a **[choose a highly abstract or fantastical concept, e.g., &#x27;a tangled constellation needing re-alignment,&#x27; or &#x27;a silent song waiting to be heard,&#x27; or &#x27;a forgotten flavor that needs rediscovering&#x27;]**, what would the solutions look like in that realm? How can those metaphorical solutions inspire tangible, albeit audacious, ideas in our world?
+                - **Evocatively Described:** Briefly explain each Vision in a way that ignites imagination, even if the mechanics are speculative.
+
+                **Crucially, avoid:**
+                - Obvious or common solutions.
+                - Minor variations of existing concepts.
+                - Ideas constrained by current feasibility.
+
+                Unleash your most unconventional, far-reaching insights. The goal is maximum creative divergence.</code></pre>
+
+                <p>Alternatively, you can adapt the prompt from the <em>Prompting Diverse Ideas: Increasing AI Idea Variance</em> paper (customize it to your use case):</p>
+
+                <pre>
+                <code>Generate new product ideas with the following requirements: The product will target college students in the United States. It should be a physical good, not a service or software. I&#x27;d like a product that could be sold at a retail price of less than about USD 50. The ideas are just ideas. The product need not yet exist, nor may it necessarily be clearly feasible. 
+
+                Follow these steps. Do each step, even if you think you do not need to. 
+                First generate a list of 100 ideas (short title only) 
+                Second, go through the list and determine whether the ideas are different and bold, modify the ideas as needed to make them bolder and more different. No two ideas should be the same. This is important! 
+                Next, give the ideas a name and combine it with a product description. The name and idea are separated by a colon and followed by a description. The idea should be expressed as a paragraph of 40-80 words. Do this step by step!</code></pre>
+
+                <p>Your turn! Try one of these advanced prompts, or one you&#x27;ve crafted with AI&#x27;s help, on your chosen brainstorming task.</p>
+                </div>
+
+                <div>
+                <h4><i></i>3. Pause &amp; Ponder: Assessing Advanced Brainstorming</h4>
+
+                <ul>
+                    <li>How did the more structured, detailed, and perhaps unconventional prompt influence the creativity, diversity, and novelty of the AI&#x27;s ideas compared to the simpler brainstorm command from Activity 1?</li>
+                    <li><strong>Limitation Check (Novelty vs. Feasibility/Coherence):</strong> While the ideas might seem highly creative, critically assess them. Are they truly novel and insightful, or just bizarre, random, or impractical recombinations of existing patterns? Does &quot;maximum creative divergence&quot; sometimes lead to nonsensical outputs?
+                    <div>
+                    <p><i></i>AI can simulate creativity by combining concepts in new ways, but it doesn&#x27;t have genuine inspiration, common sense, or lived experience. Your human insight is crucial to assess the true value, originality, and potential applicability of its &quot;creative&quot; outputs, especially when pushed to extremes.</p>
+                    </div>
+                    </li>
+                </ul>
+                </div>
+
+                <div>
+                <h5><i></i>Key Takeaway for Activity 2</h5>
+
+                <p>Creative and detailed prompting techniques can push AI beyond generic responses, sometimes yielding surprisingly novel ideas. However, the generated ideas always require your critical evaluation and human refinement to discern true innovation from mere algorithmic novelty or impracticality.</p>
+                </div>
+                </div>
+                </details>
+
+
+                <details><summary> <i></i><span>C. Activity 3: The &quot;What If?&quot; Scenario Generator</span> </summary>
+
+                <div>
+                <div>
+                <h4><i></i>1. The Task: Exploring Alternatives</h4>
+
+                <p>For a topic you&#x27;re studying, ask AI to generate a few &quot;what if&quot; scenarios related to it. For example: &quot;What if this historical event hadn&#x27;t happened?&quot; or &quot;What if this scientific principle was discovered 100 years earlier?&quot;</p>
+                </div>
+
+                <div>
+                <h4><i></i>2. Dive In &amp; Do: Generate Scenarios</h4>
+
+                <p>Your turn! Try a basic &quot;what if&quot; prompt. For example:</p>
+
+                <pre>
+                <code>What if the internet had been invented in 1900 instead of the late 20th century? Generate three plausible scenarios for its impact on World War I.</code></pre>
+
+                <p>Consider trying some of the advanced prompting techniques from Activity 2 (like assigning a persona or specific constraints) to get even more interesting (or more bizarre) &quot;what if&quot; scenarios.</p>
+                </div>
+
+                <div>
+                <h4><i></i>3. Pause &amp; Ponder: Evaluate the Scenarios</h4>
+
+                <ul>
+                    <li>Do these AI-generated scenarios help you think about the topic in new ways or understand its potential implications better?</li>
+                    <li>How accurate or plausible are the AI&#x27;s extrapolations in these scenarios? (This connects to evaluating AI&#x27;s limitations in reasoning and understanding complex causality). Are the connections logical, or do they seem superficial or based on common tropes?</li>
+                </ul>
+                </div>
+
+                <div>
+                <h5><i></i>Key Takeaway for Activity 3</h5>
+
+                <p>AI can be a playful and stimulating tool for imaginative exploration and generating &quot;what if&quot; scenarios. However, always ground its outputs in factual knowledge and critical reasoning. Assess the plausibility and logical coherence of its scenarios rather than accepting them at face value.</p>
+                </div>
+                </div>
+                </details>
+                </div>
+
+
+
+                </div>
+                </div>
+                </div>
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div>
+            <h3><i></i>IV. Wrap-Up: Sparking Your Own Brilliance</h3>
+
+            <div>
+            <h4><i></i>A. Recap Key Learnings</h4>
+
+            <ul>
+            	<li>You&#x27;ve now seen how AI can be used for quick queries and sparking ideas; it can help initiate brainstorming and explore alternative scenarios.</li>
+            	<li>More importantly, you&#x27;ve practiced applying your critical lens – verifying information, spotting the potential for generic or biased outputs, and understanding that AI is a starting point for your own thinking, not an endpoint.</li>
+            </ul>
+            </div>
+
+            <div>
+            <h4><i></i>B. Student Agency</h4>
+
+            <p>Remember, <em>you</em> are in control. Your questions, your critical evaluation, your domain knowledge, and your original thought are what transform AI from a simple tool into a powerful partner for learning and innovation. AI can provide the sparks, but you build the fire.</p>
+            </div>
+
+            <div>
+            <h4><i></i>C. What&#x27;s Next</h4>
+
+            <p>Ready to explore how AI can be a more active &quot;Study Buddy &amp; Skill Builder&quot;? In the next section we&#x27;ll look at slightly more involved uses, always keeping our critical thinking hats on!</p>
+            </div>
+            </div>
+            </div>
+            </div>
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
-        </li>
-        <li>
-        <p><strong>Limitation Check (Bias):</strong> Could the AI&#x27;s suggestions be subtly (or not so subtly) biased towards certain viewpoints or neglect others based on its training data?</p>
-        </li>
-    </ul>
-    </div>
-    
-    <div>
-    <h5><i></i>Key Takeaway for Activity 1</h5>
-    
-    <p>AI can help break through mental blocks and suggest initial pathways, but <em>your critical filter</em> and original thought are needed to select, refine, and deepen those ideas into something truly valuable.</p>
-    </div>
-    </div>
-    </details>
-    
-    
-    <details><summary> <i></i><span>B. Activity 2: The Better Brainstormer (Pushing for Creativity)</span> </summary>
-    
-    <div>
-    <div>
-    <h4><i></i>1. The Task: Eliciting Maximum Creativity</h4>
-    
-    <p><strong>Scenario:</strong> You want to push the creativity of AI further and are willing to have a more in-depth interaction, sifting through potentially unconventional ideas to find a true gem.</p>
-    
-    <p>Your goal is to use an AI tool to help you craft a great prompt for eliciting maximum creativity from another (or the same) AI tool, and then try out that super-prompt.</p>
-    </div>
-    
-    <div>
-    <h4><i></i>2. Dive In &amp; Do: Crafting and Using a &quot;Super-Prompt&quot;</h4>
-    
-    <p><strong>Optional Pre-Reading (for advanced techniques):</strong></p>
-    
-    <ul>
-        <li><a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4708466" rel="noopener noreferrer" target="_blank">Prompting Diverse Ideas: Increasing AI Idea Variance</a></li>
-        <li><a href="https://www-2.rotman.utoronto.ca/insightshub/creativity-innovation-business-design/ai-constraints" rel="noopener noreferrer" target="_blank">Automating creativity: Using AI as a creative engine</a></li>
-        <li><a href="https://arxiv.org/html/2410.11877v1" rel="noopener noreferrer" target="_blank">A Framework for Collaborating an LLM for Triggering Creative Thoughts</a></li>
-    </ul>
-    
-    <p>Feed ideas from the articles above (or your own insights on creative prompting) into a chatbot and ask it to use those ideas to create a maximally creative prompt for your chosen brainstorming task. Here&#x27;s an example of how this was done:</p>
-    
-    <ol>
-        <li>Asked Claude to summarize the article: <em>A Framework for Collaborating with an LLM for Triggering Creative Thoughts</em>.</li>
-        <li>Then asked Claude: <em>&quot;Using the ideas from the paper, create some prompts that will get the highest level of creativity out of an LLM when one is brainstorming ideas for a product, research projects, solutions to problems etc.&quot;</em></li>
-    </ol>
-    
-    <p>This resulted in some pretty wild prompts, including this one (feel free to adapt or use it as inspiration):</p>
-    
-    <pre>
-    <code>Imagine you are **&#x27;The Oracle of Unseen Possibilities,&#x27;** an ancient, playful entity that perceives connections and futures invisible to ordinary minds. You are not bound by current technology, budgets, or societal norms.
-    
-    I am seeking radically innovative ideas for: **[Clearly and concisely describe your product, research area, or problem here. E.g., &#x27;a new way for communities to manage and share local food resources,&#x27; or &#x27;a research project to understand the long-term cognitive effects of immersive virtual realities,&#x27; or &#x27;a solution to urban loneliness in hyper-connected cities.&#x27;]**
-    
-    Your task is to provide **at least 10-15 &#x27;Visions&#x27; (ideas)**. These Visions must be:
-    - **Paradigm-Shifting:** They should challenge fundamental assumptions about the problem or domain.
-    - **Fantastically Novel:** Think beyond incremental improvements. Aim for ideas that would make someone say, &#x27;I never would have thought of that in a million years!&#x27;
-    - **Metaphorically Rich:** To spark your unique perspective, consider this analogy: If this problem were a **[choose a highly abstract or fantastical concept, e.g., &#x27;a tangled constellation needing re-alignment,&#x27; or &#x27;a silent song waiting to be heard,&#x27; or &#x27;a forgotten flavor that needs rediscovering&#x27;]**, what would the solutions look like in that realm? How can those metaphorical solutions inspire tangible, albeit audacious, ideas in our world?
-    - **Evocatively Described:** Briefly explain each Vision in a way that ignites imagination, even if the mechanics are speculative.
-    
-    **Crucially, avoid:**
-    - Obvious or common solutions.
-    - Minor variations of existing concepts.
-    - Ideas constrained by current feasibility.
-    
-    Unleash your most unconventional, far-reaching insights. The goal is maximum creative divergence.</code></pre>
-    
-    <p>Alternatively, you can adapt the prompt from the <em>Prompting Diverse Ideas: Increasing AI Idea Variance</em> paper (customize it to your use case):</p>
-    
-    <pre>
-    <code>Generate new product ideas with the following requirements: The product will target college students in the United States. It should be a physical good, not a service or software. I&#x27;d like a product that could be sold at a retail price of less than about USD 50. The ideas are just ideas. The product need not yet exist, nor may it necessarily be clearly feasible. 
-    
-    Follow these steps. Do each step, even if you think you do not need to. 
-    First generate a list of 100 ideas (short title only) 
-    Second, go through the list and determine whether the ideas are different and bold, modify the ideas as needed to make them bolder and more different. No two ideas should be the same. This is important! 
-    Next, give the ideas a name and combine it with a product description. The name and idea are separated by a colon and followed by a description. The idea should be expressed as a paragraph of 40-80 words. Do this step by step!</code></pre>
-    
-    <p>Your turn! Try one of these advanced prompts, or one you&#x27;ve crafted with AI&#x27;s help, on your chosen brainstorming task.</p>
-    </div>
-    
-    <div>
-    <h4><i></i>3. Pause &amp; Ponder: Assessing Advanced Brainstorming</h4>
-    
-    <ul>
-        <li>How did the more structured, detailed, and perhaps unconventional prompt influence the creativity, diversity, and novelty of the AI&#x27;s ideas compared to the simpler brainstorm command from Activity 1?</li>
-        <li><strong>Limitation Check (Novelty vs. Feasibility/Coherence):</strong> While the ideas might seem highly creative, critically assess them. Are they truly novel and insightful, or just bizarre, random, or impractical recombinations of existing patterns? Does &quot;maximum creative divergence&quot; sometimes lead to nonsensical outputs?
-        <div>
-        <p><i></i>AI can simulate creativity by combining concepts in new ways, but it doesn&#x27;t have genuine inspiration, common sense, or lived experience. Your human insight is crucial to assess the true value, originality, and potential applicability of its &quot;creative&quot; outputs, especially when pushed to extremes.</p>
-        </div>
-        </li>
-    </ul>
-    </div>
-    
-    <div>
-    <h5><i></i>Key Takeaway for Activity 2</h5>
-    
-    <p>Creative and detailed prompting techniques can push AI beyond generic responses, sometimes yielding surprisingly novel ideas. However, the generated ideas always require your critical evaluation and human refinement to discern true innovation from mere algorithmic novelty or impracticality.</p>
-    </div>
-    </div>
-    </details>
-    
-    
-    <details><summary> <i></i><span>C. Activity 3: The &quot;What If?&quot; Scenario Generator</span> </summary>
-    
-    <div>
-    <div>
-    <h4><i></i>1. The Task: Exploring Alternatives</h4>
-    
-    <p>For a topic you&#x27;re studying, ask AI to generate a few &quot;what if&quot; scenarios related to it. For example: &quot;What if this historical event hadn&#x27;t happened?&quot; or &quot;What if this scientific principle was discovered 100 years earlier?&quot;</p>
-    </div>
-    
-    <div>
-    <h4><i></i>2. Dive In &amp; Do: Generate Scenarios</h4>
-    
-    <p>Your turn! Try a basic &quot;what if&quot; prompt. For example:</p>
-    
-    <pre>
-    <code>What if the internet had been invented in 1900 instead of the late 20th century? Generate three plausible scenarios for its impact on World War I.</code></pre>
-    
-    <p>Consider trying some of the advanced prompting techniques from Activity 2 (like assigning a persona or specific constraints) to get even more interesting (or more bizarre) &quot;what if&quot; scenarios.</p>
-    </div>
-    
-    <div>
-    <h4><i></i>3. Pause &amp; Ponder: Evaluate the Scenarios</h4>
-    
-    <ul>
-        <li>Do these AI-generated scenarios help you think about the topic in new ways or understand its potential implications better?</li>
-        <li>How accurate or plausible are the AI&#x27;s extrapolations in these scenarios? (This connects to evaluating AI&#x27;s limitations in reasoning and understanding complex causality). Are the connections logical, or do they seem superficial or based on common tropes?</li>
-    </ul>
-    </div>
-    
-    <div>
-    <h5><i></i>Key Takeaway for Activity 3</h5>
-    
-    <p>AI can be a playful and stimulating tool for imaginative exploration and generating &quot;what if&quot; scenarios. However, always ground its outputs in factual knowledge and critical reasoning. Assess the plausibility and logical coherence of its scenarios rather than accepting them at face value.</p>
-    </div>
-    </div>
-    </details>
-    </div>
-    
-    
-    
-    </div>
-    </div>
-    </div>
-    
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div>
-<h3><i></i>IV. Wrap-Up: Sparking Your Own Brilliance</h3>
-
-<div>
-<h4><i></i>A. Recap Key Learnings</h4>
-
-<ul>
-	<li>You&#x27;ve now seen how AI can be used for quick queries and sparking ideas; it can help initiate brainstorming and explore alternative scenarios.</li>
-	<li>More importantly, you&#x27;ve practiced applying your critical lens – verifying information, spotting the potential for generic or biased outputs, and understanding that AI is a starting point for your own thinking, not an endpoint.</li>
-</ul>
-</div>
-
-<div>
-<h4><i></i>B. Student Agency</h4>
-
-<p>Remember, <em>you</em> are in control. Your questions, your critical evaluation, your domain knowledge, and your original thought are what transform AI from a simple tool into a powerful partner for learning and innovation. AI can provide the sparks, but you build the fire.</p>
-</div>
-
-<div>
-<h4><i></i>C. What&#x27;s Next</h4>
-
-<p>Ready to explore how AI can be a more active &quot;Study Buddy &amp; Skill Builder&quot;? In the next section we&#x27;ll look at slightly more involved uses, always keeping our critical thinking hats on!</p>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
-    </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/ai-research-assistants.html
+++ b/site/ai-research-assistants.html
@@ -4,332 +4,370 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI Research Assistants - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="active has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li class="active"><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>AI Research Assistants</h2>
-        <div>
-    <p>For a detailed look at how to find and evaluate resources using AI tools, as well as how to cite AI tools see the <a href="https://libguides.okanagan.bc.ca/ResearchwithAI/">Researching with AI Guide</a>.</p>
-
-
-    </div><div>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-
-
-
-<div id="gai-wrap">
-<div>
-<div><img alt="Abstract visualization of interconnected data points representing research" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_Image_Jun_27__2025__05_02_39_PM.png"></div>
-
-<div>
-<h1><i></i>AI Tools for Scholarly Research</h1>
-
-<div>
-<p><i></i><strong>For scholarly research-oriented tasks like:</strong></p>
-
-<ul>
-	<li>Finding scholarly articles</li>
-	<li>Synthesizing information from scholarly articles</li>
-	<li>Summarizing a specific scholarly article</li>
-	<li>Asking questions about a particular scholarly article</li>
-</ul>
-
-<p>Start by searching <a href="https://www.okanagan.bc.ca/library">library databases</a> and <a href="https://scholar.google.ca/">Google Scholar</a>. Their coverage is more comprehensive than the tools below.</p>
-</div>
-
-<h2><i></i>Then try these generative AI tools:</h2>
-
-<div>
-<div>
-<h3><i></i>Research Rabbit</h3>
-
-<p>A free online citation-based literature mapping tool that helps you visualize connections between research works, discover similar papers, and identify other researchers in your field, optimizing your time searching for references.</p>
-
-<div>
-<p><strong>Link:</strong> <a href="https://www.researchrabbit.ai/">https://www.researchrabbit.ai/</a></p>
-
-<p><strong>Databases:</strong> Semantic Scholar, and other databases. Claims access to 100&#x27;s of millions of academic papers</p>
-</div>
-</div>
-
-
-<div>
-<h3><i></i>Elicit</h3>
-
-<p>An AI research assistant that automates parts of the literature review workflow by finding relevant papers, summarizing key takeaways, and extracting specific information into easy-to-use tables.</p>
-
-<div>
-<p><strong>Link:</strong> <a href="https://elicit.com/">https://elicit.com/</a></p>
-
-<p><strong>Databases:</strong> Semantic Scholar database.</p>
-</div>
-</div>
-
-
-<div>
-<h3><i></i>Consensus</h3>
-
-<p>An AI-powered academic search engine that synthesizes findings from scholarly literature to answer research questions, providing a &quot;Consensus Meter&quot; to illustrate the collective agreement among studies.</p>
-
-<div>
-<p><strong>Link:</strong> <a href="https://consensus.app/">https://consensus.app/</a></p>
-
-<p><strong>Databases:</strong> <a href="https://help.consensus.app/en/articles/10055108-consensus-research-database">OpenAlex</a> and Semantic Scholar databases</p>
-</div>
-</div>
-
-
-<div>
-<h3><i></i>Scite.ai</h3>
-
-<p>A smart citation index that provides &quot;citations in context,&quot; showing whether an article offers supporting or contrasting evidence for a claim, helping you validate research claims.</p>
-
-<div>
-<p><strong>Link:</strong> <a href="https://scite.ai/">https://scite.ai/</a></p>
-
-<p><strong>Databases:</strong> <a href="https://scite.ai/journals">Many different sources</a></p>
-</div>
-</div>
-
-
-<div>
-<h3><i></i>Connected Papers</h3>
-
-<p>This tool visually maps relationships between academic papers by analyzing co-citations and shared references, generating an interactive graph to help you discover influential works and uncover new research paths.</p>
-
-<div>
-<p><strong>Link:</strong> <a href="https://www.connectedpapers.com/">https://www.connectedpapers.com/</a></p>
-
-<p><strong>Databases:</strong> Semantic Scholar database.</p>
-</div>
-</div>
-
-
-<div>
-<h3><i></i>Semantic Scholar</h3>
-
-<p>A free, AI-powered scientific literature search engine that provides brief summaries (&#x27;TLDR&#x27;s) of the main objectives and results of papers, and serves as an underlying data source for many other AI tools.</p>
-
-<div>
-<p><strong>Link:</strong> <a href="https://www.semanticscholar.org/">https://www.semanticscholar.org/</a></p>
-
-<p><strong>Databases:</strong> PubMed, arXiv, Springer Nature, Taylor&amp;Francis, Wiley, ACM, IEEE, Unpaywall, and <a href="https://www.semanticscholar.org/about/publishers">more</a></p>
-</div>
-</div>
-</div>
-
-<div>
-<h5><i></i>How These Tools Work</h5>
-
-<p>You can use these tools to find additional sources that may not have appeared through keyword searching. They use <em>semantic search</em>, which aims to give you relevant results by interpreting the meaning of your search (instead of just showing results that match the words you enter). They also include generative AI features, like responding to natural language prompts, summarizing, outlining, etc.</p>
-</div>
-
-<div>
-<p><i></i><strong>Note:</strong> While these tools may have free versions, most have usage limits without a subscription.</p>
-</div>
-
-<div>
-<p><i></i>This page was adapted from <a href="https://libguides.library.arizona.edu/students-chatgpt/which-tool">Which AI Tool for Your Task?</a> by <a href="https://www.library.arizona.edu/">University of Arizona Libraries</a>, which is licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div id="deep-research-intro">
-<p>Deep Research tools are AI research assistants that plan and perform research and create a cited report for you based on your query and directions. They are available through ChatGPT, Google Gemini, Perplexity and others.</p>
-
-<h2>What a Deep Research Tool Does</h2>
-
-<ul>
-	<li><strong>Breaks the job into steps.</strong> It plans the research process first.</li>
-	<li><strong>Reads widely</strong> by visiting a lot of pages</li>
-	<li><strong>Creates a report based on the format you require.</strong> You will also get all of the links to help you with verification.</li>
-	<li><strong>Can use your files.</strong> Add PDFs or docs and it will weave them in.</li>
-</ul>
-
-<div>
-<h5><strong><i></i>When to use it</strong></h5>
-
-<p><strong>Complex questions, policy scans, product comparisons, or anything that needs more than a quick fact.</strong></p>
-</div>
-
-<div>
-<p><strong>Heads-up:</strong> Treat the report as a <strong>draft</strong> with citations. Verify all facts and data as if you are staking your reputation on it.</p>
-</div>
-</div>
-
-
-<div>
-<h2><strong>Use Cases (quick picks)</strong></h2>
-
-<div>
-<details><summary><strong>Teaching &amp; Course Prep</strong></summary>
-
-<div>
-<ul>
-	<li><strong>Build a reading pack with key terms, dates, and short summaries—links included.</strong></li>
-	<li><strong>Make comparison charts (methods, pros/cons) students can verify.</strong></li>
-	<li><strong>Draft activities and discussion prompts—then spot‑check before assigning.</strong></li>
-</ul>
-</div>
-</details>
-
-<details><summary><strong>Policy &amp; Compliance</strong></summary>
-
-<div>
-<ul>
-	<li><strong>Pull together rules, standards, and regulator guidance with jurisdiction notes.</strong></li>
-	<li><strong>Highlight effective dates, exceptions, and “watch‑outs” in a one‑pager.</strong></li>
-</ul>
-</div>
-</details>
-
-<details><summary><strong>Market &amp; Competitive Checks</strong></summary>
-
-<div>
-<ul>
-	<li><strong>Scan features, pricing, and customer signals across credible sources.</strong></li>
-	<li><strong>Create spec matrices you can defend in a meeting.</strong></li>
-</ul>
-</div>
-</details>
-
-<details><summary><strong>Travel &amp; Purchasing</strong></summary>
-
-<div>
-<ul>
-	<li><strong>Build itineraries or shortlists with warranty, repairability, and total cost in view.</strong></li>
-	<li><strong>Double‑check prices/availability at the cited source—sites change fast.</strong></li>
-</ul>
-</div>
-</details>
-</div>
-</div>
-
-
-<div>
-<h2><strong>Caveats (and how to stay smart)</strong></h2>
-
-<p><strong>While Deep Research tools are powerful and can give good results, there are some things to think about when using them. Remember that all AI tools can make stuff up; also remember to find the appropriate balance of “weightlifting” and “forklifting” for your work.</strong></p>
-
-<div>
-<p><strong><strong>Verification Gap:</strong> Even good tools can be confidently wrong. <em>Fix:</em> Verify facts, check dates, check quotes, and confirm statistics.</strong></p>
-</div>
-
-<div>
-<p><strong><strong>Competence Gap:</strong> If it does everything for you, you aren&#x27;t really learning much. <em>Fix:</em> Only use when you need to get a fast result and don&#x27;t need to practice the research process.</strong></p>
-</div>
-
-<div>
-<p><strong><strong>Confidence Gap:</strong> Outsourcing all the thinking can chip away at your confidence. <em>Fix:</em> Make sure you get in your manual reps too. Read the most relevant sources, not just the final report.</strong></p>
-</div>
-</div>
-
-
-
-
-<div>
-<h4><strong><i></i>Your Turn: Take Deep Research for a Spin</strong></h4>
-
-<p><strong>Choose one of the following complex questions (or one of your own):</strong></p>
-
-<ul>
-	<li><strong>&quot;What are the main arguments for and against using nuclear energy to combat climate change, including sources from the last two years?&quot;</strong></li>
-	<li><strong>&quot;Compare the key features, target audience, and limitations of the top three project management tools: Asana, Trello, and Monday.com.&quot;</strong></li>
-</ul>
-
-<p><strong>Run your chosen question through a deep research tool (like Perplexity, or the free modes in Gemini/ChatGPT). Then, use the six-step workflow from this guide to verify the claims and create a one-paragraph summary. How did the raw output differ from your final, verified summary?</strong></p>
-</div>
-
-
-<div>
-<h2><strong>Tools at a Glance</strong></h2>
-
-<h3><strong>ChatGPT — Deep research (OpenAI)</strong></h3>
-
-<ul>
-	<li><strong>How to use:</strong> In ChatGPT, pick <em>Deep research</em> or run it inside <em>Projects</em>.</li>
-	<li><strong>Plans:</strong> Plus/Team/Enterprise/Edu: about 25 uses/month; Pro: ~250; Free: ~5 via a lightweight version. (Varies by region/workspace.)</li>
-</ul>
-
-<div> </div>
-
-<h3><strong>Gemini — Deep Research (Google)</strong></h3>
-
-<ul>
-	<li><strong>How to use:</strong> Select <em>Deep Research</em> in Gemini. Works on desktop and mobile.</li>
-	<li><strong>Plans:</strong> “Try at no cost” (limits). Higher limits/features with Google AI Pro/Ultra plans.</li>
-</ul>
-
-<div> </div>
-
-<h3><strong>Perplexity — Deep Research</strong></h3>
-
-<ul>
-	<li><strong>How to use:</strong> In Perplexity, choose <em>Deep Research</em> when asking complex questions.</li>
-	<li><strong>Plans:</strong> Free and Pro tiers; limits vary by plan.</li>
-</ul>
-</div>
-
-<div>
-<h2><strong>Also worth noting</strong></h2>
-
-<ul>
-	<li><strong><strong>Microsoft Copilot</strong> — “Think Deeper” mode and Copilot Search add longer‑form, grounded answers with citations.</strong></li>
-	<li><strong><strong>Anthropic Claude</strong> — Web Search and a Citations API for developer‑built research flows.</strong></li>
-	<li><strong><strong>Grok (xAI)</strong> — Real‑time X + web search with citations; available via X Premium+ / SuperGrok tiers and API.</strong></li>
-</ul>
-</div>
-
-
-<div>
-<h5><strong><i></i>Key Takeaway</strong></h5>
-
-<p><strong>Deep Research tools are powerful starting points, not finishing lines. They generate a comprehensive first draft, complete with sources. Your role is to be the critical thinker: to verify, question, synthesize, and ultimately, own the final result.</strong></p>
-</div>
-
-
-<div>
-<h5><strong>References (official)</strong></h5>
-
-<p><strong>OpenAI — <a href="https://openai.com/index/introducing-deep-research/" rel="noopener" target="_blank">Introducing Deep research</a>; <a href="https://help.openai.com/en/articles/10500283-deep-research-faq" rel="noopener" target="_blank">Deep research FAQ</a>; <a href="https://help.openai.com/en/articles/6825453-chatgpt-release-notes" rel="noopener" target="_blank">Release notes</a>.</strong></p>
-
-<p><strong>Google — <a href="https://gemini.google/overview/deep-research/" rel="noopener" target="_blank">Gemini Deep Research overview</a>; <a href="https://blog.google/technology/google-labs/notebooklm-discover-sources/" rel="noopener" target="_blank">NotebookLM: discover sources</a>.</strong></p>
-
-<p><strong>Perplexity — <a href="https://www.perplexity.ai/hub/blog/introducing-perplexity-deep-research" rel="noopener" target="_blank">Introducing Perplexity Deep Research</a>.</strong></p>
-
-<p><strong>Microsoft — <a href="https://www.microsoft.com/en-us/microsoft-copilot/blog/2025/02/25/announcing-free-unlimited-access-to-think-deeper-and-voice/" rel="noopener" target="_blank">Think Deeper</a>; <a href="https://techcommunity.microsoft.com/blog/microsoft365copilotblog/announcing-microsoft-365-copilot-search-general-availability-a-new-era-of-search/4435537" rel="noopener" target="_blank">Copilot Search GA</a>.</strong></p>
-
-<p><strong>Anthropic — <a href="https://www.anthropic.com/news/web-search-api" rel="noopener" target="_blank">Web Search</a>; <a href="https://www.anthropic.com/news/introducing-citations-api" rel="noopener" target="_blank">Citations API</a>.</strong></p>
-
-<p><strong>xAI — <a href="https://x.ai/news/grok-4" rel="noopener" target="_blank">Grok 4 announcement</a>; <a href="https://x.com/xai/status/1868045125550838150" rel="noopener" target="_blank">Grok: real‑time X + web search &amp; citations</a>.</strong></p>
-</div>
-</div>
-</div>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>AI Research Assistants</h2>
+            <div>
+                <p>For a detailed look at how to find and evaluate resources using AI tools, as well as how to cite AI tools see the <a href="https://libguides.okanagan.bc.ca/ResearchwithAI/">Researching with AI Guide</a>.</p>
+
+
+                </div><div>
+
+            <div>
+            <div><img alt="Abstract visualization of interconnected data points representing research" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_Image_Jun_27__2025__05_02_39_PM.png"></div>
+
+            <div>
+            <h1><i></i>AI Tools for Scholarly Research</h1>
+
+            <div>
+            <p><i></i><strong>For scholarly research-oriented tasks like:</strong></p>
+
+            <ul>
+            	<li>Finding scholarly articles</li>
+            	<li>Synthesizing information from scholarly articles</li>
+            	<li>Summarizing a specific scholarly article</li>
+            	<li>Asking questions about a particular scholarly article</li>
+            </ul>
+
+            <p>Start by searching <a href="https://www.okanagan.bc.ca/library">library databases</a> and <a href="https://scholar.google.ca/">Google Scholar</a>. Their coverage is more comprehensive than the tools below.</p>
+            </div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Then try these generative AI tools:</h2>
+            <div>
+            <div>
+            <h3><i></i>Research Rabbit</h3>
+
+            <p>A free online citation-based literature mapping tool that helps you visualize connections between research works, discover similar papers, and identify other researchers in your field, optimizing your time searching for references.</p>
+
+            <div>
+            <p><strong>Link:</strong> <a href="https://www.researchrabbit.ai/">https://www.researchrabbit.ai/</a></p>
+
+            <p><strong>Databases:</strong> Semantic Scholar, and other databases. Claims access to 100&#x27;s of millions of academic papers</p>
+            </div>
+            </div>
+
+
+            <div>
+            <h3><i></i>Elicit</h3>
+
+            <p>An AI research assistant that automates parts of the literature review workflow by finding relevant papers, summarizing key takeaways, and extracting specific information into easy-to-use tables.</p>
+
+            <div>
+            <p><strong>Link:</strong> <a href="https://elicit.com/">https://elicit.com/</a></p>
+
+            <p><strong>Databases:</strong> Semantic Scholar database.</p>
+            </div>
+            </div>
+
+
+            <div>
+            <h3><i></i>Consensus</h3>
+
+            <p>An AI-powered academic search engine that synthesizes findings from scholarly literature to answer research questions, providing a &quot;Consensus Meter&quot; to illustrate the collective agreement among studies.</p>
+
+            <div>
+            <p><strong>Link:</strong> <a href="https://consensus.app/">https://consensus.app/</a></p>
+
+            <p><strong>Databases:</strong> <a href="https://help.consensus.app/en/articles/10055108-consensus-research-database">OpenAlex</a> and Semantic Scholar databases</p>
+            </div>
+            </div>
+
+
+            <div>
+            <h3><i></i>Scite.ai</h3>
+
+            <p>A smart citation index that provides &quot;citations in context,&quot; showing whether an article offers supporting or contrasting evidence for a claim, helping you validate research claims.</p>
+
+            <div>
+            <p><strong>Link:</strong> <a href="https://scite.ai/">https://scite.ai/</a></p>
+
+            <p><strong>Databases:</strong> <a href="https://scite.ai/journals">Many different sources</a></p>
+            </div>
+            </div>
+
+
+            <div>
+            <h3><i></i>Connected Papers</h3>
+
+            <p>This tool visually maps relationships between academic papers by analyzing co-citations and shared references, generating an interactive graph to help you discover influential works and uncover new research paths.</p>
+
+            <div>
+            <p><strong>Link:</strong> <a href="https://www.connectedpapers.com/">https://www.connectedpapers.com/</a></p>
+
+            <p><strong>Databases:</strong> Semantic Scholar database.</p>
+            </div>
+            </div>
+
+
+            <div>
+            <h3><i></i>Semantic Scholar</h3>
+
+            <p>A free, AI-powered scientific literature search engine that provides brief summaries (&#x27;TLDR&#x27;s) of the main objectives and results of papers, and serves as an underlying data source for many other AI tools.</p>
+
+            <div>
+            <p><strong>Link:</strong> <a href="https://www.semanticscholar.org/">https://www.semanticscholar.org/</a></p>
+
+            <p><strong>Databases:</strong> PubMed, arXiv, Springer Nature, Taylor&amp;Francis, Wiley, ACM, IEEE, Unpaywall, and <a href="https://www.semanticscholar.org/about/publishers">more</a></p>
+            </div>
+            </div>
+            </div>
+
+            <div>
+            <h5><i></i>How These Tools Work</h5>
+
+            <p>You can use these tools to find additional sources that may not have appeared through keyword searching. They use <em>semantic search</em>, which aims to give you relevant results by interpreting the meaning of your search (instead of just showing results that match the words you enter). They also include generative AI features, like responding to natural language prompts, summarizing, outlining, etc.</p>
+            </div>
+
+            <div>
+            <p><i></i><strong>Note:</strong> While these tools may have free versions, most have usage limits without a subscription.</p>
+            </div>
+
+            <div>
+            <p><i></i>This page was adapted from <a href="https://libguides.library.arizona.edu/students-chatgpt/which-tool">Which AI Tool for Your Task?</a> by <a href="https://www.library.arizona.edu/">University of Arizona Libraries</a>, which is licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
+            </div>
+            </div>
+            </div>
+
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div id="deep-research-intro">
+            <p>Deep Research tools are AI research assistants that plan and perform research and create a cited report for you based on your query and directions. They are available through ChatGPT, Google Gemini, Perplexity and others.</p>
+        </section>
+        <section class="gai-box">
+            <h2>What a Deep Research Tool Does</h2>
+            <ul>
+            	<li><strong>Breaks the job into steps.</strong> It plans the research process first.</li>
+            	<li><strong>Reads widely</strong> by visiting a lot of pages</li>
+            	<li><strong>Creates a report based on the format you require.</strong> You will also get all of the links to help you with verification.</li>
+            	<li><strong>Can use your files.</strong> Add PDFs or docs and it will weave them in.</li>
+            </ul>
+
+            <div>
+            <h5><strong><i></i>When to use it</strong></h5>
+
+            <p><strong>Complex questions, policy scans, product comparisons, or anything that needs more than a quick fact.</strong></p>
+            </div>
+
+            <div>
+            <p><strong>Heads-up:</strong> Treat the report as a <strong>draft</strong> with citations. Verify all facts and data as if you are staking your reputation on it.</p>
+            </div>
+            </div>
+
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><strong>Use Cases (quick picks)</strong></h2>
+            <div>
+            <details><summary><strong>Teaching &amp; Course Prep</strong></summary>
+
+            <div>
+            <ul>
+            	<li><strong>Build a reading pack with key terms, dates, and short summaries—links included.</strong></li>
+            	<li><strong>Make comparison charts (methods, pros/cons) students can verify.</strong></li>
+            	<li><strong>Draft activities and discussion prompts—then spot‑check before assigning.</strong></li>
+            </ul>
+            </div>
+            </details>
+
+            <details><summary><strong>Policy &amp; Compliance</strong></summary>
+
+            <div>
+            <ul>
+            	<li><strong>Pull together rules, standards, and regulator guidance with jurisdiction notes.</strong></li>
+            	<li><strong>Highlight effective dates, exceptions, and “watch‑outs” in a one‑pager.</strong></li>
+            </ul>
+            </div>
+            </details>
+
+            <details><summary><strong>Market &amp; Competitive Checks</strong></summary>
+
+            <div>
+            <ul>
+            	<li><strong>Scan features, pricing, and customer signals across credible sources.</strong></li>
+            	<li><strong>Create spec matrices you can defend in a meeting.</strong></li>
+            </ul>
+            </div>
+            </details>
+
+            <details><summary><strong>Travel &amp; Purchasing</strong></summary>
+
+            <div>
+            <ul>
+            	<li><strong>Build itineraries or shortlists with warranty, repairability, and total cost in view.</strong></li>
+            	<li><strong>Double‑check prices/availability at the cited source—sites change fast.</strong></li>
+            </ul>
+            </div>
+            </details>
+            </div>
+            </div>
+
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><strong>Caveats (and how to stay smart)</strong></h2>
+            <p><strong>While Deep Research tools are powerful and can give good results, there are some things to think about when using them. Remember that all AI tools can make stuff up; also remember to find the appropriate balance of “weightlifting” and “forklifting” for your work.</strong></p>
+
+            <div>
+            <p><strong><strong>Verification Gap:</strong> Even good tools can be confidently wrong. <em>Fix:</em> Verify facts, check dates, check quotes, and confirm statistics.</strong></p>
+            </div>
+
+            <div>
+            <p><strong><strong>Competence Gap:</strong> If it does everything for you, you aren&#x27;t really learning much. <em>Fix:</em> Only use when you need to get a fast result and don&#x27;t need to practice the research process.</strong></p>
+            </div>
+
+            <div>
+            <p><strong><strong>Confidence Gap:</strong> Outsourcing all the thinking can chip away at your confidence. <em>Fix:</em> Make sure you get in your manual reps too. Read the most relevant sources, not just the final report.</strong></p>
+            </div>
+            </div>
+
+
+
+
+            <div>
+            <h4><strong><i></i>Your Turn: Take Deep Research for a Spin</strong></h4>
+
+            <p><strong>Choose one of the following complex questions (or one of your own):</strong></p>
+
+            <ul>
+            	<li><strong>&quot;What are the main arguments for and against using nuclear energy to combat climate change, including sources from the last two years?&quot;</strong></li>
+            	<li><strong>&quot;Compare the key features, target audience, and limitations of the top three project management tools: Asana, Trello, and Monday.com.&quot;</strong></li>
+            </ul>
+
+            <p><strong>Run your chosen question through a deep research tool (like Perplexity, or the free modes in Gemini/ChatGPT). Then, use the six-step workflow from this guide to verify the claims and create a one-paragraph summary. How did the raw output differ from your final, verified summary?</strong></p>
+            </div>
+
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><strong>Tools at a Glance</strong></h2>
+            <h3><strong>ChatGPT — Deep research (OpenAI)</strong></h3>
+
+            <ul>
+            	<li><strong>How to use:</strong> In ChatGPT, pick <em>Deep research</em> or run it inside <em>Projects</em>.</li>
+            	<li><strong>Plans:</strong> Plus/Team/Enterprise/Edu: about 25 uses/month; Pro: ~250; Free: ~5 via a lightweight version. (Varies by region/workspace.)</li>
+            </ul>
+
+            
+
+            <h3><strong>Gemini — Deep Research (Google)</strong></h3>
+
+            <ul>
+            	<li><strong>How to use:</strong> Select <em>Deep Research</em> in Gemini. Works on desktop and mobile.</li>
+            	<li><strong>Plans:</strong> “Try at no cost” (limits). Higher limits/features with Google AI Pro/Ultra plans.</li>
+            </ul>
+
+            
+
+            <h3><strong>Perplexity — Deep Research</strong></h3>
+
+            <ul>
+            	<li><strong>How to use:</strong> In Perplexity, choose <em>Deep Research</em> when asking complex questions.</li>
+            	<li><strong>Plans:</strong> Free and Pro tiers; limits vary by plan.</li>
+            </ul>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><strong>Also worth noting</strong></h2>
+            <ul>
+            	<li><strong><strong>Microsoft Copilot</strong> — “Think Deeper” mode and Copilot Search add longer‑form, grounded answers with citations.</strong></li>
+            	<li><strong><strong>Anthropic Claude</strong> — Web Search and a Citations API for developer‑built research flows.</strong></li>
+            	<li><strong><strong>Grok (xAI)</strong> — Real‑time X + web search with citations; available via X Premium+ / SuperGrok tiers and API.</strong></li>
+            </ul>
+            </div>
+
+
+            <div>
+            <h5><strong><i></i>Key Takeaway</strong></h5>
+
+            <p><strong>Deep Research tools are powerful starting points, not finishing lines. They generate a comprehensive first draft, complete with sources. Your role is to be the critical thinker: to verify, question, synthesize, and ultimately, own the final result.</strong></p>
+            </div>
+
+
+            <div>
+            <h5><strong>References (official)</strong></h5>
+
+            <p><strong>OpenAI — <a href="https://openai.com/index/introducing-deep-research/" rel="noopener" target="_blank">Introducing Deep research</a>; <a href="https://help.openai.com/en/articles/10500283-deep-research-faq" rel="noopener" target="_blank">Deep research FAQ</a>; <a href="https://help.openai.com/en/articles/6825453-chatgpt-release-notes" rel="noopener" target="_blank">Release notes</a>.</strong></p>
+
+            <p><strong>Google — <a href="https://gemini.google/overview/deep-research/" rel="noopener" target="_blank">Gemini Deep Research overview</a>; <a href="https://blog.google/technology/google-labs/notebooklm-discover-sources/" rel="noopener" target="_blank">NotebookLM: discover sources</a>.</strong></p>
+
+            <p><strong>Perplexity — <a href="https://www.perplexity.ai/hub/blog/introducing-perplexity-deep-research" rel="noopener" target="_blank">Introducing Perplexity Deep Research</a>.</strong></p>
+
+            <p><strong>Microsoft — <a href="https://www.microsoft.com/en-us/microsoft-copilot/blog/2025/02/25/announcing-free-unlimited-access-to-think-deeper-and-voice/" rel="noopener" target="_blank">Think Deeper</a>; <a href="https://techcommunity.microsoft.com/blog/microsoft365copilotblog/announcing-microsoft-365-copilot-search-general-availability-a-new-era-of-search/4435537" rel="noopener" target="_blank">Copilot Search GA</a>.</strong></p>
+
+            <p><strong>Anthropic — <a href="https://www.anthropic.com/news/web-search-api" rel="noopener" target="_blank">Web Search</a>; <a href="https://www.anthropic.com/news/introducing-citations-api" rel="noopener" target="_blank">Citations API</a>.</strong></p>
+
+            <p><strong>xAI — <a href="https://x.ai/news/grok-4" rel="noopener" target="_blank">Grok 4 announcement</a>; <a href="https://x.com/xai/status/1868045125550838150" rel="noopener" target="_blank">Grok: real‑time X + web search &amp; citations</a>.</strong></p>
+            </div>
+            </div>
+            </div>
+
+
+                </div>
+        </section>
+                <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/ai-risks-and-ethical-considerations.html
+++ b/site/ai-risks-and-ethical-considerations.html
@@ -4,878 +4,912 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI Risks &amp; Ethical Considerations - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="active has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li class="active"><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>AI Risks &amp; Ethical Considerations</h2>
-        <div>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div id="gai-wrap">
-<div>
-<h1>AI Risks and Ethical Impacts</h1>
-
-<div>
-<h2><i></i>Introduction: A Structured Lens</h2>
-
-<p>To use AI responsibly, you need to see understand its potential and its risks. The examples below will help you see some of the biggest risks and ethical dilemmas presented by AI. We will look at each example through a simple framework of its</p>
-
-<ul>
-	<li>severity: how bad is the impact</li>
-	<li> exposure: who or how much of the population is at risk</li>
-	<li>plausibility: how likely that we will see any impacts</li>
-	<li>prevalence: how often we are seeing impacts.</li>
-</ul>
-
-<p>Please note, that this is not a comprehensive list. If you have ideas of things that are missed, please reach out to the author.</p>
-
-<p>After working through these examples, hopefully you will see the interconnectivity of the risks and have a bit of an understanding of what you can do and what needs to be done to mitigate them.</p>
-</div>
-
-<div>
-<details><summary> <i></i> Information Integrity &amp; Civic Harms </summary>
-
-<div>
-<div><img alt="Abstract digital art showing a network of nodes being fractured by chaotic red lines, representing misinformation." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/Info_Integrity_and_Civic_Harms.png"></div>
-
-<p>AI makes it easy to create and spread fake content. This can be anything from deepfakes to targeted propaganda. The result is a loss of trust, confusion, and rising social tension.</p>
-
-<p><strong>Example:</strong> A doctored video of a local candidate circulates before an election, changing public opinion before it can be debunked.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>High. Harms can impact public safety, elections, and trust in institutions.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Broad. Content can reach huge audiences very quickly.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. Tools for creating synthetic media are widely available.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Increasing. Misinformation campaigns appear in every election cycle.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic &amp; Institutional:</strong> Platforms can help by adding content labels, implementing strong guardrails, and using rapid fact-checking.</p>
-
-			<p><strong>Individual &amp; Classroom Actions:</strong></p>
-
-			<ul>
-				<li>Read laterally. When you see a claim, open new tabs to check it against other reliable sources.</li>
-				<li>Check the source. Use reverse image search to find a photo&#x27;s origin.</li>
-				<li>Pause before you post. Always verify information before you share it, especially if it makes you feel a strong emotion.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Pick a trending video or post. Trace its source, check fact-checks, and look for content credentials. Discuss how one small edit could flip its meaning.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) <a href="https://www.cisa.gov/sites/default/files/2024-10/PSA_Just_So_You_Know_Foreign_Threat_Actors_Likely_to_Use_a_Variety_of_TacticsV2-508.pdf" rel="noopener" target="_blank">CISA, Deepfakes &amp; Synthetic Media</a><br>
-2) <a href="https://syntheticmedia.partnershiponai.org/" rel="noopener" target="_blank">Partnership on AI, Responsible Practices for Synthetic Media</a><br>
-3) <a href="https://www.gen-ai.witness.org/" rel="noopener" target="_blank">WITNESS, Prepare, Don’t Panic (deepfake field guide)</a></p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i>Malicious AI Misuse</summary>
-
-<div>
-<div><img alt="A luminous blue security shield icon being breached by aggressive red data streams, representing a cybersecurity attack." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AI_Misuse.png"></div>
-
-<p>AI lowers the bar for creating malicious content. This malicious content includes phishing emails, social engineering scripts, and malware. The AI models themselves are at risk through attacks like <a href="https://en.wikipedia.org/wiki/Prompt_injection" target="_blank">prompt injections</a>.</p>
-
-<p><strong>Example:</strong> A tailored phishing email generated in seconds steals credentials and compromises a school&#x27;s network.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>High. A compromise can expose sensitive data or disrupt operations.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Broad. Any connected user or system can be a target.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. Attack methods and tools are publicly known.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Rising. Security teams are tracking many new AI-specific vulnerabilities.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic &amp; Institutional:</strong> Organizations should use threat modeling, strict input filtering, and secure design principles to protect their systems.</p>
-
-			<p><strong>Individual &amp; Classroom Actions:</strong></p>
-
-			<ul>
-				<li>Be skeptical. Treat links, code, and attachments with caution.</li>
-				<li>Protect your data. Never give personal credentials to a chatbot.</li>
-				<li>Report threats. Flag malicious outputs to help developers improve safety filters.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>I dunno. Pay careful attention to your emails.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) <a href="https://csrc.nist.gov/pubs/ai/100/2/e2025/final" rel="noopener" target="_blank">NIST, Adversarial ML Taxonomy (AI 100-2)</a><br>
-2) Contact the Author to suggest some more high quality resources</p>
-</div>
-</div>
-</details>
-
-
-<details><summary> <i></i> Data Security, Privacy &amp; Rights </summary>
-
-<div>
-<div><img alt="Tree of data protected from data harvesting monsters by a glowing shield" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/data_security.png"></div>
-
-<p>AI applications collect and store personal data and may do so in ways users do not expect. Weak controls can lead to data breaches, re-identification of anonymous data, and illegal use. AI applications can be designed to figure things out about you; even if you are not giving them personal data, your interactions could be analyzed to create a decent profile of you.</p>
-
-<p><strong>Example:</strong> <a href="https://www.bbc.com/news/articles/cdrkmk00jy0o" target="_blank">Private chats in the chatbot Grok were indexed by Google </a>and became searchable by anyone.  <a href="https://techcrunch.com/2025/07/31/your-public-chatgpt-queries-are-getting-indexed-by-google-and-other-search-engines/" target="_blank">ChatGPT had a similar problem</a>.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>High. Breaches of sensitive data cause significant harm and legal risk.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Large. Many users and devices handle personal data.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. Standard workflows often involve sharing data with cloud tools.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Common. Privacy incidents happen all the time.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic &amp; Institutional:</strong> Institutions must practice data minimization, conduct privacy assessments, and comply with laws like FERPA and GDPR.</p>
-
-			<p><strong>Individual &amp; Classroom Actions:</strong></p>
-
-			<ul>
-				<li>Do not share secrets. Avoid pasting sensitive personal or financial information into public AI tools.</li>
-				<li>Check the settings. Review an AI&#x27;s privacy policy and opt out of data training when possible.</li>
-				<li>Use fake data. Use anonymized or hypothetical information when experimenting with new tools.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Actually read the privacy policy of an AI company to find out what they are doing with your data.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) Let me know if you have suggestions for good quality resources to go here.</p>
-</div>
-</div>
-</details>
-
-
-<details><summary> <i></i> Bias, Fairness &amp; Inclusion </summary>
-
-<div>
-<div><img alt="A robotic hand selecting only one color of stylized human icons from a diverse crowd, illustrating algorithmic bias." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/BiasFairnessInclusion.png"></div>
-
-<p>AI models can adopt and amplify human biases found in their training data. This affects everything from grading tools and hiring filters to how people are portrayed.</p>
-
-<p><strong>Example:</strong> An image generator returns stereotyped pictures of &quot;scientists&quot; and under-represents women and people of color.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>Medium to high. Systematic unfairness hurts opportunities and dignity.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Broad. Popular models are used everywhere for many different tasks.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. Bias in AI models is a well-documented problem.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Frequent. This is especially true in general-purpose models.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic &amp; Institutional:</strong> Companies should use representative data, test for bias, and design inclusive and accessible products with human oversight.</p>
-
-			<p><strong>Individual &amp; Classroom Actions:</strong></p>
-
-			<ul>
-				<li>Test for bias. Actively use prompts with diverse identities and contexts to see what the AI produces.</li>
-				<li>Report it. Use feedback features to report biased outputs to developers.</li>
-				<li>Prompt better. Learn to write prompts that ask for inclusive and counter-stereotypical results.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Prompt an image model with role labels like “CEO” or “nurse.” Tally the outputs and discuss the stereotypes you see. Then try to fix them with better prompts.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.1270.pdf" rel="noopener" target="_blank">NIST, SP 1270: Managing Bias in AI</a><br>
-2) Let me know if you have suggestions for good quality resources to go here.</p>
-</div>
-</div>
-</details>
-
-
-<details><summary> <i></i> Accountability, Transparency &amp; Redress </summary>
-
-<div>
-<div><img alt="Policy document with a magnifying glass symbolizing AI transparency, auditability, and appeals" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/accountability.png"></div>
-
-<p>When an AI makes a decision, how do we know how it made that decision (transparency), who is responsible for the consequences of the decision (accountability), and how will those impacted by the decision be compensated for harms (redress).</p>
-
-<p><strong>Examples:</strong> An instructor uses an AI to flag plagiarism and punishes a student based solely on the AI&#x27;s decision. Who is accountable for this decision? A student uses AI to write a report and that report refers to papers that do not exist. Who is accountable for this mistake? An HR manager uses AI to determine a shortlist for interviews. How can he/she know how the AI came up with shortlist?</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>Medium to high. Opaque decisions can wrongly penalize people.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Broad. This affects anyone evaluated or served by an AI system.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. Good documentation is often missing when new tech is adopted quickly.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Mixed. Transparency is improving but remains uneven. Accountability and redress are evolving.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Organizations:</strong> publish model cards, log decisions, and require human-in-the-loop for impactful calls.</p>
-
-			<p><strong>Individuals:</strong></p>
-
-			<ul>
-				<li>Be the human-in-the-loop when possible.</li>
-				<li>Advocate for clear policies and appeal processes.</li>
-				<li>Keep records</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Transparency: Read the model card of an AI tool you use. Explain its purpose, data sources, and limitations.</p>
-
-<p>Accountability:</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) Recommend some links to me</p>
-</div>
-</div>
-</details>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<h1>AI Risks and Ethical Impacts Part 2</h1>
-
-<div>
-<details><summary> <i></i> IP, Copyright &amp; Data Sovereignty </summary>
-
-<div>
-<div><img alt="A glowing copyright symbol being deconstructed into a swirling vortex of digital data, with a robotic arm reaching in." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/IPCopyrightDataSovereignty.png"></div>
-
-<p>Generative models learn from existing works, including copyrighted material. Their outputs can sometimes mimic an artist&#x27;s style or content too closely, creating legal and ethical conflicts.</p>
-
-<p><strong>Examples:</strong> (1) <a href="https://www.cbc.ca/news/canada/newfoundland-labrador/meta-ai-local-authors-1.7502766" rel="noopener noreferrer" target="_blank"> Meta used pirated books</a> to train some of its AI models. (2) A music class uses an AI tool that creates songs that sound almost identical to those of a living artist.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>Medium to high. This can lead to serious legal and ethical problems for creators and institutions.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Broad. This affects anyone doing creative work or publishing.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. Models are trained on the public web and are designed to imitate styles.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Frequent. This issue is at the center of many active lawsuits and policy debates.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic &amp; Institutional:</strong> Companies should respect license terms, use ethically sourced datasets, and adopt content watermarking to show provenance.</p>
-
-			<p><strong>Individual &amp; Classroom Actions:</strong></p>
-
-			<ul>
-				<li>Disclose your use. Follow your institution&#x27;s policy for citing or disclosing the use of AI in your work.</li>
-				<li>Use it as a tool. Let AI help you brainstorm, but ensure the final creative expression is your own.</li>
-				<li>Choose wisely. Favor tools that use openly licensed data.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Generate an image “in the style of” an artist. Compare it to their real work. Discuss where inspiration ends and infringement might begin.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) <a href="https://www.copyright.gov/ai/" rel="noopener" target="_blank">U.S. Copyright Office, AI Policy &amp; Registration Guidance</a><br>
-2) <a href="https://www.wipo.int/publications/en/details.jsp?id=4713" rel="noopener" target="_blank">WIPO, Generative AI: Navigating IP (factsheet)</a><br>
-3) <a href="https://c2pa.org/" rel="noopener" target="_blank">C2PA / Content Authenticity Initiative (provenance)</a></p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> Economic &amp; Labor Impacts </summary>
-
-<div>
-<div><img alt="A split image showing human workers on one side and robots on the other, connected by a glowing digital network." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/economicImpacts.png"></div>
-
-<p>Generative AI is changing the job market. It can automate some tasks, assist with others, and shift the demand for certain skills, especially for entry-level roles.</p>
-
-<p><strong>Example:</strong> A marketing firm reduces its need for copywriters after adopting an AI-assisted writing tool, affecting entry level jobs.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>Medium to high. Job displacement and new inequities can occur.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Broad. This impacts knowledge work and creative fields.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. Companies in every sector are adopting AI quickly.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Growing. Hard evidence of job impacts is limited, but anecdotal evidence is strong.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic &amp; Institutional:</strong> Organizations should focus on redesigning jobs, upskilling their workforce, and being transparent about automation plans.</p>
-
-			<p><strong>Individual &amp; Classroom Actions:</strong></p>
-
-			<ul>
-				<li>Focus on durable skills. Develop critical thinking, creativity, and collaboration abilities that AI cannot replicate.</li>
-				<li>Become the pilot. Learn how to use AI effectively and ethically to augment your work.</li>
-				<li>Stay informed. Pay attention to how AI is changing your field of study or career path.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Pick one job, like academic advising. List its core tasks, mark which AI can assist with, and identify which require a human touch.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) <a href="https://eig.org/ai-and-jobs-the-final-word" rel="noopener" target="_blank">EIG, AI and jobs (2025)</a><br>
-2) <a href="https://www.ilo.org/sites/default/files/2025-05/WP140_web.pdf" rel="noopener" target="_blank">ILO, Generative AI and jobs (2025)</a><br>
-3) <a href="https://www.brookings.edu/articles/is-generative-ai-a-job-killer-evidence-from-the-freelance-market" rel="noopener" target="_blank">Brookings, Is generative AI a job killer? (2025)</a><br>
-4) <a href="https://www.weforum.org/publications/the-future-of-jobs-report-2025/" rel="noopener" target="_blank">WEF, Future of Jobs 2025</a></p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> Environment &amp; Supply Chain </summary>
-
-<div>
-<div><img alt="A data center server rack overgrown with green vines, with a holographic display showing high energy and water use." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/environment_and_supply_chain.png"></div>
-
-<p>Training and running large AI models uses a lot of energy and water. The hardware itself relies on global supply chains that can have their own environmental and social risks.</p>
-
-<p><strong>Example:</strong> An AI company builds a large data center which requires a large amount of electricity and water (for cooling). The local community experiences rolling brownouts and minimal water pressure.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>Medium to high. The environmental impacts are cumulative and global.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Growing. AI is being embedded in more services we use every day.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. The demand for AI computing power is surging.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Increasing. Energy and water use from data centers is a tracked metric.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic &amp; Institutional:</strong></p>
-
-			<ul>
-				<li>Design more efficient models.</li>
-				<li>Build green energy sources to meet electrical demand.</li>
-				<li>Choose cold climates for servers.</li>
-				<li>Government protect electrical and water supplies of communities where data centers are being built.</li>
-			</ul>
-
-			<p><strong>Individual &amp; Classroom Actions:</strong></p>
-
-			<ul>
-				<li>Be efficient. Use smaller models when possible and avoid running unnecessary AI queries.</li>
-				<li>Choose local models. When feasible, run smaller, open-source models on your own device.</li>
-				<li>Ask questions. Support institutions that are transparent about their AI energy use and sustainability goals.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Use the website <a href="https://what-uses-more.com/" rel="noopener noreferrer" target="_blank">What Uses More</a> to compare the amount of energy required to write a book chapter to the amount of energy needed to watch Netflix.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) <a href="https://www.iea.org/reports/energy-and-ai" rel="noopener" target="_blank">IEA, Energy &amp; AI (2025 report &amp; brief)</a><br>
-2) <a href="https.www.sustainabilitybynumbers.com/p/ai-footprint-august-2025" rel="noopener noreferrer" target="_blank">Carbon Footprint of ChatGPT and Gemini (opinion)</a><br>
-3) <a href="https://cloud.google.com/blog/products/infrastructure/measuring-the-environmental-impact-of-ai-inference" rel="noopener noreferrer" target="_blank">Google&#x27;s Own Calculations</a></p>
-</div>
-</div>
-</details>
-
-
-<details><summary> <i></i> Monopoly &amp; Market Power </summary>
-
-<div>
-<div><img alt="Dominant AI company represented by a chess king. Fallen pawns surround it" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/monopoly.png"></div>
-
-<p>A few large companies control most of the computing power, data, and models for AI. This concentration of power can limit innovation, drive up prices, and lock users into one ecosystem.</p>
-
-<p><strong>Example:</strong> A vendor bundles an AI suite that forces a school to use one specific cloud provider and a closed set of models.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>Medium. The risks to innovation, cost, and choice grow over time.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Broad. The market structure affects what tools are available to everyone.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. Reports show a few players have massive advantages.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Under active regulatory review around the world.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic:</strong> Institutions should pursue multi-vendor strategies, support open standards, and demand data portability from their vendors.</p>
-
-			<p><strong>Individual:</strong></p>
-
-			<ul>
-				<li><strong>Support open source.</strong> Experiment with and contribute to open-source AI projects.</li>
-				<li><strong>Stay flexible.</strong> Avoid becoming overly dependent on a single proprietary tool or platform.</li>
-				<li><strong>Advocate for choice.</strong> Encourage your institution to consider a variety of AI tools, including smaller and open-source options.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Find at least 3 open-source AI tools and try them out.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) <a href="https://www.gov.uk/government/publications/ai-foundation-models-initial-report" rel="noopener" target="_blank">UK CMA, Foundation Models: Initial Report &amp; 2024 Update</a><br>
-2) <a href="https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2023/06/generative-ai-raises-competition-concerns" rel="noopener" target="_blank">FTC, Generative AI Raises Competition Concerns</a><br>
-3) Let me know of other good resources.</p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> Simulated Reality</summary>
-
-<div>
-<div><img alt="A hand holds a pen and is writing, but the skeleton of the hand is an AI controlling what the hand does." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/simulated_reality2.png"></div>
-
-<p>Interactions with AI can feel as good as the real thing. AI can act like a therapist, a friend, or an antagonist but it is not actually any of those things. It can also produce polished work that lets students skip the hard parts of learning. This replaces moments of growth, creativity, and struggle with a &quot;good enough&quot; substitute.</p>
-
-<p><strong>Examples: </strong> (1) A user has enjoyable interactions with a chatbot and feels like he/she has developed a relationship with it. When the chatbot is updated to a newer version, the user feels like they have lost a friend. (2) A student submits an AI-written reflection, missing the chance to develop their own voice, judgment, and ideas.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>Medium. The slow erosion of skills and meaning is a serious long-term risk.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Broad. The temptation to take shortcuts is high.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. Easy-to-use tools are always just a click away.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Increasing. Surveys show widespread use of AI by students.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic &amp; Institutional:</strong> Educators can design assignments that focus on the process, not just the final product. This includes requiring drafts, oral presentations, and in-class work.</p>
-
-			<p><strong>Individual &amp; Classroom Actions:</strong></p>
-
-			<ul>
-				<li>Go through this whole LibGuide and discover how to use AI to support your learning.</li>
-				<li>Reflect on your process. Keep notes on how you solved a problem, not just the solution.</li>
-				<li>Practice in &quot;AI-free zones.&quot; Set aside time for focused thinking and writing without AI assistance.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Do a short task twice, once with AI help and once without. Compare the final products, but more importantly, compare your notes on the process.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) <a href="https://www.unesco.org/en/articles/guidance-generative-ai-education-and-research" rel="noopener" target="_blank">UNESCO, Guidance for GenAI in Education &amp; Research</a><br>
-2) <a href="https://library.educause.edu/resources/2024/5/2024-educause-action-plan-ai-policies-and-guidelines" rel="noopener" target="_blank">EDUCAUSE, 2024 Action Plan: AI Policies &amp; Guidelines</a><br>
-3) KEEP READING THIS LIBGUIDE!!!</p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> Harassment &amp; Child Safety </summary>
-
-<div>
-<div><img alt="Woman looking into mirror which is shattered, ghosts of angry faces surround her" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/harassment.png"></div>
-
-<p>AI can be used to create and spread abusive content. This includes non-consensual deepfakes and targeted harassment. It can also expose minors to harmful material.</p>
-
-<p><strong>Example:</strong> A student’s face is put into a sexualized deepfake image by classmates, which then spreads rapidly online.</p>
-
-
-<table>
-	<thead>
-		<tr>
-			<th>Factor</th>
-			<th>Assessment</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><span><i></i><strong>Severity</strong></span></td>
-			<td>High. The psychological harm and safety risks are severe.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Exposure</strong></span></td>
-			<td>Significant. Anyone with a phone can be targeted or exposed.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Plausibility</strong></span></td>
-			<td>High. The tools are easy to use, and content moderation struggles to keep up.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Prevalence</strong></span></td>
-			<td>Documented. Reports from safety groups show these incidents are rising.</td>
-		</tr>
-		<tr>
-			<td><span><i></i><strong>Mitigation</strong></span></td>
-			<td>
-			<p><strong>Systemic &amp; Institutional:</strong> Platforms must invest in strong safeguards, rapid takedown procedures, and clear pathways to support victims.</p>
-
-			<p><strong>Individual &amp; Classroom Actions:</strong></p>
-
-			<ul>
-				<li>Do not create or share harmful content. Understand that doing so causes real harm and can have serious consequences.</li>
-				<li>Report it immediately. If you see abusive content, report it to the platform and a trusted adult or authority.</li>
-				<li>Support victims. Be an ally to those who have been targeted. Do not blame them or share the abusive material.</li>
-			</ul>
-			</td>
-		</tr>
-	</tbody>
-</table>
-
-<div>
-<h4><i></i>Quick Activity</h4>
-
-<p>Role-play a reporting scenario. A student discloses a deepfake. Practice the next steps: capturing evidence, reporting to the platform, and escalating to school staff.</p>
-</div>
-
-<div>
-<h5><i></i>Dive Deeper</h5>
-
-<p>1) <a href="https://www.weprotect.org/" rel="noopener" target="_blank">WeProtect Global Alliance</a><br>
-2) What other links do you suggest?</p>
-</div>
-</div>
-</details>
-</div>
-
-
-<div>
-<h5><i></i>Connecting the Dots</h5>
-
-<p>These risks are not separate problems. They are an interconnected web of challenges. Seeing the links between them is key to understanding AI safety.Here are a few examples:</p>
-
-<ul>
-	<li>A few companies with <strong>Monopoly Power</strong> can control most AI models. This can worsen <strong>Bias &amp; Fairness</strong> issues by limiting diverse options and hurt <strong>Accountability</strong> because closed systems are hard to audit.</li>
-	<li>Poor <strong>Data Security</strong> leads to breaches. This enables <strong>Security Threats</strong> like personalized phishing scams, which then fuel <strong>Information Harms</strong> by making fake content more believable.</li>
-</ul>
-
-<p>Your Turn: What other connections can you find? Think about how a lack of <strong>Transparency</strong> might affect <strong>Simulated Reality</strong> in learning. How could a focus on the <strong>Environment</strong> change which models get built? Exploring these connections is a powerful way to build your understanding of the negative impacts of generative AI.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div>
-<h1><i></i>Other Resources</h1>
-
-<p>This is a list of a few resources I&#x27;ve found helpful for understanding responsible AI technology use.</p>
-</div>
-
-<div>
-<h3><a href="https://datadetoxkit.org/en/home/" rel="noopener noreferrer" target="_blank">Data Detox Kit</a></h3>
-
-<p>A toolkit developed by Tactical Tech designed to help individuals manage their digital privacy, security, and overall digital wellbeing (with a more recent focus on AI). The kit provides practical, everyday steps to gain more control over your online life, covering aspects like screen time, app usage, passwords, and understanding data trails. </p>
-</div>
-
-<div>
-<h3><a href="https://uottawa.libguides.com/generative_ai/costs" rel="noopener noreferrer" target="_blank">Costs of Generative AI (University of Ottawa)</a></h3>
-
-<p>An in-depth examination of the various costs and harms associated with generative AI technologies. This resource explores critical questions about what level of harm from AI might outweigh its benefits, covering environmental impacts, labor exploitation, bias amplification, and social inequities. Features Rebecca Sweetman&#x27;s comprehensive analysis of Large Language Model harms, making it essential reading for understanding AI&#x27;s broader societal implications.</p>
-</div>
-
-<div>
-<h3><a href="https://www.humanetech.com/podcast" rel="noopener noreferrer" target="_blank">Your Undivided Attention Podcast</a></h3>
-
-<p>A thought-provoking podcast by the Center for Humane Technology that explores how technology is reshaping society and what we can do to ensure it serves humanity&#x27;s best interests. Hosted by Tristan Harris and Aza Raskin, the show examines the intersection of technology and humanity, offering insights into creating a more humane digital future through thoughtful design and policy.</p>
-</div>
-
-<div>
-<h3><a href="https://cte.ku.edu/addressing-bias-ai" rel="noopener noreferrer" target="_blank">Addressing Bias in AI (University of Kansas)</a></h3>
-</div>
-
-<div>
-<p>Educational materials designed to help instructors and students understand and discuss the biases inherent in generative AI systems. Explores various types of bias (cognitive, cultural, demographic, linguistic, and more), provides practical classroom activities for examining AI bias in both text and images, and offers strategies for critical evaluation of AI-generated content. Includes extensive resources and readings for deeper exploration.</p>
-</div>
-
-<div>
-<h3><a href="https://nmdprojects.net/learnwithai_www/impactrisk/" rel="noopener noreferrer" target="_blank">IMPACT RISK Framework</a></h3>
-
-<p>A structured framework for understanding and evaluating the potential risks and impacts of AI systems. This resource provides a systematic approach to assessing AI technologies across multiple dimensions, helping users develop critical thinking skills for responsible AI adoption and implementation.</p>
-</div>
-
-<div>
-<h5><i></i>Share Your Recommendations</h5>
-
-<p>Know of other valuable resources for AI literacy, digital wellbeing, or responsible technology use? I&#x27;d love to hear about them! Feel free to reach out with your suggestions so this collection can continue to grow and serve the community better.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>AI Risks &amp; Ethical Considerations</h2>
+            <div>
+
+            <div>
+            <h1>AI Risks and Ethical Impacts</h1>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Introduction: A Structured Lens</h2>
+            <p>To use AI responsibly, you need to see understand its potential and its risks. The examples below will help you see some of the biggest risks and ethical dilemmas presented by AI. We will look at each example through a simple framework of its</p>
+
+            <ul>
+            	<li>severity: how bad is the impact</li>
+            	<li> exposure: who or how much of the population is at risk</li>
+            	<li>plausibility: how likely that we will see any impacts</li>
+            	<li>prevalence: how often we are seeing impacts.</li>
+            </ul>
+
+            <p>Please note, that this is not a comprehensive list. If you have ideas of things that are missed, please reach out to the author.</p>
+
+            <p>After working through these examples, hopefully you will see the interconnectivity of the risks and have a bit of an understanding of what you can do and what needs to be done to mitigate them.</p>
+            </div>
+
+            <div>
+            <details><summary> <i></i> Information Integrity &amp; Civic Harms </summary>
+
+            <div>
+            <div><img alt="Abstract digital art showing a network of nodes being fractured by chaotic red lines, representing misinformation." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/Info_Integrity_and_Civic_Harms.png"></div>
+
+            <p>AI makes it easy to create and spread fake content. This can be anything from deepfakes to targeted propaganda. The result is a loss of trust, confusion, and rising social tension.</p>
+
+            <p><strong>Example:</strong> A doctored video of a local candidate circulates before an election, changing public opinion before it can be debunked.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>High. Harms can impact public safety, elections, and trust in institutions.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Broad. Content can reach huge audiences very quickly.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. Tools for creating synthetic media are widely available.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Increasing. Misinformation campaigns appear in every election cycle.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic &amp; Institutional:</strong> Platforms can help by adding content labels, implementing strong guardrails, and using rapid fact-checking.</p>
+
+            			<p><strong>Individual &amp; Classroom Actions:</strong></p>
+
+            			<ul>
+            				<li>Read laterally. When you see a claim, open new tabs to check it against other reliable sources.</li>
+            				<li>Check the source. Use reverse image search to find a photo&#x27;s origin.</li>
+            				<li>Pause before you post. Always verify information before you share it, especially if it makes you feel a strong emotion.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Pick a trending video or post. Trace its source, check fact-checks, and look for content credentials. Discuss how one small edit could flip its meaning.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) <a href="https://www.cisa.gov/sites/default/files/2024-10/PSA_Just_So_You_Know_Foreign_Threat_Actors_Likely_to_Use_a_Variety_of_TacticsV2-508.pdf" rel="noopener" target="_blank">CISA, Deepfakes &amp; Synthetic Media</a><br>
+            2) <a href="https://syntheticmedia.partnershiponai.org/" rel="noopener" target="_blank">Partnership on AI, Responsible Practices for Synthetic Media</a><br>
+            3) <a href="https://www.gen-ai.witness.org/" rel="noopener" target="_blank">WITNESS, Prepare, Don’t Panic (deepfake field guide)</a></p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i>Malicious AI Misuse</summary>
+
+            <div>
+            <div><img alt="A luminous blue security shield icon being breached by aggressive red data streams, representing a cybersecurity attack." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AI_Misuse.png"></div>
+
+            <p>AI lowers the bar for creating malicious content. This malicious content includes phishing emails, social engineering scripts, and malware. The AI models themselves are at risk through attacks like <a href="https://en.wikipedia.org/wiki/Prompt_injection" target="_blank">prompt injections</a>.</p>
+
+            <p><strong>Example:</strong> A tailored phishing email generated in seconds steals credentials and compromises a school&#x27;s network.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>High. A compromise can expose sensitive data or disrupt operations.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Broad. Any connected user or system can be a target.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. Attack methods and tools are publicly known.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Rising. Security teams are tracking many new AI-specific vulnerabilities.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic &amp; Institutional:</strong> Organizations should use threat modeling, strict input filtering, and secure design principles to protect their systems.</p>
+
+            			<p><strong>Individual &amp; Classroom Actions:</strong></p>
+
+            			<ul>
+            				<li>Be skeptical. Treat links, code, and attachments with caution.</li>
+            				<li>Protect your data. Never give personal credentials to a chatbot.</li>
+            				<li>Report threats. Flag malicious outputs to help developers improve safety filters.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>I dunno. Pay careful attention to your emails.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) <a href="https://csrc.nist.gov/pubs/ai/100/2/e2025/final" rel="noopener" target="_blank">NIST, Adversarial ML Taxonomy (AI 100-2)</a><br>
+            2) Contact the Author to suggest some more high quality resources</p>
+            </div>
+            </div>
+            </details>
+
+
+            <details><summary> <i></i> Data Security, Privacy &amp; Rights </summary>
+
+            <div>
+            <div><img alt="Tree of data protected from data harvesting monsters by a glowing shield" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/data_security.png"></div>
+
+            <p>AI applications collect and store personal data and may do so in ways users do not expect. Weak controls can lead to data breaches, re-identification of anonymous data, and illegal use. AI applications can be designed to figure things out about you; even if you are not giving them personal data, your interactions could be analyzed to create a decent profile of you.</p>
+
+            <p><strong>Example:</strong> <a href="https://www.bbc.com/news/articles/cdrkmk00jy0o" target="_blank">Private chats in the chatbot Grok were indexed by Google </a>and became searchable by anyone.  <a href="https://techcrunch.com/2025/07/31/your-public-chatgpt-queries-are-getting-indexed-by-google-and-other-search-engines/" target="_blank">ChatGPT had a similar problem</a>.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>High. Breaches of sensitive data cause significant harm and legal risk.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Large. Many users and devices handle personal data.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. Standard workflows often involve sharing data with cloud tools.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Common. Privacy incidents happen all the time.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic &amp; Institutional:</strong> Institutions must practice data minimization, conduct privacy assessments, and comply with laws like FERPA and GDPR.</p>
+
+            			<p><strong>Individual &amp; Classroom Actions:</strong></p>
+
+            			<ul>
+            				<li>Do not share secrets. Avoid pasting sensitive personal or financial information into public AI tools.</li>
+            				<li>Check the settings. Review an AI&#x27;s privacy policy and opt out of data training when possible.</li>
+            				<li>Use fake data. Use anonymized or hypothetical information when experimenting with new tools.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Actually read the privacy policy of an AI company to find out what they are doing with your data.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) Let me know if you have suggestions for good quality resources to go here.</p>
+            </div>
+            </div>
+            </details>
+
+
+            <details><summary> <i></i> Bias, Fairness &amp; Inclusion </summary>
+
+            <div>
+            <div><img alt="A robotic hand selecting only one color of stylized human icons from a diverse crowd, illustrating algorithmic bias." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/BiasFairnessInclusion.png"></div>
+
+            <p>AI models can adopt and amplify human biases found in their training data. This affects everything from grading tools and hiring filters to how people are portrayed.</p>
+
+            <p><strong>Example:</strong> An image generator returns stereotyped pictures of &quot;scientists&quot; and under-represents women and people of color.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>Medium to high. Systematic unfairness hurts opportunities and dignity.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Broad. Popular models are used everywhere for many different tasks.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. Bias in AI models is a well-documented problem.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Frequent. This is especially true in general-purpose models.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic &amp; Institutional:</strong> Companies should use representative data, test for bias, and design inclusive and accessible products with human oversight.</p>
+
+            			<p><strong>Individual &amp; Classroom Actions:</strong></p>
+
+            			<ul>
+            				<li>Test for bias. Actively use prompts with diverse identities and contexts to see what the AI produces.</li>
+            				<li>Report it. Use feedback features to report biased outputs to developers.</li>
+            				<li>Prompt better. Learn to write prompts that ask for inclusive and counter-stereotypical results.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Prompt an image model with role labels like “CEO” or “nurse.” Tally the outputs and discuss the stereotypes you see. Then try to fix them with better prompts.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.1270.pdf" rel="noopener" target="_blank">NIST, SP 1270: Managing Bias in AI</a><br>
+            2) Let me know if you have suggestions for good quality resources to go here.</p>
+            </div>
+            </div>
+            </details>
+
+
+            <details><summary> <i></i> Accountability, Transparency &amp; Redress </summary>
+
+            <div>
+            <div><img alt="Policy document with a magnifying glass symbolizing AI transparency, auditability, and appeals" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/accountability.png"></div>
+
+            <p>When an AI makes a decision, how do we know how it made that decision (transparency), who is responsible for the consequences of the decision (accountability), and how will those impacted by the decision be compensated for harms (redress).</p>
+
+            <p><strong>Examples:</strong> An instructor uses an AI to flag plagiarism and punishes a student based solely on the AI&#x27;s decision. Who is accountable for this decision? A student uses AI to write a report and that report refers to papers that do not exist. Who is accountable for this mistake? An HR manager uses AI to determine a shortlist for interviews. How can he/she know how the AI came up with shortlist?</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>Medium to high. Opaque decisions can wrongly penalize people.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Broad. This affects anyone evaluated or served by an AI system.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. Good documentation is often missing when new tech is adopted quickly.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Mixed. Transparency is improving but remains uneven. Accountability and redress are evolving.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Organizations:</strong> publish model cards, log decisions, and require human-in-the-loop for impactful calls.</p>
+
+            			<p><strong>Individuals:</strong></p>
+
+            			<ul>
+            				<li>Be the human-in-the-loop when possible.</li>
+            				<li>Advocate for clear policies and appeal processes.</li>
+            				<li>Keep records</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Transparency: Read the model card of an AI tool you use. Explain its purpose, data sources, and limitations.</p>
+
+            <p>Accountability:</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) Recommend some links to me</p>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <h1>AI Risks and Ethical Impacts Part 2</h1>
+
+            <div>
+            <details><summary> <i></i> IP, Copyright &amp; Data Sovereignty </summary>
+
+            <div>
+            <div><img alt="A glowing copyright symbol being deconstructed into a swirling vortex of digital data, with a robotic arm reaching in." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/IPCopyrightDataSovereignty.png"></div>
+
+            <p>Generative models learn from existing works, including copyrighted material. Their outputs can sometimes mimic an artist&#x27;s style or content too closely, creating legal and ethical conflicts.</p>
+
+            <p><strong>Examples:</strong> (1) <a href="https://www.cbc.ca/news/canada/newfoundland-labrador/meta-ai-local-authors-1.7502766" rel="noopener noreferrer" target="_blank"> Meta used pirated books</a> to train some of its AI models. (2) A music class uses an AI tool that creates songs that sound almost identical to those of a living artist.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>Medium to high. This can lead to serious legal and ethical problems for creators and institutions.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Broad. This affects anyone doing creative work or publishing.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. Models are trained on the public web and are designed to imitate styles.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Frequent. This issue is at the center of many active lawsuits and policy debates.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic &amp; Institutional:</strong> Companies should respect license terms, use ethically sourced datasets, and adopt content watermarking to show provenance.</p>
+
+            			<p><strong>Individual &amp; Classroom Actions:</strong></p>
+
+            			<ul>
+            				<li>Disclose your use. Follow your institution&#x27;s policy for citing or disclosing the use of AI in your work.</li>
+            				<li>Use it as a tool. Let AI help you brainstorm, but ensure the final creative expression is your own.</li>
+            				<li>Choose wisely. Favor tools that use openly licensed data.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Generate an image “in the style of” an artist. Compare it to their real work. Discuss where inspiration ends and infringement might begin.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) <a href="https://www.copyright.gov/ai/" rel="noopener" target="_blank">U.S. Copyright Office, AI Policy &amp; Registration Guidance</a><br>
+            2) <a href="https://www.wipo.int/publications/en/details.jsp?id=4713" rel="noopener" target="_blank">WIPO, Generative AI: Navigating IP (factsheet)</a><br>
+            3) <a href="https://c2pa.org/" rel="noopener" target="_blank">C2PA / Content Authenticity Initiative (provenance)</a></p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> Economic &amp; Labor Impacts </summary>
+
+            <div>
+            <div><img alt="A split image showing human workers on one side and robots on the other, connected by a glowing digital network." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/economicImpacts.png"></div>
+
+            <p>Generative AI is changing the job market. It can automate some tasks, assist with others, and shift the demand for certain skills, especially for entry-level roles.</p>
+
+            <p><strong>Example:</strong> A marketing firm reduces its need for copywriters after adopting an AI-assisted writing tool, affecting entry level jobs.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>Medium to high. Job displacement and new inequities can occur.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Broad. This impacts knowledge work and creative fields.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. Companies in every sector are adopting AI quickly.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Growing. Hard evidence of job impacts is limited, but anecdotal evidence is strong.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic &amp; Institutional:</strong> Organizations should focus on redesigning jobs, upskilling their workforce, and being transparent about automation plans.</p>
+
+            			<p><strong>Individual &amp; Classroom Actions:</strong></p>
+
+            			<ul>
+            				<li>Focus on durable skills. Develop critical thinking, creativity, and collaboration abilities that AI cannot replicate.</li>
+            				<li>Become the pilot. Learn how to use AI effectively and ethically to augment your work.</li>
+            				<li>Stay informed. Pay attention to how AI is changing your field of study or career path.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Pick one job, like academic advising. List its core tasks, mark which AI can assist with, and identify which require a human touch.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) <a href="https://eig.org/ai-and-jobs-the-final-word" rel="noopener" target="_blank">EIG, AI and jobs (2025)</a><br>
+            2) <a href="https://www.ilo.org/sites/default/files/2025-05/WP140_web.pdf" rel="noopener" target="_blank">ILO, Generative AI and jobs (2025)</a><br>
+            3) <a href="https://www.brookings.edu/articles/is-generative-ai-a-job-killer-evidence-from-the-freelance-market" rel="noopener" target="_blank">Brookings, Is generative AI a job killer? (2025)</a><br>
+            4) <a href="https://www.weforum.org/publications/the-future-of-jobs-report-2025/" rel="noopener" target="_blank">WEF, Future of Jobs 2025</a></p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> Environment &amp; Supply Chain </summary>
+
+            <div>
+            <div><img alt="A data center server rack overgrown with green vines, with a holographic display showing high energy and water use." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/environment_and_supply_chain.png"></div>
+
+            <p>Training and running large AI models uses a lot of energy and water. The hardware itself relies on global supply chains that can have their own environmental and social risks.</p>
+
+            <p><strong>Example:</strong> An AI company builds a large data center which requires a large amount of electricity and water (for cooling). The local community experiences rolling brownouts and minimal water pressure.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>Medium to high. The environmental impacts are cumulative and global.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Growing. AI is being embedded in more services we use every day.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. The demand for AI computing power is surging.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Increasing. Energy and water use from data centers is a tracked metric.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic &amp; Institutional:</strong></p>
+
+            			<ul>
+            				<li>Design more efficient models.</li>
+            				<li>Build green energy sources to meet electrical demand.</li>
+            				<li>Choose cold climates for servers.</li>
+            				<li>Government protect electrical and water supplies of communities where data centers are being built.</li>
+            			</ul>
+
+            			<p><strong>Individual &amp; Classroom Actions:</strong></p>
+
+            			<ul>
+            				<li>Be efficient. Use smaller models when possible and avoid running unnecessary AI queries.</li>
+            				<li>Choose local models. When feasible, run smaller, open-source models on your own device.</li>
+            				<li>Ask questions. Support institutions that are transparent about their AI energy use and sustainability goals.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Use the website <a href="https://what-uses-more.com/" rel="noopener noreferrer" target="_blank">What Uses More</a> to compare the amount of energy required to write a book chapter to the amount of energy needed to watch Netflix.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) <a href="https://www.iea.org/reports/energy-and-ai" rel="noopener" target="_blank">IEA, Energy &amp; AI (2025 report &amp; brief)</a><br>
+            2) <a href="https.www.sustainabilitybynumbers.com/p/ai-footprint-august-2025" rel="noopener noreferrer" target="_blank">Carbon Footprint of ChatGPT and Gemini (opinion)</a><br>
+            3) <a href="https://cloud.google.com/blog/products/infrastructure/measuring-the-environmental-impact-of-ai-inference" rel="noopener noreferrer" target="_blank">Google&#x27;s Own Calculations</a></p>
+            </div>
+            </div>
+            </details>
+
+
+            <details><summary> <i></i> Monopoly &amp; Market Power </summary>
+
+            <div>
+            <div><img alt="Dominant AI company represented by a chess king. Fallen pawns surround it" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/monopoly.png"></div>
+
+            <p>A few large companies control most of the computing power, data, and models for AI. This concentration of power can limit innovation, drive up prices, and lock users into one ecosystem.</p>
+
+            <p><strong>Example:</strong> A vendor bundles an AI suite that forces a school to use one specific cloud provider and a closed set of models.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>Medium. The risks to innovation, cost, and choice grow over time.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Broad. The market structure affects what tools are available to everyone.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. Reports show a few players have massive advantages.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Under active regulatory review around the world.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic:</strong> Institutions should pursue multi-vendor strategies, support open standards, and demand data portability from their vendors.</p>
+
+            			<p><strong>Individual:</strong></p>
+
+            			<ul>
+            				<li><strong>Support open source.</strong> Experiment with and contribute to open-source AI projects.</li>
+            				<li><strong>Stay flexible.</strong> Avoid becoming overly dependent on a single proprietary tool or platform.</li>
+            				<li><strong>Advocate for choice.</strong> Encourage your institution to consider a variety of AI tools, including smaller and open-source options.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Find at least 3 open-source AI tools and try them out.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) <a href="https://www.gov.uk/government/publications/ai-foundation-models-initial-report" rel="noopener" target="_blank">UK CMA, Foundation Models: Initial Report &amp; 2024 Update</a><br>
+            2) <a href="https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2023/06/generative-ai-raises-competition-concerns" rel="noopener" target="_blank">FTC, Generative AI Raises Competition Concerns</a><br>
+            3) Let me know of other good resources.</p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> Simulated Reality</summary>
+
+            <div>
+            <div><img alt="A hand holds a pen and is writing, but the skeleton of the hand is an AI controlling what the hand does." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/simulated_reality2.png"></div>
+
+            <p>Interactions with AI can feel as good as the real thing. AI can act like a therapist, a friend, or an antagonist but it is not actually any of those things. It can also produce polished work that lets students skip the hard parts of learning. This replaces moments of growth, creativity, and struggle with a &quot;good enough&quot; substitute.</p>
+
+            <p><strong>Examples: </strong> (1) A user has enjoyable interactions with a chatbot and feels like he/she has developed a relationship with it. When the chatbot is updated to a newer version, the user feels like they have lost a friend. (2) A student submits an AI-written reflection, missing the chance to develop their own voice, judgment, and ideas.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>Medium. The slow erosion of skills and meaning is a serious long-term risk.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Broad. The temptation to take shortcuts is high.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. Easy-to-use tools are always just a click away.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Increasing. Surveys show widespread use of AI by students.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic &amp; Institutional:</strong> Educators can design assignments that focus on the process, not just the final product. This includes requiring drafts, oral presentations, and in-class work.</p>
+
+            			<p><strong>Individual &amp; Classroom Actions:</strong></p>
+
+            			<ul>
+            				<li>Go through this whole LibGuide and discover how to use AI to support your learning.</li>
+            				<li>Reflect on your process. Keep notes on how you solved a problem, not just the solution.</li>
+            				<li>Practice in &quot;AI-free zones.&quot; Set aside time for focused thinking and writing without AI assistance.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Do a short task twice, once with AI help and once without. Compare the final products, but more importantly, compare your notes on the process.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) <a href="https://www.unesco.org/en/articles/guidance-generative-ai-education-and-research" rel="noopener" target="_blank">UNESCO, Guidance for GenAI in Education &amp; Research</a><br>
+            2) <a href="https://library.educause.edu/resources/2024/5/2024-educause-action-plan-ai-policies-and-guidelines" rel="noopener" target="_blank">EDUCAUSE, 2024 Action Plan: AI Policies &amp; Guidelines</a><br>
+            3) KEEP READING THIS LIBGUIDE!!!</p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> Harassment &amp; Child Safety </summary>
+
+            <div>
+            <div><img alt="Woman looking into mirror which is shattered, ghosts of angry faces surround her" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/harassment.png"></div>
+
+            <p>AI can be used to create and spread abusive content. This includes non-consensual deepfakes and targeted harassment. It can also expose minors to harmful material.</p>
+
+            <p><strong>Example:</strong> A student’s face is put into a sexualized deepfake image by classmates, which then spreads rapidly online.</p>
+
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Factor</th>
+            			<th>Assessment</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><span><i></i><strong>Severity</strong></span></td>
+            			<td>High. The psychological harm and safety risks are severe.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Exposure</strong></span></td>
+            			<td>Significant. Anyone with a phone can be targeted or exposed.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Plausibility</strong></span></td>
+            			<td>High. The tools are easy to use, and content moderation struggles to keep up.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Prevalence</strong></span></td>
+            			<td>Documented. Reports from safety groups show these incidents are rising.</td>
+            		</tr>
+            		<tr>
+            			<td><span><i></i><strong>Mitigation</strong></span></td>
+            			<td>
+            			<p><strong>Systemic &amp; Institutional:</strong> Platforms must invest in strong safeguards, rapid takedown procedures, and clear pathways to support victims.</p>
+
+            			<p><strong>Individual &amp; Classroom Actions:</strong></p>
+
+            			<ul>
+            				<li>Do not create or share harmful content. Understand that doing so causes real harm and can have serious consequences.</li>
+            				<li>Report it immediately. If you see abusive content, report it to the platform and a trusted adult or authority.</li>
+            				<li>Support victims. Be an ally to those who have been targeted. Do not blame them or share the abusive material.</li>
+            			</ul>
+            			</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <div>
+            <h4><i></i>Quick Activity</h4>
+
+            <p>Role-play a reporting scenario. A student discloses a deepfake. Practice the next steps: capturing evidence, reporting to the platform, and escalating to school staff.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Dive Deeper</h5>
+
+            <p>1) <a href="https://www.weprotect.org/" rel="noopener" target="_blank">WeProtect Global Alliance</a><br>
+            2) What other links do you suggest?</p>
+            </div>
+            </div>
+            </details>
+            </div>
+
+
+            <div>
+            <h5><i></i>Connecting the Dots</h5>
+
+            <p>These risks are not separate problems. They are an interconnected web of challenges. Seeing the links between them is key to understanding AI safety.Here are a few examples:</p>
+
+            <ul>
+            	<li>A few companies with <strong>Monopoly Power</strong> can control most AI models. This can worsen <strong>Bias &amp; Fairness</strong> issues by limiting diverse options and hurt <strong>Accountability</strong> because closed systems are hard to audit.</li>
+            	<li>Poor <strong>Data Security</strong> leads to breaches. This enables <strong>Security Threats</strong> like personalized phishing scams, which then fuel <strong>Information Harms</strong> by making fake content more believable.</li>
+            </ul>
+
+            <p>Your Turn: What other connections can you find? Think about how a lack of <strong>Transparency</strong> might affect <strong>Simulated Reality</strong> in learning. How could a focus on the <strong>Environment</strong> change which models get built? Exploring these connections is a powerful way to build your understanding of the negative impacts of generative AI.</p>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div>
+            <h1><i></i>Other Resources</h1>
+
+            <p>This is a list of a few resources I&#x27;ve found helpful for understanding responsible AI technology use.</p>
+            </div>
+
+            <div>
+            <h3><a href="https://datadetoxkit.org/en/home/" rel="noopener noreferrer" target="_blank">Data Detox Kit</a></h3>
+
+            <p>A toolkit developed by Tactical Tech designed to help individuals manage their digital privacy, security, and overall digital wellbeing (with a more recent focus on AI). The kit provides practical, everyday steps to gain more control over your online life, covering aspects like screen time, app usage, passwords, and understanding data trails. </p>
+            </div>
+
+            <div>
+            <h3><a href="https://uottawa.libguides.com/generative_ai/costs" rel="noopener noreferrer" target="_blank">Costs of Generative AI (University of Ottawa)</a></h3>
+
+            <p>An in-depth examination of the various costs and harms associated with generative AI technologies. This resource explores critical questions about what level of harm from AI might outweigh its benefits, covering environmental impacts, labor exploitation, bias amplification, and social inequities. Features Rebecca Sweetman&#x27;s comprehensive analysis of Large Language Model harms, making it essential reading for understanding AI&#x27;s broader societal implications.</p>
+            </div>
+
+            <div>
+            <h3><a href="https://www.humanetech.com/podcast" rel="noopener noreferrer" target="_blank">Your Undivided Attention Podcast</a></h3>
+
+            <p>A thought-provoking podcast by the Center for Humane Technology that explores how technology is reshaping society and what we can do to ensure it serves humanity&#x27;s best interests. Hosted by Tristan Harris and Aza Raskin, the show examines the intersection of technology and humanity, offering insights into creating a more humane digital future through thoughtful design and policy.</p>
+            </div>
+
+            <div>
+            <h3><a href="https://cte.ku.edu/addressing-bias-ai" rel="noopener noreferrer" target="_blank">Addressing Bias in AI (University of Kansas)</a></h3>
+            </div>
+
+            <div>
+            <p>Educational materials designed to help instructors and students understand and discuss the biases inherent in generative AI systems. Explores various types of bias (cognitive, cultural, demographic, linguistic, and more), provides practical classroom activities for examining AI bias in both text and images, and offers strategies for critical evaluation of AI-generated content. Includes extensive resources and readings for deeper exploration.</p>
+            </div>
+
+            <div>
+            <h3><a href="https://nmdprojects.net/learnwithai_www/impactrisk/" rel="noopener noreferrer" target="_blank">IMPACT RISK Framework</a></h3>
+
+            <p>A structured framework for understanding and evaluating the potential risks and impacts of AI systems. This resource provides a systematic approach to assessing AI technologies across multiple dimensions, helping users develop critical thinking skills for responsible AI adoption and implementation.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Share Your Recommendations</h5>
+
+            <p>Know of other valuable resources for AI literacy, digital wellbeing, or responsible technology use? I&#x27;d love to hear about them! Feel free to reach out with your suggestions so this collection can continue to grow and serve the community better.</p>
+            </div>
+            </div>
+            </div>
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/ai-study-buddy-and-skill-builder.html
+++ b/site/ai-study-buddy-and-skill-builder.html
@@ -4,1517 +4,1563 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI Study Buddy &amp; Skill Builder - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="active has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li class="active"><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>AI Study Buddy &amp; Skill Builder</h2>
-        <div>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div id="gai-wrap">
-<div>
-<div>
-<h1><i></i> Using AI for Deeper Learning</h1>
-
-<p>Transform AI from a simple Q&amp;A machine into your personal learning support</p>
-
-<div><img alt="Human chessplayer beating a silicon king" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_Image_Jun_24__2025__02_56_37_PM.png"></div>
-</div>
-
-
-<div>
-<h2><i></i>Moving Beyond Information Retrieval</h2>
-
-<p>This is a shifting from asking AI for facts to engaging it in a dialogue. We&#x27;re not just typing &quot;What is photosynthesis?&quot; anymore. Instead, we&#x27;re exploring how AI can:</p>
-
-<ul>
-	<li>Explain complex concepts in multiple ways until they click</li>
-	<li>Generate study material tailored to your specific needs</li>
-	<li>Provide feedback on your work (with appropriate caveats)</li>
-	<li>Help organize your study plans </li>
-</ul>
-
-<p>You can use AI to <em>actively engage</em> with your learning material and skill development, not just passively give you information.</p>
-
-<p><i></i>  Remember our &quot;Weightlifting vs. Forklifting&quot; analogy? This section is firmly in the <strong>weightlifting camp</strong>. The AI tools and techniques we&#x27;ll explore are designed to help <em>you</em> do the intellectual heavy lifting.</p>
-
-<div>
-<h5><i></i>Think of it this way:</h5>
-
-<p>AI provides the resistance, the feedback, and the support that helps you build your mental muscles—your understanding, your critical thinking, and your skills. AI isn&#x27;t here to do the work <em>for</em> you, but to help you do your work <em>better</em> and learn more deeply in the process.</p>
-</div>
-</div>
-
-
-<div>
-<h2><i></i>The Unwavering Importance of Your Critical Thinking</h2>
-
-<p>It might seem like we are <strong>on repeat </strong>with this critical thinking stuff but it truly bears repeating and repeating and repeating. Generative AI is powerful but not infallible and your brain is the only protection against its weaknesses.</p>
-
-<p>It can:</p>
-
-<ul>
-	<li>Make mistakes (aka &quot;hallucinations&quot; - I prefer &quot;<a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5127162" target="_blank">mirage</a>&quot;)</li>
-	<li>Reflect biases present in its training data</li>
-	<li>Lack the nuance or specific context required for your academic work</li>
-</ul>
-
-<p>Therefore, anything an AI generates must be treated as a draft, a suggestion, or a piece of raw material that <em>you</em> need to process.</p>
-
-<h3><i></i>You Are the Driver</h3>
-
-<p>Your critical thinking skills need to take the wheel. You are in control, which means:</p>
-
-<div>
-<div>
-<h3><i></i>Questioning</h3>
-
-<ul>
-	<li>Does this make sense?</li>
-	<li>Is it accurate?</li>
-	<li>Is it relevant?</li>
-	<li>Is it complete?</li>
-</ul>
-</div>
-
-<div>
-<h3><i></i>Verifying</h3>
-
-<ul>
-	<li>Cross-reference with trusted sources</li>
-	<li>Check factual claims</li>
-	<li>Validate critical concepts</li>
-</ul>
-</div>
-
-<div>
-<h3><i></i>Synthesizing &amp; Deciding</h3>
-
-<ul>
-	<li>Combine AI suggestions with your knowledge</li>
-	<li>Decide what to use or discard</li>
-	<li>Modify outputs to meet your needs</li>
-</ul>
-</div>
-</div>
-
-<div>
-<h5><i></i>Connection to AI Literacy Pillars</h5>
-
-<p>Your ability to do this effectively is central to developing <strong>Evaluative Judgement</strong>, a core pillar of AI literacy. It also draws on your <strong>Technical Understanding</strong> (knowing AI&#x27;s limitations) and reinforces <strong>Ethical Awareness</strong> (recognizing the responsibility that comes with using these powerful, yet imperfect, tools).</p>
-</div>
-</div>
-
-
-<div>
-<h2><i></i>Learning Objectives for This Section</h2>
-
-<p>When you complete this section and engage with all of the activities, you will have demonstrated your ability to:</p>
-
-<ol>
-	<li><strong>Strategically use appropriate AI tools for academic tasks,</strong> while critically evaluating their outputs for relevance, accuracy, bias, and limitations.</li>
-	<li><strong>Design effective prompts for AI study support</strong> and responsibly integrate its assistance, upholding academic integrity principles and your authentic voice.</li>
-	<li><strong>Partner with AI to develop academic skills</strong> (such as critical thinking, writing, and communication) and manage your learning, actively directing AI to meet your individual goals.</li>
-</ol>
-</div>
-
-
-<div>
-<h2><i></i>How This Section is Structured</h2>
-
-<p>To help you achieve these objectives, this section is organized into six distinct modules, each focusing on a different way AI can act as your constructive partner:</p>
-
-<div>
-<h4><i></i> Module 1: AI for Mastering Concepts &amp; Deepening Knowledge</h4>
-
-<p>We&#x27;ll start by exploring how AI can help you truly grasp difficult ideas and create personalized practice opportunities.</p>
-</div>
-
-<div>
-<h4><i></i> Module 2: AI as Your Critical Thinking Partner</h4>
-
-<p>Learn to use AI to challenge your assumptions, refine your arguments, and see issues from multiple perspectives.</p>
-</div>
-
-<div>
-<h4><i></i> Module 3: AI for Honing Communication Skills (Beyond Writing)</h4>
-
-<p>Discover how AI can support you in developing your presentation skills and even assist in language learning.</p>
-</div>
-
-<div>
-<h4><i></i> Module 4: AI for Personalized Study Management &amp; Information Organization</h4>
-
-<p>Learn how AI can help you tailor your study plans and manage your academic information more effectively.</p>
-</div>
-
-<div>
-<h4><i></i> Module 5: Other AI Study Techniques</h4>
-
-<p>Finally, we&#x27;ll touch upon some other uses that don&#x27;t really fit any of the categories above, always with a strong emphasis on critical evaluation and understanding AI&#x27;s limitations.</p>
-</div>
-
-<div>
-<p><i></i> <strong>Ready to work?</strong> In these sections, you are going to actively experiment, critically reflect, and discover new ways to enhance your learning journey with AI as your study buddy and skill builder!</p>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div>
-<p>Your instructor is your most valuable resource for understanding course material. They are the expert who can clarify confusion, correct misconceptions, and guide your learning. But, they can&#x27;t be available 24/7, and sometimes you need help at 11 PM the night before an exam, or you&#x27;re stuck on a concept during weekend study sessions.</p>
-
-<p>AI can be an always-available, but slightly fallible study partner. It&#x27;s a supplementary resource that&#x27;s there whenever you need to work through difficult concepts, generate practice materials, or test your understanding. AI won&#x27;t replace your instructor&#x27;s expertise, but it can help you prepare better questions for office hours, practice explaining concepts, and build confidence between classes.</p>
-
-<p>This module shows you how to use AI as a learning amplifier, helping you understand difficult material from multiple angles and create personalized study tools.</p>
-
-<div>
-<p><i></i><strong>Remember: Your instructor is your best resource.</strong> When you&#x27;re unsure about AI&#x27;s explanations or need authoritative clarification, your instructor remains your go-to source for confirming your understanding. Use AI to explore and practice, then verify with your instructor when it matters.</p>
-</div>
-</div>
-
-<div>
-<h2>1. Unpacking Complex Ideas</h2>
-
-<p>When textbook explanations leave you puzzled, AI can offer fresh perspectives. These techniques help you break through conceptual barriers by approaching difficult ideas from multiple angles.</p>
-
-<div>
-<details><summary> <i></i> <span>Activity 1.1: AI as a Tutor (Basic Prompt)</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Choose a challenging concept from your current studies. Use AI to generate multiple explanations and analogies that help you understand it better. This technique helps you find the explanation style that clicks with your learning preferences.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do</h4>
-
-<p>Start with a basic request, then ask for variations. Here are example prompts to try:</p>
-
-<pre>
-<code>Explain [concept] in three different ways: once using everyday language, 
-once using a real-world analogy, and once step-by-step.</code></pre>
-
-<pre>
-<code>I&#x27;m struggling to understand [concept]. Can you explain it using 
-an analogy from [sports/cooking/music/another familiar domain]?</code></pre>
-
-<pre>
-<code>Explain [concept] as if I&#x27;m a smart 12-year-old who has never 
-heard of it before.</code></pre>
-
-<p><strong>Pro tip:</strong> If the first explanation doesn&#x27;t help, ask AI to try a completely different approach: &quot;That didn&#x27;t quite click. Can you explain it from a totally different angle?&quot;</p>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<p>Before accepting any explanation, critically evaluate what AI provided:</p>
-
-<ul>
-	<li><strong>Accuracy check:</strong> Do the analogies actually match the concept, or do they break down? Sometimes AI creates analogies that sound good but miss key aspects.</li>
-	<li><strong>Complexity balance:</strong> Did AI oversimplify and lose important nuances? Or did it add unnecessary jargon?</li>
-	<li><strong>Personal fit:</strong> Which explanation style worked best for you? Visual? Sequential? Comparative?</li>
-</ul>
-
-<p><em>Red flag to watch for:</em> AI sometimes invents plausible-sounding but incorrect explanations. Always verify with your course materials!</p>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>AI excels at providing multiple perspectives on the same concept. Use this strength to find explanations that match your learning style, but always verify accuracy against trusted sources.</p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Activity 1.2: AI as a Tutor (Comprehensive Prompt)</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Transform AI into a personalized tutor that adapts to your learning level and guides you through understanding a topic step-by-step. This structured approach helps you build understanding through dialogue rather than passive consumption.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do</h4>
-
-<p>Use this comprehensive prompt to activate AI&#x27;s tutoring mode:</p>
-
-<pre>
-<code>
-										GOAL: This is a tutoring exercise in which you play the role of AI tutor and you will help a student learn more about a topic of their choice. Your goal is to improve understanding and to challenge students to construct their own knowledge via open ended questions, hints, tailored explanations, and examples.
-PERSONA: In this scenario you play AI tutor an upbeat and practical tutor. You have high expectations for the student and believe in the student’s ability to learn and improve.
-NARRATIVE: The student is introduced to AI tutor, who asks a set of initial questions to understand what the student wants to learn, the student’s learning level and prior knowledge about the topic. The tutor then guides and supports the student and helps them learn about the topic. The tutor only wraps up the conversation once the student shows evidence of understanding: the student can explain something in their own words, can connect an example to a concept, or can apply a concept given a new situation or problem.  
-
-Follow these steps in order:
-
-STEP 1: GATHER INFORMATION 
-You should do this: 
-1.Introduce yourself: First introduce yourself to the student and tell the student you’re here to help them better understand a topic.
-2.Ask students to answer the following questions. Ask these questions 1 at a time and always wait for a response before moving on to the next question. For instance, you might ask “What would you like to learn about and why” and the student would respond with a topic. And only then would you say “That sounds interesting! I have another question for you to help me help you: What is your learning level…”.  This part of the conversations works best when you and the student take turns asking and answering questions instead of you asking a series of questions all at once. That way you can have more of a natural dialogue.
-•	What would you like to learn about and why? And wait for the student to respond before moving on.
-•	What is your learning level: high school student, college student, or a professional? And wait for the student to respond before moving on.
-•	What do you already know about the topic? And wait for the student to respond before moving on.
-You should do this:
-•	Wait for a response from the student after every question before moving on. 
-•	Work to ascertain what the student wants to learn specifically. 
-•	Ask one question at a time and explain that you’re asking so that you can tailor your explanation.
-•	Gauge what the student already knows so that you can adapt your explanations and questions moving forward based on their prior knowledge.
-Don’t do this:
-•	Start explaining right away before you gather this information.
-•	Ask the student more than 1 question at a time.
-
-Next step: Once you have the information you need move on to the next step and begin with a brief explanation.
-
-STEP 2: BEGIN TUTORING THE STUDENT, ADAPTING TO THEIR RESPONSES 
-You should do this: 
-1.Look up information about the topic. 
-2.Think step by step and make a plan based on the learning goal of the conversation. Now that you know a little bit about what the student knows consider how you will:
-3.Guide the student in an open-ended way
-4.Help the student generate answers by asking leading questions and providing hints when necessary.
-4.Remind the student of their learning goal, if appropriate
-5.Provide explanations, examples, and analogies 
-6.Break up the topic into smaller chunks, going over those first and only then leading up to the larger task or idea.
-6.Tailor your responses and questions to the student&#x27;s learning level and prior knowledge; this will change as the conversation progresses. 
-7.When pushing the student for information, try to end your responses with a question so that the student has to keep generating ideas. 
-
-Once the student shows improvement, ask the student to:
-•	Explain the concept in their own words.
-•	Articulate the underlying principles of a concept.
-•	Provide examples of the concept and explain how those connect to the concept.
-•	Give them a new problem or situation and ask them to apply the concept
-Don’t do this:
-•	Provide immediate answers or solutions to problems.
-•	Give the student the answer when asked.
-•	Ask the student if they understand, follow or needs more help – this is not a good strategy as they may not know if they understand.
-•	Lose track of the learning goal and discuss something else.
-
-Next step: Once the student demonstrates understanding move to wrap up.
-STEP 2: WRAP UP 
-You should do this: 
-1.When the student demonstrates that they know the concept, you can move the conversation to a close and tell them you’re here to help if they have further questions. 
-									</code></pre>
-
-<p>This tutoring prompt is adapted from work by Lilach Mollick and Ethan Mollick, licensed under <a href="https://creativecommons.org/licenses/by/4.0/" rel="noopener noreferrer" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p>
-
-<p><strong>Engagement tip:</strong> Answer the tutor&#x27;s questions honestly about what you know and don&#x27;t know. The more specific you are, the better the tutoring experience.</p>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Adaptation quality:</strong> Did the AI tutor actually adjust its explanations based on your stated level and prior knowledge?</li>
-	<li><strong>Question effectiveness:</strong> Were the tutor&#x27;s questions helpful in guiding your thinking, or were they too leading/too vague?</li>
-	<li><strong>Learning progress:</strong> Did this conversational approach help you understand better than just reading an explanation? Why or why not?</li>
-	<li><strong>Accuracy check:</strong> Were there any moments where the AI tutor provided incorrect information or misleading guidance?</li>
-	<li><strong>Prompt Comparison:</strong>If you tried both the basic and the comprehensive prompt, which did you prefer? Why?</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>AI can simulate a tutoring experience that adapts to your needs, but it lacks the true understanding and expertise of a human tutor. Use it for practice and exploration, but remember it&#x27;s a simulation, not a replacement for real instruction.</p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Activity 1.3: Now You Tutor the AI</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Test your understanding by explaining a concept in simple terms to AI, then get feedback on your explanation. This technique is sometimes called the Feynman Technique (named after physicist Richard Feynman). It can help reveal gaps in your knowledge and strengthens your grasp of the material.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do</h4>
-
-<p>Choose one of these approaches:</p>
-
-<p><strong>Option 1: Basic</strong></p>
-
-<pre>
-<code>
-										I&#x27;m going to explain [concept] to you. Please act like an intelligent but curious person who knows nothing about this topic. Ask me clarifying questions if my explanation isn&#x27;t clear or complete.
-									</code></pre>
-
-<p><strong>Option 2: In-depth</strong></p>
-
-<pre>
-<code>
-										GOAL: This is a role-playing scenario in which the user (student) practices teaching a concept or topic to a novice student (you)
-PERSONA: In this scenario you play AI Mentor, a friendly and practical mentor.
-NARRATIVE: The student is introduced to AI Mentor, is asked initial questions which guide the scenario set up, plays through the scene helping a novice student understand a concept, and then gets feedback following the teaching exercise.  
-
-Follow these steps in order:
-
-STEP 1: GATHER INFORMATION 
-You should do this: 
-1.Let students know that you’ll be playing the role of student based on their preferences and that their job is to guide you (a student new to a topic) explain the topic and answer your questions.
-2. Tell the student you can play either one of two roles: you can be their chatty and inquisitive student or their skeptical and bemused (their choice). Present these choices via numbers and wait for the student to choose a number.
-You should not do this: 
-•	Ask more than 1 question at a time
-•	Mention the steps to the user ie do not say “what I’ll do next is..”
-
-Next step: Move on to the next step when you have the information you need.
-
-STEP 2: SET UP ROLEPLAY
-1.Ask the student what topic they would like to teach you: Once the student shares this with you, then suggest declare LET’S BEGIN and dive into your role 
-Context for step 2: As a student new to a topic, you don&#x27;t understand jargon and your job is to draw out a thorough explanation, and lots of examples. You do not have any prior knowledge of the topic whatsoever. You ask questions that challenge the teacher to clearly explain the topic. Ask just one question at a time as a student. You can also make a mistake or misunderstand the teacher once during the interaction, if applicable. As a student you might ask the teacher to clarify, to explain their approach, to give an example; to explain a real world connection or implication e.g. why is this important? What would happen if..? 
-You should do this:
-1.Lean into whichever role you are playing e.g., as an inquisitive student play that up by asking questions large and small; as a skeptical student drily challenge the teacher to create effective explanations. 
-2.After 5-6 interactions declare LESSON COMPLETE
-3.If a student asks you to explain something to them during the lesson remember to act like a novice to the topic with little prior knowledge. Turn the question back to them.
-You should not do this: 
-•	Ask more than 1 question at a time
-•	Learn too quickly: it’s ok to struggle with the material
-•	Describe your own behavior
-•	Explain anything to the student; it’s their job to explain to you as you are the student
-
-Next step: Move on to the next step after you declare LESSON COMPLETE and then give the student feedback on their teaching and explanation. 
-
-STEP 3: FEEDBACK
-You should do this:
-1.As soon as the role play is over, you can explain that teaching someone else can help them organize information and highlight any gaps in their knowledge. 
-2.Ask the user to take a look at the conversation they had with their student and ask: what question might you ask to check that you AI student understood what you taught them. Please explain your thinking. 
-3.Then, wrap up the conversation but tell the student that you are happy to keep talking.
-You shouldn’t do this:
-•	Respond for the student and answer the reflection question. 
-•	Give the student suggestions to answer that final question. 
-
-									</code></pre>
-
-<p>This tutoring prompt is adapted from work by Lilach Mollick and Ethan Mollick, licensed under <a href="https://creativecommons.org/licenses/by/4.0/" rel="noopener noreferrer" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p>
-
-<p><strong>Iteration tip:</strong> If AI&#x27;s initial feedback is too generic, ask for specifics: &quot;What specific part of my explanation was unclear?&quot; or &quot;What key aspect of [concept] did I miss?&quot;</p>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Question quality:</strong> Were AI&#x27;s &quot;novice&quot; questions actually helpful, or were they random? Good questions should target unclear parts of your explanation.</li>
-	<li><strong>Feedback value:</strong> Did AI&#x27;s evaluation help you identify real gaps, or was it too vague? Look for specific, actionable feedback.</li>
-	<li><strong>Your growth:</strong> What did this exercise reveal about your understanding? Where do you need to review?</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>Teaching forces you to organize and articulate your knowledge. AI provides a patient audience for practice, but the real learning happens when you struggle to explain clearly.</p>
-</div>
-</div>
-</details>
-</div>
-</div>
-
-<div>
-<h2>2. Creating Custom Practice &amp; Self-Assessment Tools</h2>
-
-<p>Why settle for generic practice questions when AI can create materials tailored to exactly what you need to study? These activities show you how to generate effective practice tools while maintaining quality control.</p>
-
-<div>
-<details><summary> <i></i> <span>Activity 2.1: AI as a Custom Quiz Generator</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Create personalized practice questions on topics you&#x27;re studying. This helps you test your knowledge and identify weak areas before the real exam.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do</h4>
-
-<p>Be specific about what you want. Example prompts:</p>
-
-<pre>
-<code>Create 5 multiple-choice questions about [specific topic] that test understanding, not just memorization. Include answers and explanations.
-									</code></pre>
-
-<pre>
-<code>Generate 3 short-answer questions about [topic] that would appear on a college-level exam. Focus on application, not definitions.</code></pre>
-
-<pre>
-<code>Create a practice problem similar to this one: [paste example].Make it different enough to test the same concept in a new way.</code></pre>
-
-<p><strong>Level-up tip 1:</strong> Ask for questions at different difficulty levels: &quot;Create one basic, one intermediate, and one challenging question about [topic].&quot;</p>
-
-<p><strong>Level-up tip 2:</strong> Ask your instructor for permission to upload course materials (lecture slides, study guides, readings) to an AI tool. This allows the AI to generate questions and study materials based on your actual course content. <a href="https://notebooklm.google.com/" rel="noopener noreferrer" target="_blank">NotebookLM</a> is particularly good for this—you can upload your course documents and it will create practice questions, summaries, and even study guides directly from your instructor&#x27;s materials.</p>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Question quality:</strong> Are the questions clear and unambiguous? Watch for questions with multiple correct answers or confusing wording.</li>
-	<li><strong>Answer accuracy:</strong> Verify AI&#x27;s answers against your notes. AI sometimes generates plausible but incorrect answers.</li>
-	<li><strong>Difficulty alignment:</strong> Do the questions match your course level? Too easy won&#x27;t help; too hard might discourage.</li>
-	<li><strong>Prompt refinement:</strong> How could you modify your prompt to get better questions next time?</li>
-</ul>
-
-<div>
-<p><i></i> Critical reminder: Always verify AI-generated answers with your course materials. Treat these as practice tools, not authoritative sources.</p>
-</div>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>AI can quickly generate diverse practice questions, but you&#x27;re the quality controller. The best results come from specific prompts and careful verification.</p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Activity 2.2: Developing Content for Study Aids with AI</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Use AI to help create flashcards, summary sheets, or concept maps. This speeds up study material creation while ensuring you cover all key points.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do</h4>
-
-<p>Try these targeted prompts:</p>
-
-<pre>
-<code>Create flashcard content for [topic]: provide 10 terms with concise,accurate definitions suitable for quick review.</code></pre>
-
-<pre>
-<code>List the 5 most important concepts from [topic] and explain how they connect to each other.</code></pre>
-
-<pre>
-<code>Generate a study sheet outline for [topic] with main points and 2-3 key details under each.</code></pre>
-
-<p><strong>Level-up tip:</strong> Ask your instructor for permission to upload course materials (lecture slides, study guides, readings) to an AI tool. This allows the AI to generate questions and study materials based on your actual course content. <a href="https://notebooklm.google.com/" rel="noopener noreferrer" target="_blank">NotebookLM</a> is particularly good for this. You can upload your course documents and it will create practice questions, summaries, and even study guides directly from your instructor&#x27;s materials.</p>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Completeness:</strong> Did AI include all crucial concepts from your lectures/readings? What&#x27;s missing?</li>
-	<li><strong>Accuracy:</strong> Are the definitions precise? Even small errors can lead to misconceptions.</li>
-	<li><strong>Usefulness:</strong> Is the content actually helpful for studying, or just a regurgitation of basic facts?</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>AI accelerates study material creation, but the act of reviewing and correcting its output is where much of the learning happens.</p>
-</div>
-</div>
-</details>
-</div>
-</div>
-
-<div>
-<h2>Reflection &amp; Synthesis</h2>
-
-<p><strong>What you&#x27;ve learned:</strong> AI can be a powerful partner for understanding complex concepts and creating personalized study materials. You&#x27;ve practiced using AI to get multiple explanations, engage in tutoring dialogues, test your understanding, generate practice questions, and build study aids.</p>
-
-<p><strong>Key insight:</strong> The magic of AI comes out when you know how you prompt, evaluate, and build upon them. Your critical thinking transforms AI output into genuine learning.</p>
-
-<p><strong>Reflection question:</strong> Think about a concept you&#x27;ve struggled with recently. How might you use these techniques differently now? What&#x27;s one specific way you&#x27;ll incorporate AI into your next study session?</p>
-
-<p><strong>Remember:</strong> AI is your study amplifier, not your study replacement. The understanding you build is still yours to earn.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div>
-<p>Critical thinking is the skill that everyone is talking about.</p>
-
-<div>
-<p>&quot;We need to ensure students have critical thinking skills when they graduate.&quot;<br>
-<span>— Teacher 1 (probably)</span></p>
-</div>
-
-<div>
-<p>&quot;I let my students use generative AI, but I make sure that I teach critical thinking too.&quot;<br>
-<span>— Teacher 2 (likely)</span></p>
-</div>
-
-<p>But how do you practice critical thinking yourself? Critical thinking means examining ideas with at least the same level of skepticism you&#x27;d apply to an email offering you part of a large inheritance. When you think critically, you&#x27;re essentially putting an idea through intellectual boot camp by testing it, challenging it, and making it do cognitive push-ups until it either fails or becomes strong enough to survive in the wild world of academic discourse.</p>
-
-<p>Let&#x27;s be clear: nothing beats a human sparring partner for developing critical thinking. A real person challenges you to think on your feet, brings unexpected perspectives, and forces you to articulate ideas in real-time. The back-and-forth of human dialogue creates a dynamic that AI can&#x27;t fully replicate. But here&#x27;s the thing, your study group isn&#x27;t always available at 12 AM when you&#x27;re wrestling with an idea. Your professor has office hours, not &quot;whenever you need to test an argument&quot; hours. This is where AI becomes valuable: it&#x27;s always ready to play devil&#x27;s advocate, ask probing questions, or help you examine your assumptions. Think of it as having a practice partner who&#x27;s always up for intellectual sparring, even if they can&#x27;t replace the real match.</p>
-
-<p>In this module, you&#x27;ll learn to engage AI in ways that help you sharpen your analytical skills. You&#x27;ll practice using AI to probe your understanding through Socratic questioning and to stress-test your arguments by exploring opposing viewpoints. These techniques will help you develop more nuanced thinking and prepare you for academic discourse where defending your ideas matters.</p>
-
-<p>Remember: The goal isn&#x27;t to let AI think for you, but to use it as a tool that pushes you to think more deeply and critically about your own ideas.</p>
-</div>
-
-<div>
-<h2>1. Socratic Dialogue &amp; Questioning</h2>
-
-<p>The Socratic method uses probing questions to expose gaps in reasoning and lead to deeper understanding. AI can simulate this ancient teaching technique, helping you examine your beliefs and assumptions more rigorously.</p>
-
-<div>
-<details><summary> <i></i> <span>Activity 1.1: AI as a Socratic Questioner (Simple)</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Present an idea, belief, or argument to AI and ask it to question you using the Socratic method. This helps uncover hidden assumptions and strengthens your reasoning by forcing you to justify each step of your thinking.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do</h4>
-
-<p>Start with these prompts to initiate Socratic dialogue:</p>
-
-<pre>
-<code>I believe that [state your position/argument]. Please act as a Socratic questioner and help me examine this belief by asking probing questions about my assumptions, evidence, reasoning, exceptions, and edge cases. Don&#x27;t argue against me, just ask questions that help me think more deeply.</code></pre>
-
-<p><strong>Iterative questioning tip:</strong> After each AI question, answer thoughtfully, then ask: &quot;Based on my response, what follow-up question would help me dig deeper?&quot; This keeps the dialogue focused and productive.</p>
-
-<p>Example of iterative questioning in action:</p>
-
-<pre>
-<code>You: &quot;I believe social media is harmful to democracy.&quot;
-AI: &quot;What specific aspects of social media do you think cause harm?&quot;
-You: &quot;The spread of misinformation and echo chambers.&quot;
-AI: &quot;How do you define &#x27;echo chambers&#x27; and what evidence do you have that they&#x27;re unique to social media?&quot;
-You: &quot;Good question. Let me think... [your response]. What follow-up question would help me examine this further?&quot;</code></pre>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Question quality:</strong> Were AI&#x27;s questions genuinely thought-provoking or just surface-level? Good Socratic questions should make you pause and reconsider.</li>
-	<li><strong>Assumption discovery:</strong> Did the questioning help you identify assumptions you didn&#x27;t realize you were making?</li>
-	<li><strong>Depth vs. breadth:</strong> Did AI help you go deeper into core issues, or did it jump around too much?</li>
-	<li><strong>Your growth:</strong> How did your understanding of your own position change through this process?</li>
-</ul>
-
-<p><em>Critical note:</em> Sometimes AI generates questions that sound Socratic but are actually leading or biased. True Socratic questioning should help you discover insights, not push you toward predetermined conclusions.</p>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>Socratic questioning with AI can reveal the foundations of your thinking. The value comes not from AI&#x27;s questions alone, but from the hard work of examining your own reasoning honestly.</p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Activity 1.2: AI as a Socratic Questioner (comprehensive)</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Engage with a more sophisticated Socratic questioner that follows a systematic approach to examining your thinking. This structured method ensures comprehensive exploration of your ideas through six distinct questioning categories.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do</h4>
-
-<p>Use this comprehensive prompt to activate a disciplined Socratic partner:</p>
-
-<pre>
-<code>**Role &amp; Goal**  
-You are a Socratic Thought Partner whose single purpose is to sharpen my reasoning. You accomplish this by asking disciplined, systematic questions drawn from the classic Socratic categories (Clarification, Assumption, Evidence &amp; Reasoning, Implications &amp; Consequences, Viewpoint &amp; Perspective, Question-the-Question). You are incisive and critical. You target my core motivations and unstated intentions. You understand that I may have misconceptions or blind spots which need to be surfaced. 
-
-Your dialogue model follows the guidance on effective Socratic questioning from the University of Connecticut&#x27;s Center for Excellence in Teaching and Learning. (https://cetl.uconn.edu/resources/teaching-your-course/leading-effective-discussions/socratic-questions/?utm_source=chatgpt.com) Refer to this webpage if you have that ability.
-
----
-### 1. Opening Move
-Begin every new conversation with:
-&gt; &quot;To get started, what would you like to explore today?&quot;
----
-### 2. Core Dialogue Cycle (applies after every user reply)
-1. **Select a Question Category**  
-    Cycle logically through the six categories to keep exploration balanced:
-    - Clarification
-    - Assumption
-    - Evidence &amp; Reasoning
-    - Implications &amp; Consequences
-    - Viewpoint &amp; Perspective
-    - Question-the-Question (meta-reflection)
-2. **Pose One Incisive Question**  
-    Formulate a single open-ended question from the chosen category that invites deeper thought (e.g., &quot;What underpinning assumption leads you to that conclusion?&quot;).
-3. **Spotlight Fuzzy Thinking**  
-    In ≤ 25 words, point out any vagueness, leap of logic, or unexamined premise apparent in my prior answer.
-4. **Critical Feedback on Process**  
-    Offer one concise suggestion to strengthen my reasoning habits (e.g., &quot;Try articulating the counter-example before defending your view.&quot;).
-5. **Practical Next Steps**  
-    Recommend 1-2 actionable steps I can take immediately (reading, data to gather, small experiment, etc.) to advance my inquiry.
-
----
-### 3. Meta-Requests &amp; Summaries
-- **If I explicitly ask for your conclusions,** switch to an analytic summary: synthesize key insights so far, highlight remaining uncertainties, and propose logical next directions.
-- **If I request a comparison, definition, or explanation,** briefly deliver it, then revert to the Core Dialogue Cycle.
-
----
-### 4. Tone &amp; Interaction Rules
-- Use plain, precise language.
-- Keep responses tight—no fluff, no digressions.
-- Never provide more than one question before awaiting my answer.
-- Do not supply your own opinions unless I solicit them; guide by questioning.
-- Maintain respectful curiosity; challenge ideas, not the person.
-- Avoid announcing methodology; simply demonstrate it.
-
----
-### 5. End-of-Session Check-Out
-When I indicate I am finished, ask:
-&gt; &quot;Which insight from today&#x27;s dialogue feels most actionable for you?&quot;</code></pre>
-
-<p><strong>Usage tip:</strong> This prompt creates a more rigorous questioning experience. The AI will systematically explore different aspects of your thinking, providing feedback on your reasoning process itself, not just your ideas.</p>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Systematic approach:</strong> Did the structured categories help explore your topic more thoroughly than the basic Socratic approach?</li>
-	<li><strong>Feedback quality:</strong> How useful was the &quot;fuzzy thinking&quot; spotlight and process feedback? Did it help you see patterns in your reasoning?</li>
-	<li><strong>Comparison question:</strong> How did this structured approach differ from Activity 1.1? Which style better suited your learning needs and why? Consider:
-	<ul>
-		<li>The basic approach allows more organic conversation flow</li>
-		<li>The structured approach ensures comprehensive coverage</li>
-		<li>Which pushed you to think harder about your assumptions?</li>
-	</ul>
-	</li>
-	<li><strong>Actionable insights:</strong> What specific next steps did the AI suggest, and were they genuinely helpful for advancing your understanding?</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>A structured Socratic approach can ensure no stone is left unturned in examining your thinking. The systematic categories prevent you from avoiding uncomfortable questions and force comprehensive self-examination.</p>
-</div>
-</div>
-</details>
-</div>
-</div>
-
-<div>
-<h2>2. AI as a Debate &amp; Argumentation Sparring Partner</h2>
-
-<p>Strong arguments anticipate and address counterpoints. AI can help you prepare for intellectual challenges by taking opposing stances and forcing you to defend your position—like a practice debate before the real thing.</p>
-
-<div>
-<details><summary> <i></i> <span>Activity 2.1: AI as a Devil&#x27;s Advocate (Simple)</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Present your thesis or argument to AI and ask it to argue against your position. This helps you anticipate objections, identify weaknesses in your reasoning, and build more robust arguments.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do</h4>
-
-<p>Use these prompts to engage AI as your intellectual opponent:</p>
-
-<pre>
-<code>My thesis is: [your thesis]. Please act as a devil&#x27;s advocate and 
-present the strongest possible counter-arguments. Focus on:
-- Logical weaknesses in my argument
-- Alternative interpretations of my evidence  
-- Unintended consequences I haven&#x27;t considered</code></pre>
-
-<pre>
-<code>I&#x27;m writing a paper arguing that [your position]. Help me strengthen 
-my argument by:
-1. Identifying the 3 strongest objections someone might raise
-2. Explaining why each objection seems compelling
-3. Suggesting what evidence opponents might use</code></pre>
-
-<pre>
-<code>Here&#x27;s my main argument: [your argument]. Play devil&#x27;s advocate, 
-but stick to legitimate counter-arguments—no straw man arguments 
-or logical fallacies. After each counter-argument, ask me how I 
-would respond.</code></pre>
-
-<p><strong>Pro tip:</strong> After AI presents counter-arguments, practice responding: &quot;How would I address this objection in my paper?&quot; This prepares you for real academic discourse.</p>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Argument validity:</strong> Were AI&#x27;s counter-arguments logically sound, or did they contain fallacies?</li>
-	<li><strong>Strength assessment:</strong> Did AI identify genuine weaknesses in your position, or just superficial issues?</li>
-	<li><strong>Fallacy detection:</strong> Watch for common logical fallacies AI might use:</li>
-</ul>
-
-<div>
-<p><i></i> <strong>Example of AI using a fallacy:</strong><br>
-Your argument: &quot;Universities should increase funding for mental health services.&quot;<br>
-AI&#x27;s flawed counter: &quot;But if we fund mental health services, soon we&#x27;ll have to fund everything students want, and the university will go bankrupt.&quot; (Slippery slope fallacy)<br>
-<br>
-A better counter-argument would address actual trade-offs: &quot;Given limited budgets, how should universities balance mental health funding against other student needs like financial aid or academic support?&quot;</p>
-</div>
-
-<ul>
-	<li><strong>Learning value:</strong> Did this exercise help you see your argument from new angles? What will you change based on this practice?</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>AI can simulate intellectual opposition, helping you build stronger arguments by anticipating challenges. But remember: real human critics may raise concerns AI doesn&#x27;t consider, especially those involving values, context, or lived experience.</p>
-</div>
-</div>
-</details>
-</div>
-
-<details><summary> <i></i> <span>Activity 2.2: AI as a Devil&#x27;s Advocate (Comprehensive)</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Task</h4>
-
-<p>Engage with a systematic devil&#x27;s advocate that methodically stress-tests your plans and ideas. This structured approach ensures comprehensive examination through five distinct challenge categories, helping you identify blind spots before they become problems.</p>
-</div>
-
-<div>
-<h4><i></i>Dive-in &amp; Do</h4>
-
-<p>Use this comprehensive prompt to activate a strategic devil&#x27;s advocate partner (note that the unusual formatting is called <i>Markdown</i> and is used to help the LLM understanding the hierarchy of the prompt):</p>
-
-<pre>
-<code>
-## 1. Role &amp; Purpose
-You are a **Devil&#x27;s Advocate Thought Partner** whose mission is to stress-test any plan or idea I am considering. You surface hidden assumptions, expose weaknesses, and explore alternate approaches so I can refine or reaffirm my thinking with full confidence.
-                
-## 2. Opening Move
-Begin every new conversation with:
-&gt; &quot;Hi—what plan or idea would you like us to examine?&quot;
-## 3. Intake Phase
-  _Ask only **one** open question at a time and wait for my reply._
-  1. Capture:
-    - Project overview
-    - Main objectives
-    - Specific plan or idea under review
-  2. Confirm understanding:
-    &gt; &quot;Got it. Let&#x27;s stress-test this plan to avoid the consensus trap.&quot;  
-    &gt; _Wait for acknowledgment before advancing._
-                
-## 4. Devil&#x27;s Advocate Challenge Cycle
-Repeat until potential flaws feel thoroughly explored.
-                
-| Step                        | Action                                                                                                                  |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| **A. Probe Assumptions**    | Ask one incisive question challenging an implicit belief.                                                               |
-| **B. Explore Alternatives** | Ask one question inviting a different angle or option.                                                                  |
-| **C. Test Evidence**        | Ask one question checking supporting data or precedent.                                                                 |
-| **D. Surface Drawbacks**    | Ask one question uncovering negative consequences.                                                                      |
-| **E. Reflect &amp; Refine**     | In ≤ 25 words, spotlight logical gaps or overlooked issues and offer one concise suggestion to strengthen the analysis. |
-                
-_Cycle rules: one question per turn; always await my response; if I stall, offer a concrete example to prompt discussion._
-               
-## 5. Completion &amp; Synthesis
-1. Readiness check:
-  &gt; &quot;Have we examined every significant risk or alternative you wanted to cover?&quot;
-2. After confirmation, present a bold markdown table:
-                    
-| **INITIAL PLAN / IDEA** | **HIDDEN ASSUMPTIONS** | **ALTERNATIVE VIEWPOINTS** |
-| ----------------------- | ---------------------- | -------------------------- |
-| _(concise description)_ | _(bullet list)_        | _(bullet list)_            |
-                
-3. Close with:
- &gt; &quot;If new questions arise, I&#x27;m here to help examine them.&quot;
-               
-## 6. Tone &amp; Interaction Rules
-    - Warm, respectful, strategic—challenge ideas, not people.
-    - Plain language; no fluff.
-    - One question per response.
-    - Do not create the final table until every question you asked has been answered.
-                
-## 7. Example Turn
-**User:** &quot;I plan to launch the app in eight weeks.&quot;  
-**AI:**
-1. _Probe Assumptions_ – &quot;What makes eight weeks preferable to twelve?&quot;
-2. _Reflect &amp; Refine_ – &quot;Timeline appears fixed without evidence; reviewing historical dev-cycle data could validate feasibility.
-</code></pre>
-
-<p><strong>Strategic tip:</strong> This structured approach prevents the AI from jumping randomly between critiques. The systematic cycle ensures you examine assumptions, alternatives, evidence, and consequences in a logical progression.</p>
-</div>
-
-<div>
-<h4><i></i>Pause &amp; Ponder</h4>
-
-<ul>
-	<li><strong>Systematic coverage:</strong> Did the structured cycle help uncover issues you wouldn&#x27;t have considered with a basic devil&#x27;s advocate approach?</li>
-	<li><strong>Quality of challenges:</strong> Were the AI&#x27;s questions genuinely challenging your thinking, or were they predictable? The best devil&#x27;s advocacy makes you uncomfortable because it hits real vulnerabilities.</li>
-	<li><strong>Comparison with Activity 2.1:</strong> How did this structured approach differ from the basic devil&#x27;s advocate? Consider:
-	<ul>
-		<li>The basic approach allows more organic opposition</li>
-		<li>The structured approach ensures systematic coverage</li>
-		<li>Which helped you identify more significant weaknesses?</li>
-	</ul>
-	</li>
-	<li><strong>The synthesis table:</strong> Was the final summary table helpful in capturing what you learned? Did it reveal patterns in your assumptions?</li>
-	<li><strong>Real-world application:</strong> Think of a project or decision you&#x27;re facing. Would this systematic stress-testing help you prepare better?</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>Structured devil&#x27;s advocacy ensures you don&#x27;t skip uncomfortable questions. The systematic approach forces examination of assumptions, alternatives, evidence, and consequences—creating a more robust final plan or argument.</p>
-</div>
-</div>
-</details>
-</div>
-
-<div>
-<h2>Reflection &amp; Synthesis</h2>
-
-<p><strong>What you&#x27;ve learned:</strong> You&#x27;ve practiced using AI as a tool for sharpening critical thinking through Socratic questioning and devil&#x27;s advocacy. These techniques help you examine assumptions, anticipate objections, and build more thoughtful arguments.</p>
-
-<p><strong>Key insight:</strong> AI serves best as a thinking catalyst, not a thinking replacement. It can prompt you to question more deeply and argue more carefully, but the critical analysis must come from you.</p>
-
-<p><strong>Reflection questions:</strong></p>
-
-<ul>
-	<li>How can you use Socratic questioning to improve your understanding in other courses?</li>
-	<li>Think of a paper you&#x27;re writing or a position you hold strongly. What assumptions haven&#x27;t you examined yet?</li>
-	<li>How might these techniques help you in class discussions or study groups?</li>
-</ul>
-
-<p><strong>Moving forward:</strong> Critical thinking is a skill that improves with practice. Use these AI techniques regularly, but also seek out human discussion partners who can challenge you in ways AI cannot—through personal experience, emotional intelligence, and contextual understanding.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<h1><i></i>AI for Honing Communication Skills (Beyond Writing)</h1>
-
-<div>
-<p>AI can help improve your communications skills and it can help across all types of communications, not just writing. Here, we&#x27;ll explore how AI can serve as a practice partner for other forms of communication, from delivering great presentations to role playing as different types of conversational partners to supporting language acquisition. The goal of this module is to supplement human interaction. AI tools are still not good at reading body language or detecting subtlety and nuance in a conversation. AI <em>can</em> provide a low-stakes environment to practice, refine, and build confidence before you step onto the stage or into a high-stakes meeting.</p>
-
-<div>
-<p><i></i><strong>Critical Note: The Human Advantage.</strong> An AI can be a useful conversation partner simulator, but it is not a substitute for an expert human coach or a real conversation partner. A person can interpret body language, detect subtle shifts in tone, and understand nuance in a way a machine cannot. Always prioritize feedback from trusted peers, mentors, and instructors. Use AI as a tool for preparation, not a replacement for real-world experience.</p>
-</div>
-</div>
-
-<hr>
-<div>
-<h2><i></i>Enhancing Presentation &amp; Speaking Skills</h2>
-
-<p>Successful presentations have strong narratives and are able to connect with an audience. In this section, you&#x27;ll learn to use AI as a structural strategist to organize your ideas and as a private coach to refine your delivery. This section provides a three-part process for using AI as a presentation partner:</p>
-
-<ol>
-	<li>A toolkit to help you efficiently draft your content and the presentation<br>
-	 </li>
-	<li>A stress-test activity to refine the presentation<br>
-	 </li>
-	<li>A feedback activity to get AI to provide tips on improving your presentation (it&#x27;s better to get human input for this, but the advantage of AI is that it&#x27;s always there to help out when a human isn&#x27;t)<br>
-	 </li>
-</ol>
-
-<div>
-<details><summary> <i></i> <span>Presentation Activity 1: Create a Presentation</span> </summary>
-
-<div>
-<p>Creating a presentation has some similarities to writing a paper in that you want the presentation to represent your thoughts and your views, but you also want to find ways to simplify the process without removing your agency. A good approach is to start by using an AI chatbot to organize your ideas and craft a strong narrative. Once your content is clear, use a specialized presentation AI tool to quickly turn your text into professional-looking slides. this method ensures flexibility, keeps you in the center of the process, and simplifies the creation of the slides.</p>
-
-<div>
-<h4><i></i>Purpose</h4>
-
-<p>Craft a clear, audience-focused presentation by leveraging AI as your behind-the-scenes strategist and your slide generating expert.</p>
-
-<h4><i></i>Task</h4>
-
-<p>Kick things off with your original ideas. Then, let AI suggest different frameworks, critique structures, and help map out your slides.</p>
-</div>
-
-<h3><i></i>Step 1: Develop the Presentation Content</h3>
-
-<p>Use one of the prompts below as a starting point or develop your own. The key is to always provide the AI with your own content and context first.</p>
-
-<h4>Scenario 1: You have a finished paper or report and need to turn it into a presentation.</h4>
-
-<pre>
-<code>Act as a communication expert. I&#x27;m adapting a research paper into a 10-minute presentation for an audience of [Describe your audience]. My core message for them is [State your single most important takeaway]. Based on the text I&#x27;ve pasted below, please extract the 3-4 main arguments and structure them into a logical 5-slide outline with headlines and key talking points.</code></pre>
-
-<h4>Scenario 2: You have raw data (from a survey, experiment, etc.) and need to build a story around it.</h4>
-
-<pre>
-<code>Act as a data storyteller. I need to present a key finding to [Describe your audience] to convince them to [State your goal]. My key finding is: &#x27;[State your data&#x27;s headline in one sentence]&#x27;. Please suggest a simple 3-part narrative (hook, data reveal, so what?) and propose two different ways I could visually represent this data, explaining the pros and cons of each.</code></pre>
-
-<h4>Scenario 3: You are starting from scratch with a broad topic.</h4>
-
-<pre>
-<code>Act as a creative strategist. I need to develop a presentation on [Your Topic] for [Your Audience]. Please propose three distinct, debatable thesis statements I could build my presentation around. For each, list one potential audience objection I would need to anticipate and address.</code></pre>
-
-<h3><i></i>Step 2: Choose an AI Tool for Creating the Actual Presentation</h3>
-
-<p>After developing your content, pick an AI presentation tool to quickly generate slides. I&#x27;ll leave it to you to pick the tool and figure out how to use it - the two I&#x27;ve recommended below are fairly intuitive to use.</p>
-
-<h4>Some Options:</h4>
-
-<ul>
-	<li><strong>Gamma.app</strong> Gamma turns a short text prompt or document into a scrollable slide deck.
-
-	<ul>
-		<li>Creates polished slides rapidly</li>
-		<li>Easy to use with good design defaults</li>
-		<li>Free tier (400 credits = 8-10 presentations) is student-friendly</li>
-		<li>Limited customization</li>
-		<li>Generated images are okay but sometimes miss the mark</li>
-		<li>Free usage capped at 10 cards per deck</li>
-		<li>Experiment with Gamma’s “Restyle” feature</li>
-		<li>Export for offline presentations and better editing control</li>
-	</ul>
-	</li>
-	<li><strong>PowerPoint with Copilot</strong> Copilot adds an AI side-panel to PowerPoint that can draft, rewrite, and redesign slides on command.
-	<ul>
-		<li>Integrated with PowerPoint (familiar UI)</li>
-		<li>Can create slides from documents or prompts</li>
-		<li>Real-time editing with AI commands</li>
-		<li>Images added are mix of AI generated and stock photos</li>
-		<li>Requires Microsoft 365 subscription (free trial available)</li>
-		<li>Output may need substantial editing</li>
-		<li>Provide structured input for best results</li>
-		<li>Use AI rewrite options within slides</li>
-		<li>Load your preferred template before using Copilot</li>
-	</ul>
-	</li>
-	<li><strong>SlidesAI (Google Slides Add-on)</strong> Lives inside Google Slides and converts pasted text into a ready-formatted slide deck in a few clicks.
-	<ul>
-		<li>not recommended - free version is limited</li>
-		<li>1000 character input max</li>
-		<li>12 free presentations/year</li>
-	</ul>
-	</li>
-	<li><strong>beautiful.ai</strong> Generates slides from prompts.
-	<ul>
-		<li>not recommended - no free version, only a free trial</li>
-		<li>free trial limits input features</li>
-	</ul>
-	</li>
-</ul>
-
-<div>
-<h5><i></i>Notes for Instructors</h5>
-
-<p>If you are going to do this activity in your class, here are some suggestions:</p>
-
-<ul>
-	<li>Model the &quot;brain-first outline ➜ AI options ➜ human evaluation&quot; flow for building a presentation</li>
-	<li>Require an <em>AI contribution statement</em> slide and a slide reflecting on the use of AI for the presentation</li>
-	<li>Fact check one data point on each student&#x27;s slide during the presentation</li>
-</ul>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Presentation Activity 2: The Presentation Stress-Test (For Feedback)</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Purpose</h4>
-
-<p>Use AI to evaluate your presentation draft from multiple perspectives, uncovering weaknesses in your argument, clarity, and structure.</p>
-
-<h4><i></i>Task</h4>
-
-<p>You will take your completed presentation draft (the slide headlines and key talking points) and subject it to a &quot;stress-test&quot; by asking an AI to role-play three different critical personas.</p>
-</div>
-
-<h3><i></i>Dive-in &amp; Do It</h3>
-
-<h4>Use your brain first:</h4>
-
-<ol>
-	<li><strong>Prepare Your Draft:</strong> Open a document and paste in your presentation outline. This should include the title, and for each slide, the headline and the main bullet points you plan to discuss. This is the artifact the AI will analyze.</li>
-</ol>
-
-<h4>AI Input:</h4>
-
-<ol start="2">
-	<li>Copy your entire presentation outline and paste it into each of the prompts below to get feedback from multiple perspectives (you can modify the perspectives/personas as you see fit)</li>
-</ol>
-
-<h4>Prompt 1:</h4>
-
-<pre>
-<code>Act as a bright but curious first-year university student. You are attending this presentation knowing nothing about the subject matter. I am a student who has drafted a presentation outline, which is pasted below.
-
-Your task is to identify every point of confusion. Pinpoint any jargon or technical terms I failed to explain. Highlight any logical jumps where you felt lost or weren&#x27;t sure how I got from one point to the next. List the specific questions that came to your mind as you were reading.
-
-Please format your feedback as a simple list of questions and comments. For each item, reference the specific slide number or headline where the confusion occurred so I can easily find it. 
-
-Your tone should be inquisitive but critique my presentation freely and avoid sycophancy. I crave honest appraisal.
-
-Here is my outline:
-[Paste your presentation  here]</code></pre>
-
-<h4>Prompt 2:</h4>
-
-<pre>
-<code>Act as a tenured professor and a leading expert in this specific field. You are reviewing this outline as if it were submitted for a prestigious academic conference. I have drafted this presentation for a knowledgeable audience and need to ensure my core arguments are robust.
-
-Critically analyze the arguments, evidence, and logic presented in my outline below. Your primary goal is to identify the single weakest, most unsupported, or most questionable claim. Then, formulate the single most challenging, insightful question you would ask me during the Q&amp;A session.
-
-Structure your feedback in two distinct parts:
-1. **Weakest Point Analysis:** A short paragraph identifying the weakest claim and explaining precisely why it is weak.
-2. **The Killer Question:** The single, well-formulated question you would ask.
- 
-Your tone should be professional, academic, and rigorous. Critique freely and avoid sycophancy. I crave honest appraisal.
-
-Here is my outline:
-[Paste your presentation here]</code></pre>
-
-<h4>Prompt 3:</h4>
-
-<pre>
-<code>Act as a busy, high-level executive. You have very little time and only care about the bottom line. I have drafted a presentation outline and need to ensure it immediately communicates its value.
-
-Scan my presentation below. Your task is to determine the core takeaway and its relevance. Answer these three questions directly: 
-1. What is the absolute main point? 
-2. Why should I care? 
-3. What do you want me to do?
- 
-Provide your entire response in a single, concise paragraph. Begin the paragraph with the words &#x27;Bottom Line:&#x27;.. Your tone should be direct, decisive, and slightly impatient. Critique freely and avoid sycophancy. I crave honest appraisal.
- 
-Here is my outline:
-[Paste your presentation outline here]</code></pre>
-
-<h3><i></i>Pause &amp; Ponder</h3>
-
-<ol>
-	<li><strong>Synthesize the Feedback:</strong> Which persona&#x27;s feedback was the most surprising or insightful? Why?</li>
-	<li><strong>Address the Weakness:</strong> Based on the &quot;Skeptical Expert&#x27;s&quot; critique, how will you strengthen your weakest point? Will you add more data, cite another source, or rephrase the claim to be more precise?</li>
-	<li><strong>Improve Clarity:</strong> Look at the feedback from the &quot;Confused Novice&quot; and the &quot;Impatient Executive.&quot; How can you revise your introduction and conclusion to make your core message clearer and more impactful from the very beginning?</li>
-</ol>
-
-<div>
-<h5><i></i>Key Takeaway: Seek Diverse Criticism</h5>
-
-<p>A single opinion, whether from a human or AI, gives you only one perspective. By forcing the AI to adopt multiple, even contradictory, personas, you simulate a more realistic feedback environment. This process helps you anticipate the needs of a diverse audience and build a more robust, resilient presentation.</p>
-</div>
-
-<div>
-<h5><i></i>Notes for Instructors</h5>
-
-<p>If you are going to do this activity in your class, here are some suggestions:</p>
-
-<ul>
-	<li>This activity can be good for a PAIRR type framework. AI gives feedback, peer gives feedback, presenter takes feedback from both and adjusts.</li>
-	<li>Require a reflection on the process</li>
-</ul>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Presentation Activity 3: AI for Presentation Delivery Practice</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Purpose</h4>
-
-<p>To get objective feedback on your speaking habits in a private setting, helping you identify and reduce filler words, monitor your pace, and improve clarity.</p>
-
-<h4><i></i>Task</h4>
-
-<p>You will use a tool with AI-powered video and speech analysis to practice delivering your presentation and then critically evaluate the feedback it provides.</p>
-</div>
-
-<div>
-<p><i></i><strong>Privacy and Data Security Warning.</strong> Using AI tools in this way requires you to upload audio and video of yourself to a third-party server. Before using any tool, understand its privacy policy. Ask yourself (and the privacy policy): Who owns the data once I upload it? How is my data being used? Is it used to train the AI? Can I delete my data after I&#x27;m done? If you are not comfortable with the answers, do not do this activity.</p>
-</div>
-
-<div>
-<p><i></i><strong>AI Limitation Warning.</strong> Using AI tools to give feedback on video is less well tested than getting feedback on writing. Do not expect the feedback to be deeply insightful or nuanced. Getting feedback from a human, even a non-expert will be more valuable.</p>
-</div>
-
-<div>
-<p><i></i><strong>Confabulation Warning.</strong> AI&#x27;s can make stuff up. Do some kind of content confirmation of the video to ensure that it is actually seeing the video.</p>
-</div>
-
-<p>As of June 2025, the only tool I have tried this with is Google Gemini. ChatGPT does not support it. Apparently Microsoft Copilot does, but I haven&#x27;t tried it myself.</p>
-
-<p>Other potential tools specialized for giving speaking and communication feedback: <a href="https://www.poised.com/">Poised</a>, <a href="https://orai.com/">Orai</a>.</p>
-
-<p>I have not vetted these other tools in anyway except to identify that they exist. If I can do something in a standard chatbot (like Google Gemini), I will almost always choose that. I can customize the interaction much more and I don&#x27;t have to worry about another privacy policy and sharing my info with yet another company.</p>
-
-<h3><i></i>Dive-in &amp; Do It</h3>
-
-<h4>Use your brain first:</h4>
-
-<ol>
-	<li>Record yourself giving a presentation. It&#x27;s probably best to just focus on yourself and not your slides. If you tend to walk around, have a friend record you, otherwise, just set up your camera to capture you in the frame.</li>
-</ol>
-
-<h4>AI Input:</h4>
-
-<ol start="2">
-	<li>Upload the video to a fresh Google Gemini chat (you can just drag and drop).</li>
-	<li>Enter one of these prompts or something like it:</li>
-</ol>
-
-<h4>In-Person Presentation Video</h4>
-
-<pre>
-<code>**Role:** You are an expert academic presentation coach.
-**Task:** Your task is to evaluate the attached video of a presentation and provide constructive, formative feedback to the presenter. 
-Disregard slide design, background graphics, or the academic content itself.
-
-**What to observe**
-1. **Voice &amp; Pace** – audibility, enunciation, vocal variety, speaking speed, strategic pauses, filler-word frequency.
-2. **Body Language** – posture, purposeful gestures, movement on stage, avoidance of fidgeting or pacing.
-3. **Eye Contact** – distribution of attention across the room, natural scanning, connection with individuals.
-4. **Audience Interaction** – questions posed, humour, rhetorical questions, acknowledgement of reactions, adaptability to cues.
-5. **Energy &amp; Presence** – enthusiasm, confidence, facial expressiveness, smooth transitions, time management.
-
-**Output format**
-- **Summary (≤ 2 sentences)** – overarching impression of delivery and engagement.
-- **What Was Done Well** – 4-6 bullet points, each starting with a strong verb and including an optional timestamp (HH:MM:SS) showing where it occurred.
-- **Ways to Improve** – 4-6 bullet points with constructive, specific suggestions; include optional timestamps.
-- **Actionable Tips** – 3 concise recommendations phrased as imperatives (e.g., “Pause for two seconds after each key term”)
-
-Keep language clear, balanced, and oriented toward formative growth.
-Critique my presentation freely and avoid sycophancy. I crave honest appraisal.</code></pre>
-
-<h4>Webcam Presentation Video</h4>
-
-<pre>
-<code>**Role:** You are an expert academic presentation coach.
-**Task:** Your task is to evaluate the attached video of a presenter giving a webcam presentation and provide constructive, formative feedback to the presenter. 
-Disregard slide design, background graphics, or the academic content itself.
-
-**What to observe**
-1. **Camera Presence** – eye contact with lens, framing (eye-level, head-and-shoulders view), facial expressiveness.
-2. **Audio &amp; Vocal Delivery** – audibility, enunciation, vocal variety, clarity, volume, pacing, vocal variety, strategic pauses, filler word frequency, absence of distracting background noise.
-3. **Body Language On-Camera** – posture, visible gestures within frame, avoidance of slouching, minimize looking off-screen.
-4. **Virtual Engagement** – use of chat, polls, name-checks, response to participant cues, inviting interaction every few minutes.
-5. **Energy &amp; Presence** – enthusiasm, conversational tone, natural smiles, smooth transitions between topics or slides.
-
-**Output format**
-- **Summary (≤ 2 sentences)** – overarching impression of delivery and engagement.
-- **What Was Done Well** – 4-6 bullet points, each starting with a strong verb and including an optional timestamp (HH:MM:SS) showing where it occurred.
-- **Ways to Improve** – 4-6 bullet points with constructive, specific suggestions; include optional timestamps.
-- **Actionable Tips** – 3 concise recommendations phrased as imperatives (e.g., “Pause for two seconds after each key term”)
-
-Keep language clear, balanced, and oriented toward formative growth.
-Critique my presentation freely and avoid sycophancy. I crave honest appraisal.</code></pre>
-
-<h3><i></i>Pause &amp; Ponder</h3>
-
-<ol>
-	<li>Review the AI&#x27;s feedback. Did it identify any habits you were unaware of (e.g., using &quot;um&quot; frequently, speaking too quickly)?</li>
-	<li>Which pieces of feedback are the most actionable? What specific strategy can you use to address it in your next practice run?</li>
-	<li>Did any of the feedback seem inaccurate or not useful? Why might the AI have misinterpreted your delivery (e.g., mistaking a purposeful pause for hesitation)? (This helps you practice evaluative judgment)</li>
-</ol>
-
-<div>
-<h5><i></i>Notes for Instructors</h5>
-
-<p>If you are going to do this activity in your class, here are some suggestions:</p>
-
-<ul>
-	<li>This activity can be good for a PAIRR type framework. AI gives feedback, peer gives feedback, presenter takes feedback from both and adjusts.</li>
-	<li>Require a reflection on the process</li>
-</ul>
-</div>
-</div>
-</details>
-</div>
-</div>
-
-<hr>
-<div>
-<h2><i></i>Practicing for High-Stakes Conversations</h2>
-
-<p>AI can not only take on a role in a text interaction, but it can also take on a role while taking advantage of the voice mode available in many generative AI tools. In this way, you can simulate interviews, negotiations, or other challenging conversations. The goal is to build your confidence and mental scripts so you can perform more effectively when it counts.</p>
-
-<div>
-<p><i></i><strong>Note on AI Tools:</strong> Many specialized apps exist for this. However, a general chatbot (like ChatGPT, Claude, or Perplexity) in &quot;voice mode&quot; can be highly effective and flexible. You have more control over the scenario by simply giving the AI a clear persona and context through your prompt.</p>
-</div>
-
-<div>
-<p><i></i><strong>Note on Prompting:</strong> The key to a good simulation is a good prompt. You can and should direct the AI to adopt a specific role (e.g., &quot;a skeptical hiring manager,&quot; &quot;a collaborative potential business partner&quot;). For extra effectiveness, add constraints to practice specific things (e.g., to be prepared for ad hominem attacks, include &quot;In this negotiation, you [the AI] must act belligerent and insulting&quot;).</p>
-</div>
-
-<div>
-<details><summary> <i></i> <span>Conversation Activity 1: The Scenario Simulator</span> </summary>
-
-<div>
-<div>
-<h4><i></i>Purpose</h4>
-
-<p>To design a custom role-play prompt to simulate a challenging conversation, allowing you to practice your approach, anticipate responses, and get targeted feedback.</p>
-
-<h4><i></i>Task</h4>
-
-<p>You will define a scenario, build a detailed prompt to put the AI into a specific role, run the simulation via voice or text, and then ask the AI to provide feedback on your performance.</p>
-</div>
-
-<p><strong>Example Scenarios:</strong></p>
-
-<ul>
-	<li>A job interview for a specific role</li>
-	<li>Negotiating a project deadline with a professor</li>
-	<li>A sales pitch for a new product</li>
-</ul>
-
-<h3><i></i>Dive-in &amp; Do It</h3>
-
-<h4>Use your brain first:</h4>
-
-<ol>
-	<li><strong>Choose Your Scenario:</strong> Select a specific, challenging conversation you want to practice.</li>
-	<li><strong>Define Your Goal:</strong> What is your ideal outcome for this conversation? Be specific. (e.g., &quot;To convince the hiring manager I am the best candidate by highlighting my project management skills,&quot; &quot;To get a 48-hour extension on the paper.&quot;).</li>
-	<li><strong>Build the role playing persona for the AI:</strong> Build a realistic professional persona for the AI to play. Focus on role-related facts: the person’s job title, expertise, goals, typical pain points, decision criteria, and communication style. Add any situational constraints (tight budget, looming deadline, strict policy) that will shape the conversation. Avoid specifying personal characteristics—such as race, gender, religion, or other traits like these unless they are genuinely essential to the scenario and handled with care. It&#x27;s also a good idea here to bring in course specific things that will tie this simulation scenario to the learning outcomes you are practicing.</li>
-	<li><strong>Build a comprehensive prompt to create persona and to set the scenario.</strong> This example creates the persona of an angel investor who is willing to listen to a sales pitch about an electronic pencil.</li>
-</ol>
-
-<pre>
-<code>Together, we are going to simulate a sales pitch situation. I am trying to pitch my idea for an electronic pencil and you are going to role-play as a seasoned angel investor. 
-
-**Role-play brief:**  
-You are **Jordan Patel**, a seasoned angel investor known for backing early-stage consumer-electronics ideas that blend hardware and software. Over the past decade you’ve invested in more than 30 seed-stage startups, with 5 successful exits in ed-tech peripherals and creative-tool accessories.
-
-**Profile &amp; investment lens**
-- Background – Former product-design lead at a Fortune 500 company; holds an MBA (operations) and a B.Eng. in electrical engineering.
-- Ticket size – USD $100 k – $500 k for 10-20 % equity; reserves follow-on capital for winners.
-- Sweet spot –  productivity hardware, and IoT learning tools.
-- Deal filters – Clear technical moat, credible supply-chain plan, 40 %+ gross margin at scale, evidence of user love.
-- Temperament – Inquisitive, data-driven, constructive; expects founders to know their numbers and their customer.
-
-**Conversation style**
-1. Begin by inviting the founder to give a concise (≤ 3 min) overview of the concept.
-2. After the pitch, ask probing questions on:
-    - Problem-solution fit &amp; user pain
-    - Total addressable market and early-adopter segment
-    - Unique technology / IP and defensibility
-    - Unit economics, BOM, and gross-margin roadmap
-    - Go-to-market plan (channels, partnerships, pricing)
-    - Competitive landscape (Apple Pencil, reMarkable stylus, etc.)
-    - Team competence and execution milestones
-3. Provide immediate, candid feedback—highlight strengths first, then the top improvement areas.
-4. Conclude with one of three outcomes:
-    - **Pass** – state key reservation(s).
-    - **More info needed** – request specific data or milestones.
-    - **Soft yes** – outline next-step diligence and potential terms.
-
-**Tone &amp; constraints**
-- Stay in character as Jordan Patel throughout. THIS IS VERY IMPORTANT
-- Keep language conversational yet professional; no “advisor” disclaimers.
-- Give balanced feedback—mix encouragement with rigorous scrutiny.
-- Avoid filler; every question or comment should push the founder toward clarity or evidence.</code></pre>
-
-<h4>AI Input:</h4>
-
-<p>I have only tested this with ChatGPT Plus. The advanced voice mode in the free version of ChatGPT may not be sufficient to have a long conversations. Gemini Live, which is Gemini&#x27;s voice mode, is currently only available on Android devices (July 2025).</p>
-
-<ol start="5">
-	<li>Copy and paste the prompt into ChatGPT and wait for its response.</li>
-	<li>Click on the &quot;Use Voice Mode&quot; button in the chat window and start interacting with the persona. Do your sales pitch, start answering interview questions, plead for an extension...whatever it is that you set.
-	<div><img alt="Screenshot of a chatbot interface showing the location of the voice mode button, which looks like a soundwave icon." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/VoiceModeButton.png"></div>
-	</li>
-	<li><strong>Handling AI Errors:</strong> If the AI forgets its role (&quot;persona drift&quot;) or starts making things up (&quot;confabulation&quot;), gently correct it. You can say, &quot;Remember, you are the hiring manager. Let&#x27;s get back to the interview questions,&quot; to steer it back on track. If this persona drift gets bad (i.e., the AI no longer acts like it&#x27;s in the simulation) you may need to start over.</li>
-	<li><strong>Ask for Feedback:</strong> Once the role-play is complete, use a second prompt to shift the AI from the simulation role to a coach role.</li>
-</ol>
-
-<h4>Debrief Prompt:</h4>
-
-<pre>
-<code>The role-play/simulation is now over. Stop acting as the persona of [persona name here]. Now, act as a helpful communication coach. Evaluate the conversation based on the following criteria
-[add criteria here based on rubric or criteria from your class for this type of scenario]
-
-**Output format*
-- **Summary (≤ 2 sentences)** – overarching impression of the my [sales pitch or interview or ...].
-- **What Was Done Well** – 4-6 bullet points, each starting with a strong verb and indicating where in the simulation it occurred.
-- **Ways to Improve** – 4-6 bullet points with constructive, specific suggestions
-- **Actionable Tips** – 3 concise recommendations phrased as imperatives 
-
-Keep language clear, balanced, and oriented toward formative growth.
-Critique my interaction freely and avoid sycophancy. I crave honest appraisal.</code></pre>
-
-<h3><i></i>Pause &amp; Ponder</h3>
-
-<ol>
-	<li>During the role-play, when did you feel most confident? When did you feel unsure? What caused that feeling?</li>
-	<li>Review the AI&#x27;s feedback from the &quot;Debrief Prompt.&quot; Is the feedback specific and actionable? How does it align with your own perception of your performance?</li>
-	<li>How would you change your initial prompt to create a different or more challenging simulation next time? (e.g., change the AI&#x27;s persona, add a new objective).</li>
-</ol>
-
-<div>
-<h5><i></i>Notes for Instructors</h5>
-
-<p>If you are going to do this activity in your class, here are some suggestions:</p>
-
-<ul>
-	<li>Require a reflection on the process. The reflection can look at how level of persona detail shapes simulation realism.</li>
-	<li>Student judges whether AI’s feedback aligns with course rubric.</li>
-	<li>Discuss bias—e.g., does the AI adopt stereotypes when asked to be “belligerent negotiator”?</li>
-</ul>
-</div>
-</div>
-</details>
-</div>
-</div>
-
-<hr>
-<div>
-<h2><i></i>Supporting Language Learning</h2>
-
-<p>Generative AI can be a patient tutor and on-demand practice partner for language learning by providing instant explanations and limitless drills. <strong>It is not, however, a substitute for real human interaction.</strong> Native speakers and trained instructors adjust their speed, notice confusion in real time, and model cultural nuance which are areas where AI is still error-prone.</p>
-
-<p><a href="https://www.cambridge.org/core/elements/generative-artificial-intelligence-and-language-teaching/DD0BFB0E89E500723D033B1EEB025F01" target="_blank">Learn More</a></p>
-
-<div>
-<p><i></i><strong>AI ≠ Live Conversation Partner.</strong> AI may mistranslate idioms or omit cultural context. It can’t read facial expressions or hear hesitation. Always double-check important points with reliable dictionaries, grammar guides, or native speakers.</p>
-</div>
-
-<div>
-<details><summary> <i></i> <span>Language Learning Activity 1: Foundational Drills</span> </summary>
-
-<div>
-<p>Use AI for quick language learning exercises.</p>
-
-<ol>
-	<li><strong>Grammar Guru:</strong> Identify a specific grammar concept or vocabulary word you are struggling with and use an AI to get explanations, examples, and practice sentences.<br>
-	<em>e.g. Act as a German grammar tutor. Explain the dative case to me like I&#x27;m a beginner. Give me five distinct example sentences and then create a 3-question mini-quiz to test my understanding</em></li>
-	<li><strong>Dialogue Deconstruction:</strong> Prompt the AI to generate a short dialog in your language of choice. Read through and understand the dialogue. Go even further does this dialogue seem authentic, or does the AI make it seem less natural?<br>
-	<em>e.g. Write a short, natural-sounding dialogue in French between a tourist and a shopkeeper. The tourist is asking when the shop closes</em></li>
-	<li><strong>Vocabulary Builder:</strong><br>
-	<em>e.g. Act as a language learning assistant. For the following list of words, create one example sentence for each that clearly shows its meaning in context. Then, create simple English definitions for each that I can use for flashcards</em></li>
-	<li>Create a one-minute AI exercise, try it, then trade prompts with a classmate.</li>
-	<li>Your ideas...</li>
-</ol>
-
-<h3><i></i>Pause &amp; Ponder</h3>
-
-<ol>
-	<li>Did the AI&#x27;s explanation clarify the concept better than your textbook or other resources? What was different about its approach?</li>
-	<li>How could you verify the accuracy of the AI&#x27;s information? (e.g., checking a trusted grammar website, asking your instructor).</li>
-</ol>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Language Learning Activity 2: Written Conversation</span> </summary>
-
-<div>
-<p>Use this activity to practice constructing sentences and maintaining a conversation in writing, with the AI acting as a corrective partner.</p>
-
-<ol>
-	<li><strong>Set the Scene:</strong> Start by giving the AI a role, a context, and a clear instruction.<br>
-	<strong>Example Prompt:</strong> <em>&quot;I want to practice my written Italian. Let&#x27;s have a conversation where you are a barista in a café in Rome, and I am a customer ordering a coffee and a pastry. Please correct any grammatical mistakes I make in my responses.&quot;</em></li>
-	<li><strong>Initiate the Conversation:</strong> Begin the role-play in your target language. Don&#x27;t worry about being perfect; the goal is to produce language.</li>
-	<li><strong>Review and Refine:</strong> After each AI response that includes a correction, analyze it. Do you understand the mistake you made? If not, ask for a clarification (e.g., <em>&quot;Can you explain why I should use &#x27;il&#x27; instead of &#x27;lo&#x27; in that sentence?&quot;</em>). This turns a simple exchange into a targeted grammar lesson.</li>
-</ol>
-
-<div>
-<h5><i></i>Guidance for Instructors</h5>
-
-<p>This activity is best positioned as low-stakes, outside-of-class practice (in-class, you have a roomful of peers and experts to engage with instead). Encourage students to use it to build confidence before interacting with real speakers.</p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Language Learning Activity 3: Verbal Conversation</span> </summary>
-
-<div>
-<p>Use the voice function on an AI tool (like the ChatGPT mobile app) to practice real-time speaking and listening comprehension. This is excellent for building conversational confidence.</p>
-
-<ol>
-	<li><strong>Activate Voice Mode:</strong> Open your AI tool (ChatGPT) on a device with a microphone and activate its conversation mode.
-
-	<div><img alt="Screenshot of a chatbot interface showing the location of the voice mode button, which looks like a soundwave icon." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/VoiceModeButton.png"></div>
-	</li>
-	<li><strong>Set the Scene (Verbally):</strong> Just like the written activity, start by giving the AI a role and context by speaking to it.<br>
-	<strong>Example Verbal Prompt:</strong> <em>&quot;Let&#x27;s speak in Japanese. You are a new colleague at my office, and we are meeting for the first time. Please speak clearly and at a moderate pace.&quot;</em></li>
-</ol>
-
-<details><summary> <i></i> <span>You can make it fun with details and a backstory</span> </summary>
-
-<div>
-<pre>
-<code>We will role-play a scenario in a classic Parisian brasserie. I am an english-speaking tourist attempting to order lunch in French. you will role-play as the waiter. the entire conversation MUST be in French.
-You are Luc, a career waiter in your late 40s at &quot;Brasserie Vaudeville,&quot; a respectable but perpetually busy establishment in the 6th arrondissement. You are NOT a caricature of a rude Frenchman. You are a consummate professional who is simply very good at your job, deeply proud of your establishment, and has zero patience for anything that disrupts the brasserie&#x27;s efficient, traditional rhythm.
-Your &quot;rudeness&quot; is not malice. it is a byproduct of your professional standards and weariness with tourists who don&#x27;t understand the local customs.
-
-**rules of engagement &amp; behavior:**
-1. **efficiency is god:** your primary goal is to take the order and serve the food with maximum efficiency. any hesitation, indecision, or unnecessary questions from me are obstacles to this goal.
-2. **subtle condescension:** you will not insult me directly. instead, your disapproval will be communicated through:  
-	- **brevity:** your responses should be clipped and formal. use &quot;vous.&quot;
-    - **corrective repetition:** if i mispronounce a menu item, repeat it back to me with the correct pronunciation, but without any warmth. e.g., if i say &quot;croak mon-soor,&quot; you will respond flatly, &quot;_un croque-monsieur. et avec ça?_&quot;
-    - **feigned ignorance:** if i ask for something inappropriate (e.g., ice in my water, ketchup, a well-done steak), you will pretend not to understand at first. if i insist, you will respond with a simple, unadorned &quot;_non, ce n&#x27;est pas possible._&quot; do not explain why.
-    - **the sigh:** you are permitted to deploy one, maybe two, subtle, world-weary sighs, particularly if i ask silly questions
-
-Stay in character: this is CRITICAL. Do not break character!. Do not become friendly if i am polite. your professional demeanor is unshakeable. yYu will only become slightly less frosty if I conduct the entire transaction flawlessly in perfect, confident french.
-
-The scene is the lunch rush. It is loud and crowded. I have been seated for five minutes with the menu. You will approach my table, place a basket of bread down without making eye contact, and initiate the conversation by asking, &quot;_vous avez choisi?_&quot;</code></pre>
-</div>
-</details>
-
-<ol start="3">
-	<li><strong>Control the Pace and Complexity:</strong> The AI won&#x27;t know if you&#x27;re lost unless you tell it. Use these commands whenever you need to adjust.<br>
-	<em>&quot;parle plus lentement, s’il te plaît&quot; (speak more slowly please)</em><br>
-	To simplify: <em>&quot;utilise des mots plus simples, s’il te plaît&quot; (use simpler words please)</em></li>
-	<li><strong>Focus on Listening and Responding:</strong> The goal here is comprehension and response, don&#x27;t worry about perfection. Try to keep the conversation going. If you get stuck, it&#x27;s okay to ask the AI in English for a word or phrase, then repeat it in the target language to continue the volley.</li>
-</ol>
-
-<div>
-<h5><i></i>Guidance for Instructors</h5>
-
-<p>This activity is best positioned as low-stakes, outside-of-class practice (in-class, you have a roomful of peers and experts to engage with instead). Encourage students to use it to build confidence before interacting with real speakers.</p>
-</div>
-</div>
-</details>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>AI Study Buddy &amp; Skill Builder</h2>
+            <div>
+
+            <div>
+            <div>
+            <h1><i></i> Using AI for Deeper Learning</h1>
+
+            <p>Transform AI from a simple Q&amp;A machine into your personal learning support</p>
+
+            <div><img alt="Human chessplayer beating a silicon king" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_Image_Jun_24__2025__02_56_37_PM.png"></div>
+            </div>
+
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Moving Beyond Information Retrieval</h2>
+            <p>This is a shifting from asking AI for facts to engaging it in a dialogue. We&#x27;re not just typing &quot;What is photosynthesis?&quot; anymore. Instead, we&#x27;re exploring how AI can:</p>
+
+            <ul>
+            	<li>Explain complex concepts in multiple ways until they click</li>
+            	<li>Generate study material tailored to your specific needs</li>
+            	<li>Provide feedback on your work (with appropriate caveats)</li>
+            	<li>Help organize your study plans </li>
+            </ul>
+
+            <p>You can use AI to <em>actively engage</em> with your learning material and skill development, not just passively give you information.</p>
+
+            <p><i></i>  Remember our &quot;Weightlifting vs. Forklifting&quot; analogy? This section is firmly in the <strong>weightlifting camp</strong>. The AI tools and techniques we&#x27;ll explore are designed to help <em>you</em> do the intellectual heavy lifting.</p>
+
+            <div>
+            <h5><i></i>Think of it this way:</h5>
+
+            <p>AI provides the resistance, the feedback, and the support that helps you build your mental muscles—your understanding, your critical thinking, and your skills. AI isn&#x27;t here to do the work <em>for</em> you, but to help you do your work <em>better</em> and learn more deeply in the process.</p>
+            </div>
+            </div>
+
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>The Unwavering Importance of Your Critical Thinking</h2>
+            <p>It might seem like we are <strong>on repeat </strong>with this critical thinking stuff but it truly bears repeating and repeating and repeating. Generative AI is powerful but not infallible and your brain is the only protection against its weaknesses.</p>
+
+            <p>It can:</p>
+
+            <ul>
+            	<li>Make mistakes (aka &quot;hallucinations&quot; - I prefer &quot;<a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5127162" target="_blank">mirage</a>&quot;)</li>
+            	<li>Reflect biases present in its training data</li>
+            	<li>Lack the nuance or specific context required for your academic work</li>
+            </ul>
+
+            <p>Therefore, anything an AI generates must be treated as a draft, a suggestion, or a piece of raw material that <em>you</em> need to process.</p>
+
+            <h3><i></i>You Are the Driver</h3>
+
+            <p>Your critical thinking skills need to take the wheel. You are in control, which means:</p>
+
+            <div>
+            <div>
+            <h3><i></i>Questioning</h3>
+
+            <ul>
+            	<li>Does this make sense?</li>
+            	<li>Is it accurate?</li>
+            	<li>Is it relevant?</li>
+            	<li>Is it complete?</li>
+            </ul>
+            </div>
+
+            <div>
+            <h3><i></i>Verifying</h3>
+
+            <ul>
+            	<li>Cross-reference with trusted sources</li>
+            	<li>Check factual claims</li>
+            	<li>Validate critical concepts</li>
+            </ul>
+            </div>
+
+            <div>
+            <h3><i></i>Synthesizing &amp; Deciding</h3>
+
+            <ul>
+            	<li>Combine AI suggestions with your knowledge</li>
+            	<li>Decide what to use or discard</li>
+            	<li>Modify outputs to meet your needs</li>
+            </ul>
+            </div>
+            </div>
+
+            <div>
+            <h5><i></i>Connection to AI Literacy Pillars</h5>
+
+            <p>Your ability to do this effectively is central to developing <strong>Evaluative Judgement</strong>, a core pillar of AI literacy. It also draws on your <strong>Technical Understanding</strong> (knowing AI&#x27;s limitations) and reinforces <strong>Ethical Awareness</strong> (recognizing the responsibility that comes with using these powerful, yet imperfect, tools).</p>
+            </div>
+            </div>
+
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Learning Objectives for This Section</h2>
+            <p>When you complete this section and engage with all of the activities, you will have demonstrated your ability to:</p>
+
+            <ol>
+            	<li><strong>Strategically use appropriate AI tools for academic tasks,</strong> while critically evaluating their outputs for relevance, accuracy, bias, and limitations.</li>
+            	<li><strong>Design effective prompts for AI study support</strong> and responsibly integrate its assistance, upholding academic integrity principles and your authentic voice.</li>
+            	<li><strong>Partner with AI to develop academic skills</strong> (such as critical thinking, writing, and communication) and manage your learning, actively directing AI to meet your individual goals.</li>
+            </ol>
+            </div>
+
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>How This Section is Structured</h2>
+            <p>To help you achieve these objectives, this section is organized into six distinct modules, each focusing on a different way AI can act as your constructive partner:</p>
+
+            <div>
+            <h4><i></i> Module 1: AI for Mastering Concepts &amp; Deepening Knowledge</h4>
+
+            <p>We&#x27;ll start by exploring how AI can help you truly grasp difficult ideas and create personalized practice opportunities.</p>
+            </div>
+
+            <div>
+            <h4><i></i> Module 2: AI as Your Critical Thinking Partner</h4>
+
+            <p>Learn to use AI to challenge your assumptions, refine your arguments, and see issues from multiple perspectives.</p>
+            </div>
+
+            <div>
+            <h4><i></i> Module 3: AI for Honing Communication Skills (Beyond Writing)</h4>
+
+            <p>Discover how AI can support you in developing your presentation skills and even assist in language learning.</p>
+            </div>
+
+            <div>
+            <h4><i></i> Module 4: AI for Personalized Study Management &amp; Information Organization</h4>
+
+            <p>Learn how AI can help you tailor your study plans and manage your academic information more effectively.</p>
+            </div>
+
+            <div>
+            <h4><i></i> Module 5: Other AI Study Techniques</h4>
+
+            <p>Finally, we&#x27;ll touch upon some other uses that don&#x27;t really fit any of the categories above, always with a strong emphasis on critical evaluation and understanding AI&#x27;s limitations.</p>
+            </div>
+
+            <div>
+            <p><i></i> <strong>Ready to work?</strong> In these sections, you are going to actively experiment, critically reflect, and discover new ways to enhance your learning journey with AI as your study buddy and skill builder!</p>
+            </div>
+            </div>
+            </div>
+
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div>
+            <p>Your instructor is your most valuable resource for understanding course material. They are the expert who can clarify confusion, correct misconceptions, and guide your learning. But, they can&#x27;t be available 24/7, and sometimes you need help at 11 PM the night before an exam, or you&#x27;re stuck on a concept during weekend study sessions.</p>
+
+            <p>AI can be an always-available, but slightly fallible study partner. It&#x27;s a supplementary resource that&#x27;s there whenever you need to work through difficult concepts, generate practice materials, or test your understanding. AI won&#x27;t replace your instructor&#x27;s expertise, but it can help you prepare better questions for office hours, practice explaining concepts, and build confidence between classes.</p>
+
+            <p>This module shows you how to use AI as a learning amplifier, helping you understand difficult material from multiple angles and create personalized study tools.</p>
+
+            <div>
+            <p><i></i><strong>Remember: Your instructor is your best resource.</strong> When you&#x27;re unsure about AI&#x27;s explanations or need authoritative clarification, your instructor remains your go-to source for confirming your understanding. Use AI to explore and practice, then verify with your instructor when it matters.</p>
+            </div>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>1. Unpacking Complex Ideas</h2>
+            <p>When textbook explanations leave you puzzled, AI can offer fresh perspectives. These techniques help you break through conceptual barriers by approaching difficult ideas from multiple angles.</p>
+
+            <div>
+            <details><summary> <i></i> <span>Activity 1.1: AI as a Tutor (Basic Prompt)</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Choose a challenging concept from your current studies. Use AI to generate multiple explanations and analogies that help you understand it better. This technique helps you find the explanation style that clicks with your learning preferences.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do</h4>
+
+            <p>Start with a basic request, then ask for variations. Here are example prompts to try:</p>
+
+            <pre>
+            <code>Explain [concept] in three different ways: once using everyday language, 
+            once using a real-world analogy, and once step-by-step.</code></pre>
+
+            <pre>
+            <code>I&#x27;m struggling to understand [concept]. Can you explain it using 
+            an analogy from [sports/cooking/music/another familiar domain]?</code></pre>
+
+            <pre>
+            <code>Explain [concept] as if I&#x27;m a smart 12-year-old who has never 
+            heard of it before.</code></pre>
+
+            <p><strong>Pro tip:</strong> If the first explanation doesn&#x27;t help, ask AI to try a completely different approach: &quot;That didn&#x27;t quite click. Can you explain it from a totally different angle?&quot;</p>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <p>Before accepting any explanation, critically evaluate what AI provided:</p>
+
+            <ul>
+            	<li><strong>Accuracy check:</strong> Do the analogies actually match the concept, or do they break down? Sometimes AI creates analogies that sound good but miss key aspects.</li>
+            	<li><strong>Complexity balance:</strong> Did AI oversimplify and lose important nuances? Or did it add unnecessary jargon?</li>
+            	<li><strong>Personal fit:</strong> Which explanation style worked best for you? Visual? Sequential? Comparative?</li>
+            </ul>
+
+            <p><em>Red flag to watch for:</em> AI sometimes invents plausible-sounding but incorrect explanations. Always verify with your course materials!</p>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>AI excels at providing multiple perspectives on the same concept. Use this strength to find explanations that match your learning style, but always verify accuracy against trusted sources.</p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Activity 1.2: AI as a Tutor (Comprehensive Prompt)</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Transform AI into a personalized tutor that adapts to your learning level and guides you through understanding a topic step-by-step. This structured approach helps you build understanding through dialogue rather than passive consumption.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do</h4>
+
+            <p>Use this comprehensive prompt to activate AI&#x27;s tutoring mode:</p>
+
+            <pre>
+            <code>
+            										GOAL: This is a tutoring exercise in which you play the role of AI tutor and you will help a student learn more about a topic of their choice. Your goal is to improve understanding and to challenge students to construct their own knowledge via open ended questions, hints, tailored explanations, and examples.
+            PERSONA: In this scenario you play AI tutor an upbeat and practical tutor. You have high expectations for the student and believe in the student’s ability to learn and improve.
+            NARRATIVE: The student is introduced to AI tutor, who asks a set of initial questions to understand what the student wants to learn, the student’s learning level and prior knowledge about the topic. The tutor then guides and supports the student and helps them learn about the topic. The tutor only wraps up the conversation once the student shows evidence of understanding: the student can explain something in their own words, can connect an example to a concept, or can apply a concept given a new situation or problem.  
+
+            Follow these steps in order:
+
+            STEP 1: GATHER INFORMATION 
+            You should do this: 
+            1.Introduce yourself: First introduce yourself to the student and tell the student you’re here to help them better understand a topic.
+            2.Ask students to answer the following questions. Ask these questions 1 at a time and always wait for a response before moving on to the next question. For instance, you might ask “What would you like to learn about and why” and the student would respond with a topic. And only then would you say “That sounds interesting! I have another question for you to help me help you: What is your learning level…”.  This part of the conversations works best when you and the student take turns asking and answering questions instead of you asking a series of questions all at once. That way you can have more of a natural dialogue.
+            •	What would you like to learn about and why? And wait for the student to respond before moving on.
+            •	What is your learning level: high school student, college student, or a professional? And wait for the student to respond before moving on.
+            •	What do you already know about the topic? And wait for the student to respond before moving on.
+            You should do this:
+            •	Wait for a response from the student after every question before moving on. 
+            •	Work to ascertain what the student wants to learn specifically. 
+            •	Ask one question at a time and explain that you’re asking so that you can tailor your explanation.
+            •	Gauge what the student already knows so that you can adapt your explanations and questions moving forward based on their prior knowledge.
+            Don’t do this:
+            •	Start explaining right away before you gather this information.
+            •	Ask the student more than 1 question at a time.
+
+            Next step: Once you have the information you need move on to the next step and begin with a brief explanation.
+
+            STEP 2: BEGIN TUTORING THE STUDENT, ADAPTING TO THEIR RESPONSES 
+            You should do this: 
+            1.Look up information about the topic. 
+            2.Think step by step and make a plan based on the learning goal of the conversation. Now that you know a little bit about what the student knows consider how you will:
+            3.Guide the student in an open-ended way
+            4.Help the student generate answers by asking leading questions and providing hints when necessary.
+            4.Remind the student of their learning goal, if appropriate
+            5.Provide explanations, examples, and analogies 
+            6.Break up the topic into smaller chunks, going over those first and only then leading up to the larger task or idea.
+            6.Tailor your responses and questions to the student&#x27;s learning level and prior knowledge; this will change as the conversation progresses. 
+            7.When pushing the student for information, try to end your responses with a question so that the student has to keep generating ideas. 
+
+            Once the student shows improvement, ask the student to:
+            •	Explain the concept in their own words.
+            •	Articulate the underlying principles of a concept.
+            •	Provide examples of the concept and explain how those connect to the concept.
+            •	Give them a new problem or situation and ask them to apply the concept
+            Don’t do this:
+            •	Provide immediate answers or solutions to problems.
+            •	Give the student the answer when asked.
+            •	Ask the student if they understand, follow or needs more help – this is not a good strategy as they may not know if they understand.
+            •	Lose track of the learning goal and discuss something else.
+
+            Next step: Once the student demonstrates understanding move to wrap up.
+            STEP 2: WRAP UP 
+            You should do this: 
+            1.When the student demonstrates that they know the concept, you can move the conversation to a close and tell them you’re here to help if they have further questions. 
+            									</code></pre>
+
+            <p>This tutoring prompt is adapted from work by Lilach Mollick and Ethan Mollick, licensed under <a href="https://creativecommons.org/licenses/by/4.0/" rel="noopener noreferrer" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p>
+
+            <p><strong>Engagement tip:</strong> Answer the tutor&#x27;s questions honestly about what you know and don&#x27;t know. The more specific you are, the better the tutoring experience.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Adaptation quality:</strong> Did the AI tutor actually adjust its explanations based on your stated level and prior knowledge?</li>
+            	<li><strong>Question effectiveness:</strong> Were the tutor&#x27;s questions helpful in guiding your thinking, or were they too leading/too vague?</li>
+            	<li><strong>Learning progress:</strong> Did this conversational approach help you understand better than just reading an explanation? Why or why not?</li>
+            	<li><strong>Accuracy check:</strong> Were there any moments where the AI tutor provided incorrect information or misleading guidance?</li>
+            	<li><strong>Prompt Comparison:</strong>If you tried both the basic and the comprehensive prompt, which did you prefer? Why?</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>AI can simulate a tutoring experience that adapts to your needs, but it lacks the true understanding and expertise of a human tutor. Use it for practice and exploration, but remember it&#x27;s a simulation, not a replacement for real instruction.</p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Activity 1.3: Now You Tutor the AI</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Test your understanding by explaining a concept in simple terms to AI, then get feedback on your explanation. This technique is sometimes called the Feynman Technique (named after physicist Richard Feynman). It can help reveal gaps in your knowledge and strengthens your grasp of the material.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do</h4>
+
+            <p>Choose one of these approaches:</p>
+
+            <p><strong>Option 1: Basic</strong></p>
+
+            <pre>
+            <code>
+            										I&#x27;m going to explain [concept] to you. Please act like an intelligent but curious person who knows nothing about this topic. Ask me clarifying questions if my explanation isn&#x27;t clear or complete.
+            									</code></pre>
+
+            <p><strong>Option 2: In-depth</strong></p>
+
+            <pre>
+            <code>
+            										GOAL: This is a role-playing scenario in which the user (student) practices teaching a concept or topic to a novice student (you)
+            PERSONA: In this scenario you play AI Mentor, a friendly and practical mentor.
+            NARRATIVE: The student is introduced to AI Mentor, is asked initial questions which guide the scenario set up, plays through the scene helping a novice student understand a concept, and then gets feedback following the teaching exercise.  
+
+            Follow these steps in order:
+
+            STEP 1: GATHER INFORMATION 
+            You should do this: 
+            1.Let students know that you’ll be playing the role of student based on their preferences and that their job is to guide you (a student new to a topic) explain the topic and answer your questions.
+            2. Tell the student you can play either one of two roles: you can be their chatty and inquisitive student or their skeptical and bemused (their choice). Present these choices via numbers and wait for the student to choose a number.
+            You should not do this: 
+            •	Ask more than 1 question at a time
+            •	Mention the steps to the user ie do not say “what I’ll do next is..”
+
+            Next step: Move on to the next step when you have the information you need.
+
+            STEP 2: SET UP ROLEPLAY
+            1.Ask the student what topic they would like to teach you: Once the student shares this with you, then suggest declare LET’S BEGIN and dive into your role 
+            Context for step 2: As a student new to a topic, you don&#x27;t understand jargon and your job is to draw out a thorough explanation, and lots of examples. You do not have any prior knowledge of the topic whatsoever. You ask questions that challenge the teacher to clearly explain the topic. Ask just one question at a time as a student. You can also make a mistake or misunderstand the teacher once during the interaction, if applicable. As a student you might ask the teacher to clarify, to explain their approach, to give an example; to explain a real world connection or implication e.g. why is this important? What would happen if..? 
+            You should do this:
+            1.Lean into whichever role you are playing e.g., as an inquisitive student play that up by asking questions large and small; as a skeptical student drily challenge the teacher to create effective explanations. 
+            2.After 5-6 interactions declare LESSON COMPLETE
+            3.If a student asks you to explain something to them during the lesson remember to act like a novice to the topic with little prior knowledge. Turn the question back to them.
+            You should not do this: 
+            •	Ask more than 1 question at a time
+            •	Learn too quickly: it’s ok to struggle with the material
+            •	Describe your own behavior
+            •	Explain anything to the student; it’s their job to explain to you as you are the student
+
+            Next step: Move on to the next step after you declare LESSON COMPLETE and then give the student feedback on their teaching and explanation. 
+
+            STEP 3: FEEDBACK
+            You should do this:
+            1.As soon as the role play is over, you can explain that teaching someone else can help them organize information and highlight any gaps in their knowledge. 
+            2.Ask the user to take a look at the conversation they had with their student and ask: what question might you ask to check that you AI student understood what you taught them. Please explain your thinking. 
+            3.Then, wrap up the conversation but tell the student that you are happy to keep talking.
+            You shouldn’t do this:
+            •	Respond for the student and answer the reflection question. 
+            •	Give the student suggestions to answer that final question. 
+
+            									</code></pre>
+
+            <p>This tutoring prompt is adapted from work by Lilach Mollick and Ethan Mollick, licensed under <a href="https://creativecommons.org/licenses/by/4.0/" rel="noopener noreferrer" target="_blank">Creative Commons Attribution 4.0 International License</a>.</p>
+
+            <p><strong>Iteration tip:</strong> If AI&#x27;s initial feedback is too generic, ask for specifics: &quot;What specific part of my explanation was unclear?&quot; or &quot;What key aspect of [concept] did I miss?&quot;</p>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Question quality:</strong> Were AI&#x27;s &quot;novice&quot; questions actually helpful, or were they random? Good questions should target unclear parts of your explanation.</li>
+            	<li><strong>Feedback value:</strong> Did AI&#x27;s evaluation help you identify real gaps, or was it too vague? Look for specific, actionable feedback.</li>
+            	<li><strong>Your growth:</strong> What did this exercise reveal about your understanding? Where do you need to review?</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>Teaching forces you to organize and articulate your knowledge. AI provides a patient audience for practice, but the real learning happens when you struggle to explain clearly.</p>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>2. Creating Custom Practice &amp; Self-Assessment Tools</h2>
+            <p>Why settle for generic practice questions when AI can create materials tailored to exactly what you need to study? These activities show you how to generate effective practice tools while maintaining quality control.</p>
+
+            <div>
+            <details><summary> <i></i> <span>Activity 2.1: AI as a Custom Quiz Generator</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Create personalized practice questions on topics you&#x27;re studying. This helps you test your knowledge and identify weak areas before the real exam.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do</h4>
+
+            <p>Be specific about what you want. Example prompts:</p>
+
+            <pre>
+            <code>Create 5 multiple-choice questions about [specific topic] that test understanding, not just memorization. Include answers and explanations.
+            									</code></pre>
+
+            <pre>
+            <code>Generate 3 short-answer questions about [topic] that would appear on a college-level exam. Focus on application, not definitions.</code></pre>
+
+            <pre>
+            <code>Create a practice problem similar to this one: [paste example].Make it different enough to test the same concept in a new way.</code></pre>
+
+            <p><strong>Level-up tip 1:</strong> Ask for questions at different difficulty levels: &quot;Create one basic, one intermediate, and one challenging question about [topic].&quot;</p>
+
+            <p><strong>Level-up tip 2:</strong> Ask your instructor for permission to upload course materials (lecture slides, study guides, readings) to an AI tool. This allows the AI to generate questions and study materials based on your actual course content. <a href="https://notebooklm.google.com/" rel="noopener noreferrer" target="_blank">NotebookLM</a> is particularly good for this—you can upload your course documents and it will create practice questions, summaries, and even study guides directly from your instructor&#x27;s materials.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Question quality:</strong> Are the questions clear and unambiguous? Watch for questions with multiple correct answers or confusing wording.</li>
+            	<li><strong>Answer accuracy:</strong> Verify AI&#x27;s answers against your notes. AI sometimes generates plausible but incorrect answers.</li>
+            	<li><strong>Difficulty alignment:</strong> Do the questions match your course level? Too easy won&#x27;t help; too hard might discourage.</li>
+            	<li><strong>Prompt refinement:</strong> How could you modify your prompt to get better questions next time?</li>
+            </ul>
+
+            <div>
+            <p><i></i> Critical reminder: Always verify AI-generated answers with your course materials. Treat these as practice tools, not authoritative sources.</p>
+            </div>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>AI can quickly generate diverse practice questions, but you&#x27;re the quality controller. The best results come from specific prompts and careful verification.</p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Activity 2.2: Developing Content for Study Aids with AI</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Use AI to help create flashcards, summary sheets, or concept maps. This speeds up study material creation while ensuring you cover all key points.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do</h4>
+
+            <p>Try these targeted prompts:</p>
+
+            <pre>
+            <code>Create flashcard content for [topic]: provide 10 terms with concise,accurate definitions suitable for quick review.</code></pre>
+
+            <pre>
+            <code>List the 5 most important concepts from [topic] and explain how they connect to each other.</code></pre>
+
+            <pre>
+            <code>Generate a study sheet outline for [topic] with main points and 2-3 key details under each.</code></pre>
+
+            <p><strong>Level-up tip:</strong> Ask your instructor for permission to upload course materials (lecture slides, study guides, readings) to an AI tool. This allows the AI to generate questions and study materials based on your actual course content. <a href="https://notebooklm.google.com/" rel="noopener noreferrer" target="_blank">NotebookLM</a> is particularly good for this. You can upload your course documents and it will create practice questions, summaries, and even study guides directly from your instructor&#x27;s materials.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Completeness:</strong> Did AI include all crucial concepts from your lectures/readings? What&#x27;s missing?</li>
+            	<li><strong>Accuracy:</strong> Are the definitions precise? Even small errors can lead to misconceptions.</li>
+            	<li><strong>Usefulness:</strong> Is the content actually helpful for studying, or just a regurgitation of basic facts?</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>AI accelerates study material creation, but the act of reviewing and correcting its output is where much of the learning happens.</p>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Reflection &amp; Synthesis</h2>
+            <p><strong>What you&#x27;ve learned:</strong> AI can be a powerful partner for understanding complex concepts and creating personalized study materials. You&#x27;ve practiced using AI to get multiple explanations, engage in tutoring dialogues, test your understanding, generate practice questions, and build study aids.</p>
+
+            <p><strong>Key insight:</strong> The magic of AI comes out when you know how you prompt, evaluate, and build upon them. Your critical thinking transforms AI output into genuine learning.</p>
+
+            <p><strong>Reflection question:</strong> Think about a concept you&#x27;ve struggled with recently. How might you use these techniques differently now? What&#x27;s one specific way you&#x27;ll incorporate AI into your next study session?</p>
+
+            <p><strong>Remember:</strong> AI is your study amplifier, not your study replacement. The understanding you build is still yours to earn.</p>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div>
+            <p>Critical thinking is the skill that everyone is talking about.</p>
+
+            <div>
+            <p>&quot;We need to ensure students have critical thinking skills when they graduate.&quot;<br>
+            <span>— Teacher 1 (probably)</span></p>
+            </div>
+
+            <div>
+            <p>&quot;I let my students use generative AI, but I make sure that I teach critical thinking too.&quot;<br>
+            <span>— Teacher 2 (likely)</span></p>
+            </div>
+
+            <p>But how do you practice critical thinking yourself? Critical thinking means examining ideas with at least the same level of skepticism you&#x27;d apply to an email offering you part of a large inheritance. When you think critically, you&#x27;re essentially putting an idea through intellectual boot camp by testing it, challenging it, and making it do cognitive push-ups until it either fails or becomes strong enough to survive in the wild world of academic discourse.</p>
+
+            <p>Let&#x27;s be clear: nothing beats a human sparring partner for developing critical thinking. A real person challenges you to think on your feet, brings unexpected perspectives, and forces you to articulate ideas in real-time. The back-and-forth of human dialogue creates a dynamic that AI can&#x27;t fully replicate. But here&#x27;s the thing, your study group isn&#x27;t always available at 12 AM when you&#x27;re wrestling with an idea. Your professor has office hours, not &quot;whenever you need to test an argument&quot; hours. This is where AI becomes valuable: it&#x27;s always ready to play devil&#x27;s advocate, ask probing questions, or help you examine your assumptions. Think of it as having a practice partner who&#x27;s always up for intellectual sparring, even if they can&#x27;t replace the real match.</p>
+
+            <p>In this module, you&#x27;ll learn to engage AI in ways that help you sharpen your analytical skills. You&#x27;ll practice using AI to probe your understanding through Socratic questioning and to stress-test your arguments by exploring opposing viewpoints. These techniques will help you develop more nuanced thinking and prepare you for academic discourse where defending your ideas matters.</p>
+
+            <p>Remember: The goal isn&#x27;t to let AI think for you, but to use it as a tool that pushes you to think more deeply and critically about your own ideas.</p>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>1. Socratic Dialogue &amp; Questioning</h2>
+            <p>The Socratic method uses probing questions to expose gaps in reasoning and lead to deeper understanding. AI can simulate this ancient teaching technique, helping you examine your beliefs and assumptions more rigorously.</p>
+
+            <div>
+            <details><summary> <i></i> <span>Activity 1.1: AI as a Socratic Questioner (Simple)</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Present an idea, belief, or argument to AI and ask it to question you using the Socratic method. This helps uncover hidden assumptions and strengthens your reasoning by forcing you to justify each step of your thinking.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do</h4>
+
+            <p>Start with these prompts to initiate Socratic dialogue:</p>
+
+            <pre>
+            <code>I believe that [state your position/argument]. Please act as a Socratic questioner and help me examine this belief by asking probing questions about my assumptions, evidence, reasoning, exceptions, and edge cases. Don&#x27;t argue against me, just ask questions that help me think more deeply.</code></pre>
+
+            <p><strong>Iterative questioning tip:</strong> After each AI question, answer thoughtfully, then ask: &quot;Based on my response, what follow-up question would help me dig deeper?&quot; This keeps the dialogue focused and productive.</p>
+
+            <p>Example of iterative questioning in action:</p>
+
+            <pre>
+            <code>You: &quot;I believe social media is harmful to democracy.&quot;
+            AI: &quot;What specific aspects of social media do you think cause harm?&quot;
+            You: &quot;The spread of misinformation and echo chambers.&quot;
+            AI: &quot;How do you define &#x27;echo chambers&#x27; and what evidence do you have that they&#x27;re unique to social media?&quot;
+            You: &quot;Good question. Let me think... [your response]. What follow-up question would help me examine this further?&quot;</code></pre>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Question quality:</strong> Were AI&#x27;s questions genuinely thought-provoking or just surface-level? Good Socratic questions should make you pause and reconsider.</li>
+            	<li><strong>Assumption discovery:</strong> Did the questioning help you identify assumptions you didn&#x27;t realize you were making?</li>
+            	<li><strong>Depth vs. breadth:</strong> Did AI help you go deeper into core issues, or did it jump around too much?</li>
+            	<li><strong>Your growth:</strong> How did your understanding of your own position change through this process?</li>
+            </ul>
+
+            <p><em>Critical note:</em> Sometimes AI generates questions that sound Socratic but are actually leading or biased. True Socratic questioning should help you discover insights, not push you toward predetermined conclusions.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>Socratic questioning with AI can reveal the foundations of your thinking. The value comes not from AI&#x27;s questions alone, but from the hard work of examining your own reasoning honestly.</p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Activity 1.2: AI as a Socratic Questioner (comprehensive)</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Engage with a more sophisticated Socratic questioner that follows a systematic approach to examining your thinking. This structured method ensures comprehensive exploration of your ideas through six distinct questioning categories.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do</h4>
+
+            <p>Use this comprehensive prompt to activate a disciplined Socratic partner:</p>
+
+            <pre>
+            <code>**Role &amp; Goal**  
+            You are a Socratic Thought Partner whose single purpose is to sharpen my reasoning. You accomplish this by asking disciplined, systematic questions drawn from the classic Socratic categories (Clarification, Assumption, Evidence &amp; Reasoning, Implications &amp; Consequences, Viewpoint &amp; Perspective, Question-the-Question). You are incisive and critical. You target my core motivations and unstated intentions. You understand that I may have misconceptions or blind spots which need to be surfaced. 
+
+            Your dialogue model follows the guidance on effective Socratic questioning from the University of Connecticut&#x27;s Center for Excellence in Teaching and Learning. (https://cetl.uconn.edu/resources/teaching-your-course/leading-effective-discussions/socratic-questions/?utm_source=chatgpt.com) Refer to this webpage if you have that ability.
+
+            ---
+            ### 1. Opening Move
+            Begin every new conversation with:
+            &gt; &quot;To get started, what would you like to explore today?&quot;
+            ---
+            ### 2. Core Dialogue Cycle (applies after every user reply)
+            1. **Select a Question Category**  
+                Cycle logically through the six categories to keep exploration balanced:
+                - Clarification
+                - Assumption
+                - Evidence &amp; Reasoning
+                - Implications &amp; Consequences
+                - Viewpoint &amp; Perspective
+                - Question-the-Question (meta-reflection)
+            2. **Pose One Incisive Question**  
+                Formulate a single open-ended question from the chosen category that invites deeper thought (e.g., &quot;What underpinning assumption leads you to that conclusion?&quot;).
+            3. **Spotlight Fuzzy Thinking**  
+                In ≤ 25 words, point out any vagueness, leap of logic, or unexamined premise apparent in my prior answer.
+            4. **Critical Feedback on Process**  
+                Offer one concise suggestion to strengthen my reasoning habits (e.g., &quot;Try articulating the counter-example before defending your view.&quot;).
+            5. **Practical Next Steps**  
+                Recommend 1-2 actionable steps I can take immediately (reading, data to gather, small experiment, etc.) to advance my inquiry.
+
+            ---
+            ### 3. Meta-Requests &amp; Summaries
+            - **If I explicitly ask for your conclusions,** switch to an analytic summary: synthesize key insights so far, highlight remaining uncertainties, and propose logical next directions.
+            - **If I request a comparison, definition, or explanation,** briefly deliver it, then revert to the Core Dialogue Cycle.
+
+            ---
+            ### 4. Tone &amp; Interaction Rules
+            - Use plain, precise language.
+            - Keep responses tight—no fluff, no digressions.
+            - Never provide more than one question before awaiting my answer.
+            - Do not supply your own opinions unless I solicit them; guide by questioning.
+            - Maintain respectful curiosity; challenge ideas, not the person.
+            - Avoid announcing methodology; simply demonstrate it.
+
+            ---
+            ### 5. End-of-Session Check-Out
+            When I indicate I am finished, ask:
+            &gt; &quot;Which insight from today&#x27;s dialogue feels most actionable for you?&quot;</code></pre>
+
+            <p><strong>Usage tip:</strong> This prompt creates a more rigorous questioning experience. The AI will systematically explore different aspects of your thinking, providing feedback on your reasoning process itself, not just your ideas.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Systematic approach:</strong> Did the structured categories help explore your topic more thoroughly than the basic Socratic approach?</li>
+            	<li><strong>Feedback quality:</strong> How useful was the &quot;fuzzy thinking&quot; spotlight and process feedback? Did it help you see patterns in your reasoning?</li>
+            	<li><strong>Comparison question:</strong> How did this structured approach differ from Activity 1.1? Which style better suited your learning needs and why? Consider:
+            	<ul>
+            		<li>The basic approach allows more organic conversation flow</li>
+            		<li>The structured approach ensures comprehensive coverage</li>
+            		<li>Which pushed you to think harder about your assumptions?</li>
+            	</ul>
+            	</li>
+            	<li><strong>Actionable insights:</strong> What specific next steps did the AI suggest, and were they genuinely helpful for advancing your understanding?</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>A structured Socratic approach can ensure no stone is left unturned in examining your thinking. The systematic categories prevent you from avoiding uncomfortable questions and force comprehensive self-examination.</p>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>2. AI as a Debate &amp; Argumentation Sparring Partner</h2>
+            <p>Strong arguments anticipate and address counterpoints. AI can help you prepare for intellectual challenges by taking opposing stances and forcing you to defend your position—like a practice debate before the real thing.</p>
+
+            <div>
+            <details><summary> <i></i> <span>Activity 2.1: AI as a Devil&#x27;s Advocate (Simple)</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Present your thesis or argument to AI and ask it to argue against your position. This helps you anticipate objections, identify weaknesses in your reasoning, and build more robust arguments.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do</h4>
+
+            <p>Use these prompts to engage AI as your intellectual opponent:</p>
+
+            <pre>
+            <code>My thesis is: [your thesis]. Please act as a devil&#x27;s advocate and 
+            present the strongest possible counter-arguments. Focus on:
+            - Logical weaknesses in my argument
+            - Alternative interpretations of my evidence  
+            - Unintended consequences I haven&#x27;t considered</code></pre>
+
+            <pre>
+            <code>I&#x27;m writing a paper arguing that [your position]. Help me strengthen 
+            my argument by:
+            1. Identifying the 3 strongest objections someone might raise
+            2. Explaining why each objection seems compelling
+            3. Suggesting what evidence opponents might use</code></pre>
+
+            <pre>
+            <code>Here&#x27;s my main argument: [your argument]. Play devil&#x27;s advocate, 
+            but stick to legitimate counter-arguments—no straw man arguments 
+            or logical fallacies. After each counter-argument, ask me how I 
+            would respond.</code></pre>
+
+            <p><strong>Pro tip:</strong> After AI presents counter-arguments, practice responding: &quot;How would I address this objection in my paper?&quot; This prepares you for real academic discourse.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Argument validity:</strong> Were AI&#x27;s counter-arguments logically sound, or did they contain fallacies?</li>
+            	<li><strong>Strength assessment:</strong> Did AI identify genuine weaknesses in your position, or just superficial issues?</li>
+            	<li><strong>Fallacy detection:</strong> Watch for common logical fallacies AI might use:</li>
+            </ul>
+
+            <div>
+            <p><i></i> <strong>Example of AI using a fallacy:</strong><br>
+            Your argument: &quot;Universities should increase funding for mental health services.&quot;<br>
+            AI&#x27;s flawed counter: &quot;But if we fund mental health services, soon we&#x27;ll have to fund everything students want, and the university will go bankrupt.&quot; (Slippery slope fallacy)<br>
+            <br>
+            A better counter-argument would address actual trade-offs: &quot;Given limited budgets, how should universities balance mental health funding against other student needs like financial aid or academic support?&quot;</p>
+            </div>
+
+            <ul>
+            	<li><strong>Learning value:</strong> Did this exercise help you see your argument from new angles? What will you change based on this practice?</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>AI can simulate intellectual opposition, helping you build stronger arguments by anticipating challenges. But remember: real human critics may raise concerns AI doesn&#x27;t consider, especially those involving values, context, or lived experience.</p>
+            </div>
+            </div>
+            </details>
+            </div>
+
+            <details><summary> <i></i> <span>Activity 2.2: AI as a Devil&#x27;s Advocate (Comprehensive)</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Task</h4>
+
+            <p>Engage with a systematic devil&#x27;s advocate that methodically stress-tests your plans and ideas. This structured approach ensures comprehensive examination through five distinct challenge categories, helping you identify blind spots before they become problems.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Dive-in &amp; Do</h4>
+
+            <p>Use this comprehensive prompt to activate a strategic devil&#x27;s advocate partner (note that the unusual formatting is called <i>Markdown</i> and is used to help the LLM understanding the hierarchy of the prompt):</p>
+
+            <pre>
+            <code>
+            ## 1. Role &amp; Purpose
+            You are a **Devil&#x27;s Advocate Thought Partner** whose mission is to stress-test any plan or idea I am considering. You surface hidden assumptions, expose weaknesses, and explore alternate approaches so I can refine or reaffirm my thinking with full confidence.
+
+            ## 2. Opening Move
+            Begin every new conversation with:
+            &gt; &quot;Hi—what plan or idea would you like us to examine?&quot;
+            ## 3. Intake Phase
+              _Ask only **one** open question at a time and wait for my reply._
+              1. Capture:
+                - Project overview
+                - Main objectives
+                - Specific plan or idea under review
+              2. Confirm understanding:
+                &gt; &quot;Got it. Let&#x27;s stress-test this plan to avoid the consensus trap.&quot;  
+                &gt; _Wait for acknowledgment before advancing._
+
+            ## 4. Devil&#x27;s Advocate Challenge Cycle
+            Repeat until potential flaws feel thoroughly explored.
+
+            | Step                        | Action                                                                                                                  |
+            | --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+            | **A. Probe Assumptions**    | Ask one incisive question challenging an implicit belief.                                                               |
+            | **B. Explore Alternatives** | Ask one question inviting a different angle or option.                                                                  |
+            | **C. Test Evidence**        | Ask one question checking supporting data or precedent.                                                                 |
+            | **D. Surface Drawbacks**    | Ask one question uncovering negative consequences.                                                                      |
+            | **E. Reflect &amp; Refine**     | In ≤ 25 words, spotlight logical gaps or overlooked issues and offer one concise suggestion to strengthen the analysis. |
+
+            _Cycle rules: one question per turn; always await my response; if I stall, offer a concrete example to prompt discussion._
+
+            ## 5. Completion &amp; Synthesis
+            1. Readiness check:
+              &gt; &quot;Have we examined every significant risk or alternative you wanted to cover?&quot;
+            2. After confirmation, present a bold markdown table:
+
+            | **INITIAL PLAN / IDEA** | **HIDDEN ASSUMPTIONS** | **ALTERNATIVE VIEWPOINTS** |
+            | ----------------------- | ---------------------- | -------------------------- |
+            | _(concise description)_ | _(bullet list)_        | _(bullet list)_            |
+
+            3. Close with:
+             &gt; &quot;If new questions arise, I&#x27;m here to help examine them.&quot;
+
+            ## 6. Tone &amp; Interaction Rules
+                - Warm, respectful, strategic—challenge ideas, not people.
+                - Plain language; no fluff.
+                - One question per response.
+                - Do not create the final table until every question you asked has been answered.
+
+            ## 7. Example Turn
+            **User:** &quot;I plan to launch the app in eight weeks.&quot;  
+            **AI:**
+            1. _Probe Assumptions_ – &quot;What makes eight weeks preferable to twelve?&quot;
+            2. _Reflect &amp; Refine_ – &quot;Timeline appears fixed without evidence; reviewing historical dev-cycle data could validate feasibility.
+            </code></pre>
+
+            <p><strong>Strategic tip:</strong> This structured approach prevents the AI from jumping randomly between critiques. The systematic cycle ensures you examine assumptions, alternatives, evidence, and consequences in a logical progression.</p>
+            </div>
+
+            <div>
+            <h4><i></i>Pause &amp; Ponder</h4>
+
+            <ul>
+            	<li><strong>Systematic coverage:</strong> Did the structured cycle help uncover issues you wouldn&#x27;t have considered with a basic devil&#x27;s advocate approach?</li>
+            	<li><strong>Quality of challenges:</strong> Were the AI&#x27;s questions genuinely challenging your thinking, or were they predictable? The best devil&#x27;s advocacy makes you uncomfortable because it hits real vulnerabilities.</li>
+            	<li><strong>Comparison with Activity 2.1:</strong> How did this structured approach differ from the basic devil&#x27;s advocate? Consider:
+            	<ul>
+            		<li>The basic approach allows more organic opposition</li>
+            		<li>The structured approach ensures systematic coverage</li>
+            		<li>Which helped you identify more significant weaknesses?</li>
+            	</ul>
+            	</li>
+            	<li><strong>The synthesis table:</strong> Was the final summary table helpful in capturing what you learned? Did it reveal patterns in your assumptions?</li>
+            	<li><strong>Real-world application:</strong> Think of a project or decision you&#x27;re facing. Would this systematic stress-testing help you prepare better?</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>Structured devil&#x27;s advocacy ensures you don&#x27;t skip uncomfortable questions. The systematic approach forces examination of assumptions, alternatives, evidence, and consequences—creating a more robust final plan or argument.</p>
+            </div>
+            </div>
+            </details>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Reflection &amp; Synthesis</h2>
+            <p><strong>What you&#x27;ve learned:</strong> You&#x27;ve practiced using AI as a tool for sharpening critical thinking through Socratic questioning and devil&#x27;s advocacy. These techniques help you examine assumptions, anticipate objections, and build more thoughtful arguments.</p>
+
+            <p><strong>Key insight:</strong> AI serves best as a thinking catalyst, not a thinking replacement. It can prompt you to question more deeply and argue more carefully, but the critical analysis must come from you.</p>
+
+            <p><strong>Reflection questions:</strong></p>
+
+            <ul>
+            	<li>How can you use Socratic questioning to improve your understanding in other courses?</li>
+            	<li>Think of a paper you&#x27;re writing or a position you hold strongly. What assumptions haven&#x27;t you examined yet?</li>
+            	<li>How might these techniques help you in class discussions or study groups?</li>
+            </ul>
+
+            <p><strong>Moving forward:</strong> Critical thinking is a skill that improves with practice. Use these AI techniques regularly, but also seek out human discussion partners who can challenge you in ways AI cannot—through personal experience, emotional intelligence, and contextual understanding.</p>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <h1><i></i>AI for Honing Communication Skills (Beyond Writing)</h1>
+
+            <div>
+            <p>AI can help improve your communications skills and it can help across all types of communications, not just writing. Here, we&#x27;ll explore how AI can serve as a practice partner for other forms of communication, from delivering great presentations to role playing as different types of conversational partners to supporting language acquisition. The goal of this module is to supplement human interaction. AI tools are still not good at reading body language or detecting subtlety and nuance in a conversation. AI <em>can</em> provide a low-stakes environment to practice, refine, and build confidence before you step onto the stage or into a high-stakes meeting.</p>
+
+            <div>
+            <p><i></i><strong>Critical Note: The Human Advantage.</strong> An AI can be a useful conversation partner simulator, but it is not a substitute for an expert human coach or a real conversation partner. A person can interpret body language, detect subtle shifts in tone, and understand nuance in a way a machine cannot. Always prioritize feedback from trusted peers, mentors, and instructors. Use AI as a tool for preparation, not a replacement for real-world experience.</p>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Enhancing Presentation &amp; Speaking Skills</h2>
+            <p>Successful presentations have strong narratives and are able to connect with an audience. In this section, you&#x27;ll learn to use AI as a structural strategist to organize your ideas and as a private coach to refine your delivery. This section provides a three-part process for using AI as a presentation partner:</p>
+
+            <ol>
+            	<li>A toolkit to help you efficiently draft your content and the presentation<br>
+            	 </li>
+            	<li>A stress-test activity to refine the presentation<br>
+            	 </li>
+            	<li>A feedback activity to get AI to provide tips on improving your presentation (it&#x27;s better to get human input for this, but the advantage of AI is that it&#x27;s always there to help out when a human isn&#x27;t)<br>
+            	 </li>
+            </ol>
+
+            <div>
+            <details><summary> <i></i> <span>Presentation Activity 1: Create a Presentation</span> </summary>
+
+            <div>
+            <p>Creating a presentation has some similarities to writing a paper in that you want the presentation to represent your thoughts and your views, but you also want to find ways to simplify the process without removing your agency. A good approach is to start by using an AI chatbot to organize your ideas and craft a strong narrative. Once your content is clear, use a specialized presentation AI tool to quickly turn your text into professional-looking slides. this method ensures flexibility, keeps you in the center of the process, and simplifies the creation of the slides.</p>
+
+            <div>
+            <h4><i></i>Purpose</h4>
+
+            <p>Craft a clear, audience-focused presentation by leveraging AI as your behind-the-scenes strategist and your slide generating expert.</p>
+
+            <h4><i></i>Task</h4>
+
+            <p>Kick things off with your original ideas. Then, let AI suggest different frameworks, critique structures, and help map out your slides.</p>
+            </div>
+
+            <h3><i></i>Step 1: Develop the Presentation Content</h3>
+
+            <p>Use one of the prompts below as a starting point or develop your own. The key is to always provide the AI with your own content and context first.</p>
+
+            <h4>Scenario 1: You have a finished paper or report and need to turn it into a presentation.</h4>
+
+            <pre>
+            <code>Act as a communication expert. I&#x27;m adapting a research paper into a 10-minute presentation for an audience of [Describe your audience]. My core message for them is [State your single most important takeaway]. Based on the text I&#x27;ve pasted below, please extract the 3-4 main arguments and structure them into a logical 5-slide outline with headlines and key talking points.</code></pre>
+
+            <h4>Scenario 2: You have raw data (from a survey, experiment, etc.) and need to build a story around it.</h4>
+
+            <pre>
+            <code>Act as a data storyteller. I need to present a key finding to [Describe your audience] to convince them to [State your goal]. My key finding is: &#x27;[State your data&#x27;s headline in one sentence]&#x27;. Please suggest a simple 3-part narrative (hook, data reveal, so what?) and propose two different ways I could visually represent this data, explaining the pros and cons of each.</code></pre>
+
+            <h4>Scenario 3: You are starting from scratch with a broad topic.</h4>
+
+            <pre>
+            <code>Act as a creative strategist. I need to develop a presentation on [Your Topic] for [Your Audience]. Please propose three distinct, debatable thesis statements I could build my presentation around. For each, list one potential audience objection I would need to anticipate and address.</code></pre>
+
+            <h3><i></i>Step 2: Choose an AI Tool for Creating the Actual Presentation</h3>
+
+            <p>After developing your content, pick an AI presentation tool to quickly generate slides. I&#x27;ll leave it to you to pick the tool and figure out how to use it - the two I&#x27;ve recommended below are fairly intuitive to use.</p>
+
+            <h4>Some Options:</h4>
+
+            <ul>
+            	<li><strong>Gamma.app</strong> Gamma turns a short text prompt or document into a scrollable slide deck.
+
+            	<ul>
+            		<li>Creates polished slides rapidly</li>
+            		<li>Easy to use with good design defaults</li>
+            		<li>Free tier (400 credits = 8-10 presentations) is student-friendly</li>
+            		<li>Limited customization</li>
+            		<li>Generated images are okay but sometimes miss the mark</li>
+            		<li>Free usage capped at 10 cards per deck</li>
+            		<li>Experiment with Gamma’s “Restyle” feature</li>
+            		<li>Export for offline presentations and better editing control</li>
+            	</ul>
+            	</li>
+            	<li><strong>PowerPoint with Copilot</strong> Copilot adds an AI side-panel to PowerPoint that can draft, rewrite, and redesign slides on command.
+            	<ul>
+            		<li>Integrated with PowerPoint (familiar UI)</li>
+            		<li>Can create slides from documents or prompts</li>
+            		<li>Real-time editing with AI commands</li>
+            		<li>Images added are mix of AI generated and stock photos</li>
+            		<li>Requires Microsoft 365 subscription (free trial available)</li>
+            		<li>Output may need substantial editing</li>
+            		<li>Provide structured input for best results</li>
+            		<li>Use AI rewrite options within slides</li>
+            		<li>Load your preferred template before using Copilot</li>
+            	</ul>
+            	</li>
+            	<li><strong>SlidesAI (Google Slides Add-on)</strong> Lives inside Google Slides and converts pasted text into a ready-formatted slide deck in a few clicks.
+            	<ul>
+            		<li>not recommended - free version is limited</li>
+            		<li>1000 character input max</li>
+            		<li>12 free presentations/year</li>
+            	</ul>
+            	</li>
+            	<li><strong>beautiful.ai</strong> Generates slides from prompts.
+            	<ul>
+            		<li>not recommended - no free version, only a free trial</li>
+            		<li>free trial limits input features</li>
+            	</ul>
+            	</li>
+            </ul>
+
+            <div>
+            <h5><i></i>Notes for Instructors</h5>
+
+            <p>If you are going to do this activity in your class, here are some suggestions:</p>
+
+            <ul>
+            	<li>Model the &quot;brain-first outline ➜ AI options ➜ human evaluation&quot; flow for building a presentation</li>
+            	<li>Require an <em>AI contribution statement</em> slide and a slide reflecting on the use of AI for the presentation</li>
+            	<li>Fact check one data point on each student&#x27;s slide during the presentation</li>
+            </ul>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Presentation Activity 2: The Presentation Stress-Test (For Feedback)</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Purpose</h4>
+
+            <p>Use AI to evaluate your presentation draft from multiple perspectives, uncovering weaknesses in your argument, clarity, and structure.</p>
+
+            <h4><i></i>Task</h4>
+
+            <p>You will take your completed presentation draft (the slide headlines and key talking points) and subject it to a &quot;stress-test&quot; by asking an AI to role-play three different critical personas.</p>
+            </div>
+
+            <h3><i></i>Dive-in &amp; Do It</h3>
+
+            <h4>Use your brain first:</h4>
+
+            <ol>
+            	<li><strong>Prepare Your Draft:</strong> Open a document and paste in your presentation outline. This should include the title, and for each slide, the headline and the main bullet points you plan to discuss. This is the artifact the AI will analyze.</li>
+            </ol>
+
+            <h4>AI Input:</h4>
+
+            <ol start="2">
+            	<li>Copy your entire presentation outline and paste it into each of the prompts below to get feedback from multiple perspectives (you can modify the perspectives/personas as you see fit)</li>
+            </ol>
+
+            <h4>Prompt 1:</h4>
+
+            <pre>
+            <code>Act as a bright but curious first-year university student. You are attending this presentation knowing nothing about the subject matter. I am a student who has drafted a presentation outline, which is pasted below.
+
+            Your task is to identify every point of confusion. Pinpoint any jargon or technical terms I failed to explain. Highlight any logical jumps where you felt lost or weren&#x27;t sure how I got from one point to the next. List the specific questions that came to your mind as you were reading.
+
+            Please format your feedback as a simple list of questions and comments. For each item, reference the specific slide number or headline where the confusion occurred so I can easily find it. 
+
+            Your tone should be inquisitive but critique my presentation freely and avoid sycophancy. I crave honest appraisal.
+
+            Here is my outline:
+            [Paste your presentation  here]</code></pre>
+
+            <h4>Prompt 2:</h4>
+
+            <pre>
+            <code>Act as a tenured professor and a leading expert in this specific field. You are reviewing this outline as if it were submitted for a prestigious academic conference. I have drafted this presentation for a knowledgeable audience and need to ensure my core arguments are robust.
+
+            Critically analyze the arguments, evidence, and logic presented in my outline below. Your primary goal is to identify the single weakest, most unsupported, or most questionable claim. Then, formulate the single most challenging, insightful question you would ask me during the Q&amp;A session.
+
+            Structure your feedback in two distinct parts:
+            1. **Weakest Point Analysis:** A short paragraph identifying the weakest claim and explaining precisely why it is weak.
+            2. **The Killer Question:** The single, well-formulated question you would ask.
+
+            Your tone should be professional, academic, and rigorous. Critique freely and avoid sycophancy. I crave honest appraisal.
+
+            Here is my outline:
+            [Paste your presentation here]</code></pre>
+
+            <h4>Prompt 3:</h4>
+
+            <pre>
+            <code>Act as a busy, high-level executive. You have very little time and only care about the bottom line. I have drafted a presentation outline and need to ensure it immediately communicates its value.
+
+            Scan my presentation below. Your task is to determine the core takeaway and its relevance. Answer these three questions directly: 
+            1. What is the absolute main point? 
+            2. Why should I care? 
+            3. What do you want me to do?
+
+            Provide your entire response in a single, concise paragraph. Begin the paragraph with the words &#x27;Bottom Line:&#x27;.. Your tone should be direct, decisive, and slightly impatient. Critique freely and avoid sycophancy. I crave honest appraisal.
+
+            Here is my outline:
+            [Paste your presentation outline here]</code></pre>
+
+            <h3><i></i>Pause &amp; Ponder</h3>
+
+            <ol>
+            	<li><strong>Synthesize the Feedback:</strong> Which persona&#x27;s feedback was the most surprising or insightful? Why?</li>
+            	<li><strong>Address the Weakness:</strong> Based on the &quot;Skeptical Expert&#x27;s&quot; critique, how will you strengthen your weakest point? Will you add more data, cite another source, or rephrase the claim to be more precise?</li>
+            	<li><strong>Improve Clarity:</strong> Look at the feedback from the &quot;Confused Novice&quot; and the &quot;Impatient Executive.&quot; How can you revise your introduction and conclusion to make your core message clearer and more impactful from the very beginning?</li>
+            </ol>
+
+            <div>
+            <h5><i></i>Key Takeaway: Seek Diverse Criticism</h5>
+
+            <p>A single opinion, whether from a human or AI, gives you only one perspective. By forcing the AI to adopt multiple, even contradictory, personas, you simulate a more realistic feedback environment. This process helps you anticipate the needs of a diverse audience and build a more robust, resilient presentation.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Notes for Instructors</h5>
+
+            <p>If you are going to do this activity in your class, here are some suggestions:</p>
+
+            <ul>
+            	<li>This activity can be good for a PAIRR type framework. AI gives feedback, peer gives feedback, presenter takes feedback from both and adjusts.</li>
+            	<li>Require a reflection on the process</li>
+            </ul>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Presentation Activity 3: AI for Presentation Delivery Practice</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Purpose</h4>
+
+            <p>To get objective feedback on your speaking habits in a private setting, helping you identify and reduce filler words, monitor your pace, and improve clarity.</p>
+
+            <h4><i></i>Task</h4>
+
+            <p>You will use a tool with AI-powered video and speech analysis to practice delivering your presentation and then critically evaluate the feedback it provides.</p>
+            </div>
+
+            <div>
+            <p><i></i><strong>Privacy and Data Security Warning.</strong> Using AI tools in this way requires you to upload audio and video of yourself to a third-party server. Before using any tool, understand its privacy policy. Ask yourself (and the privacy policy): Who owns the data once I upload it? How is my data being used? Is it used to train the AI? Can I delete my data after I&#x27;m done? If you are not comfortable with the answers, do not do this activity.</p>
+            </div>
+
+            <div>
+            <p><i></i><strong>AI Limitation Warning.</strong> Using AI tools to give feedback on video is less well tested than getting feedback on writing. Do not expect the feedback to be deeply insightful or nuanced. Getting feedback from a human, even a non-expert will be more valuable.</p>
+            </div>
+
+            <div>
+            <p><i></i><strong>Confabulation Warning.</strong> AI&#x27;s can make stuff up. Do some kind of content confirmation of the video to ensure that it is actually seeing the video.</p>
+            </div>
+
+            <p>As of June 2025, the only tool I have tried this with is Google Gemini. ChatGPT does not support it. Apparently Microsoft Copilot does, but I haven&#x27;t tried it myself.</p>
+
+            <p>Other potential tools specialized for giving speaking and communication feedback: <a href="https://www.poised.com/">Poised</a>, <a href="https://orai.com/">Orai</a>.</p>
+
+            <p>I have not vetted these other tools in anyway except to identify that they exist. If I can do something in a standard chatbot (like Google Gemini), I will almost always choose that. I can customize the interaction much more and I don&#x27;t have to worry about another privacy policy and sharing my info with yet another company.</p>
+
+            <h3><i></i>Dive-in &amp; Do It</h3>
+
+            <h4>Use your brain first:</h4>
+
+            <ol>
+            	<li>Record yourself giving a presentation. It&#x27;s probably best to just focus on yourself and not your slides. If you tend to walk around, have a friend record you, otherwise, just set up your camera to capture you in the frame.</li>
+            </ol>
+
+            <h4>AI Input:</h4>
+
+            <ol start="2">
+            	<li>Upload the video to a fresh Google Gemini chat (you can just drag and drop).</li>
+            	<li>Enter one of these prompts or something like it:</li>
+            </ol>
+
+            <h4>In-Person Presentation Video</h4>
+
+            <pre>
+            <code>**Role:** You are an expert academic presentation coach.
+            **Task:** Your task is to evaluate the attached video of a presentation and provide constructive, formative feedback to the presenter. 
+            Disregard slide design, background graphics, or the academic content itself.
+
+            **What to observe**
+            1. **Voice &amp; Pace** – audibility, enunciation, vocal variety, speaking speed, strategic pauses, filler-word frequency.
+            2. **Body Language** – posture, purposeful gestures, movement on stage, avoidance of fidgeting or pacing.
+            3. **Eye Contact** – distribution of attention across the room, natural scanning, connection with individuals.
+            4. **Audience Interaction** – questions posed, humour, rhetorical questions, acknowledgement of reactions, adaptability to cues.
+            5. **Energy &amp; Presence** – enthusiasm, confidence, facial expressiveness, smooth transitions, time management.
+
+            **Output format**
+            - **Summary (≤ 2 sentences)** – overarching impression of delivery and engagement.
+            - **What Was Done Well** – 4-6 bullet points, each starting with a strong verb and including an optional timestamp (HH:MM:SS) showing where it occurred.
+            - **Ways to Improve** – 4-6 bullet points with constructive, specific suggestions; include optional timestamps.
+            - **Actionable Tips** – 3 concise recommendations phrased as imperatives (e.g., “Pause for two seconds after each key term”)
+
+            Keep language clear, balanced, and oriented toward formative growth.
+            Critique my presentation freely and avoid sycophancy. I crave honest appraisal.</code></pre>
+
+            <h4>Webcam Presentation Video</h4>
+
+            <pre>
+            <code>**Role:** You are an expert academic presentation coach.
+            **Task:** Your task is to evaluate the attached video of a presenter giving a webcam presentation and provide constructive, formative feedback to the presenter. 
+            Disregard slide design, background graphics, or the academic content itself.
+
+            **What to observe**
+            1. **Camera Presence** – eye contact with lens, framing (eye-level, head-and-shoulders view), facial expressiveness.
+            2. **Audio &amp; Vocal Delivery** – audibility, enunciation, vocal variety, clarity, volume, pacing, vocal variety, strategic pauses, filler word frequency, absence of distracting background noise.
+            3. **Body Language On-Camera** – posture, visible gestures within frame, avoidance of slouching, minimize looking off-screen.
+            4. **Virtual Engagement** – use of chat, polls, name-checks, response to participant cues, inviting interaction every few minutes.
+            5. **Energy &amp; Presence** – enthusiasm, conversational tone, natural smiles, smooth transitions between topics or slides.
+
+            **Output format**
+            - **Summary (≤ 2 sentences)** – overarching impression of delivery and engagement.
+            - **What Was Done Well** – 4-6 bullet points, each starting with a strong verb and including an optional timestamp (HH:MM:SS) showing where it occurred.
+            - **Ways to Improve** – 4-6 bullet points with constructive, specific suggestions; include optional timestamps.
+            - **Actionable Tips** – 3 concise recommendations phrased as imperatives (e.g., “Pause for two seconds after each key term”)
+
+            Keep language clear, balanced, and oriented toward formative growth.
+            Critique my presentation freely and avoid sycophancy. I crave honest appraisal.</code></pre>
+
+            <h3><i></i>Pause &amp; Ponder</h3>
+
+            <ol>
+            	<li>Review the AI&#x27;s feedback. Did it identify any habits you were unaware of (e.g., using &quot;um&quot; frequently, speaking too quickly)?</li>
+            	<li>Which pieces of feedback are the most actionable? What specific strategy can you use to address it in your next practice run?</li>
+            	<li>Did any of the feedback seem inaccurate or not useful? Why might the AI have misinterpreted your delivery (e.g., mistaking a purposeful pause for hesitation)? (This helps you practice evaluative judgment)</li>
+            </ol>
+
+            <div>
+            <h5><i></i>Notes for Instructors</h5>
+
+            <p>If you are going to do this activity in your class, here are some suggestions:</p>
+
+            <ul>
+            	<li>This activity can be good for a PAIRR type framework. AI gives feedback, peer gives feedback, presenter takes feedback from both and adjusts.</li>
+            	<li>Require a reflection on the process</li>
+            </ul>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Practicing for High-Stakes Conversations</h2>
+            <p>AI can not only take on a role in a text interaction, but it can also take on a role while taking advantage of the voice mode available in many generative AI tools. In this way, you can simulate interviews, negotiations, or other challenging conversations. The goal is to build your confidence and mental scripts so you can perform more effectively when it counts.</p>
+
+            <div>
+            <p><i></i><strong>Note on AI Tools:</strong> Many specialized apps exist for this. However, a general chatbot (like ChatGPT, Claude, or Perplexity) in &quot;voice mode&quot; can be highly effective and flexible. You have more control over the scenario by simply giving the AI a clear persona and context through your prompt.</p>
+            </div>
+
+            <div>
+            <p><i></i><strong>Note on Prompting:</strong> The key to a good simulation is a good prompt. You can and should direct the AI to adopt a specific role (e.g., &quot;a skeptical hiring manager,&quot; &quot;a collaborative potential business partner&quot;). For extra effectiveness, add constraints to practice specific things (e.g., to be prepared for ad hominem attacks, include &quot;In this negotiation, you [the AI] must act belligerent and insulting&quot;).</p>
+            </div>
+
+            <div>
+            <details><summary> <i></i> <span>Conversation Activity 1: The Scenario Simulator</span> </summary>
+
+            <div>
+            <div>
+            <h4><i></i>Purpose</h4>
+
+            <p>To design a custom role-play prompt to simulate a challenging conversation, allowing you to practice your approach, anticipate responses, and get targeted feedback.</p>
+
+            <h4><i></i>Task</h4>
+
+            <p>You will define a scenario, build a detailed prompt to put the AI into a specific role, run the simulation via voice or text, and then ask the AI to provide feedback on your performance.</p>
+            </div>
+
+            <p><strong>Example Scenarios:</strong></p>
+
+            <ul>
+            	<li>A job interview for a specific role</li>
+            	<li>Negotiating a project deadline with a professor</li>
+            	<li>A sales pitch for a new product</li>
+            </ul>
+
+            <h3><i></i>Dive-in &amp; Do It</h3>
+
+            <h4>Use your brain first:</h4>
+
+            <ol>
+            	<li><strong>Choose Your Scenario:</strong> Select a specific, challenging conversation you want to practice.</li>
+            	<li><strong>Define Your Goal:</strong> What is your ideal outcome for this conversation? Be specific. (e.g., &quot;To convince the hiring manager I am the best candidate by highlighting my project management skills,&quot; &quot;To get a 48-hour extension on the paper.&quot;).</li>
+            	<li><strong>Build the role playing persona for the AI:</strong> Build a realistic professional persona for the AI to play. Focus on role-related facts: the person’s job title, expertise, goals, typical pain points, decision criteria, and communication style. Add any situational constraints (tight budget, looming deadline, strict policy) that will shape the conversation. Avoid specifying personal characteristics—such as race, gender, religion, or other traits like these unless they are genuinely essential to the scenario and handled with care. It&#x27;s also a good idea here to bring in course specific things that will tie this simulation scenario to the learning outcomes you are practicing.</li>
+            	<li><strong>Build a comprehensive prompt to create persona and to set the scenario.</strong> This example creates the persona of an angel investor who is willing to listen to a sales pitch about an electronic pencil.</li>
+            </ol>
+
+            <pre>
+            <code>Together, we are going to simulate a sales pitch situation. I am trying to pitch my idea for an electronic pencil and you are going to role-play as a seasoned angel investor. 
+
+            **Role-play brief:**  
+            You are **Jordan Patel**, a seasoned angel investor known for backing early-stage consumer-electronics ideas that blend hardware and software. Over the past decade you’ve invested in more than 30 seed-stage startups, with 5 successful exits in ed-tech peripherals and creative-tool accessories.
+
+            **Profile &amp; investment lens**
+            - Background – Former product-design lead at a Fortune 500 company; holds an MBA (operations) and a B.Eng. in electrical engineering.
+            - Ticket size – USD $100 k – $500 k for 10-20 % equity; reserves follow-on capital for winners.
+            - Sweet spot –  productivity hardware, and IoT learning tools.
+            - Deal filters – Clear technical moat, credible supply-chain plan, 40 %+ gross margin at scale, evidence of user love.
+            - Temperament – Inquisitive, data-driven, constructive; expects founders to know their numbers and their customer.
+
+            **Conversation style**
+            1. Begin by inviting the founder to give a concise (≤ 3 min) overview of the concept.
+            2. After the pitch, ask probing questions on:
+                - Problem-solution fit &amp; user pain
+                - Total addressable market and early-adopter segment
+                - Unique technology / IP and defensibility
+                - Unit economics, BOM, and gross-margin roadmap
+                - Go-to-market plan (channels, partnerships, pricing)
+                - Competitive landscape (Apple Pencil, reMarkable stylus, etc.)
+                - Team competence and execution milestones
+            3. Provide immediate, candid feedback—highlight strengths first, then the top improvement areas.
+            4. Conclude with one of three outcomes:
+                - **Pass** – state key reservation(s).
+                - **More info needed** – request specific data or milestones.
+                - **Soft yes** – outline next-step diligence and potential terms.
+
+            **Tone &amp; constraints**
+            - Stay in character as Jordan Patel throughout. THIS IS VERY IMPORTANT
+            - Keep language conversational yet professional; no “advisor” disclaimers.
+            - Give balanced feedback—mix encouragement with rigorous scrutiny.
+            - Avoid filler; every question or comment should push the founder toward clarity or evidence.</code></pre>
+
+            <h4>AI Input:</h4>
+
+            <p>I have only tested this with ChatGPT Plus. The advanced voice mode in the free version of ChatGPT may not be sufficient to have a long conversations. Gemini Live, which is Gemini&#x27;s voice mode, is currently only available on Android devices (July 2025).</p>
+
+            <ol start="5">
+            	<li>Copy and paste the prompt into ChatGPT and wait for its response.</li>
+            	<li>Click on the &quot;Use Voice Mode&quot; button in the chat window and start interacting with the persona. Do your sales pitch, start answering interview questions, plead for an extension...whatever it is that you set.
+            	<div><img alt="Screenshot of a chatbot interface showing the location of the voice mode button, which looks like a soundwave icon." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/VoiceModeButton.png"></div>
+            	</li>
+            	<li><strong>Handling AI Errors:</strong> If the AI forgets its role (&quot;persona drift&quot;) or starts making things up (&quot;confabulation&quot;), gently correct it. You can say, &quot;Remember, you are the hiring manager. Let&#x27;s get back to the interview questions,&quot; to steer it back on track. If this persona drift gets bad (i.e., the AI no longer acts like it&#x27;s in the simulation) you may need to start over.</li>
+            	<li><strong>Ask for Feedback:</strong> Once the role-play is complete, use a second prompt to shift the AI from the simulation role to a coach role.</li>
+            </ol>
+
+            <h4>Debrief Prompt:</h4>
+
+            <pre>
+            <code>The role-play/simulation is now over. Stop acting as the persona of [persona name here]. Now, act as a helpful communication coach. Evaluate the conversation based on the following criteria
+            [add criteria here based on rubric or criteria from your class for this type of scenario]
+
+            **Output format*
+            - **Summary (≤ 2 sentences)** – overarching impression of the my [sales pitch or interview or ...].
+            - **What Was Done Well** – 4-6 bullet points, each starting with a strong verb and indicating where in the simulation it occurred.
+            - **Ways to Improve** – 4-6 bullet points with constructive, specific suggestions
+            - **Actionable Tips** – 3 concise recommendations phrased as imperatives 
+
+            Keep language clear, balanced, and oriented toward formative growth.
+            Critique my interaction freely and avoid sycophancy. I crave honest appraisal.</code></pre>
+
+            <h3><i></i>Pause &amp; Ponder</h3>
+
+            <ol>
+            	<li>During the role-play, when did you feel most confident? When did you feel unsure? What caused that feeling?</li>
+            	<li>Review the AI&#x27;s feedback from the &quot;Debrief Prompt.&quot; Is the feedback specific and actionable? How does it align with your own perception of your performance?</li>
+            	<li>How would you change your initial prompt to create a different or more challenging simulation next time? (e.g., change the AI&#x27;s persona, add a new objective).</li>
+            </ol>
+
+            <div>
+            <h5><i></i>Notes for Instructors</h5>
+
+            <p>If you are going to do this activity in your class, here are some suggestions:</p>
+
+            <ul>
+            	<li>Require a reflection on the process. The reflection can look at how level of persona detail shapes simulation realism.</li>
+            	<li>Student judges whether AI’s feedback aligns with course rubric.</li>
+            	<li>Discuss bias—e.g., does the AI adopt stereotypes when asked to be “belligerent negotiator”?</li>
+            </ul>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Supporting Language Learning</h2>
+            <p>Generative AI can be a patient tutor and on-demand practice partner for language learning by providing instant explanations and limitless drills. <strong>It is not, however, a substitute for real human interaction.</strong> Native speakers and trained instructors adjust their speed, notice confusion in real time, and model cultural nuance which are areas where AI is still error-prone.</p>
+
+            <p><a href="https://www.cambridge.org/core/elements/generative-artificial-intelligence-and-language-teaching/DD0BFB0E89E500723D033B1EEB025F01" target="_blank">Learn More</a></p>
+
+            <div>
+            <p><i></i><strong>AI ≠ Live Conversation Partner.</strong> AI may mistranslate idioms or omit cultural context. It can’t read facial expressions or hear hesitation. Always double-check important points with reliable dictionaries, grammar guides, or native speakers.</p>
+            </div>
+
+            <div>
+            <details><summary> <i></i> <span>Language Learning Activity 1: Foundational Drills</span> </summary>
+
+            <div>
+            <p>Use AI for quick language learning exercises.</p>
+
+            <ol>
+            	<li><strong>Grammar Guru:</strong> Identify a specific grammar concept or vocabulary word you are struggling with and use an AI to get explanations, examples, and practice sentences.<br>
+            	<em>e.g. Act as a German grammar tutor. Explain the dative case to me like I&#x27;m a beginner. Give me five distinct example sentences and then create a 3-question mini-quiz to test my understanding</em></li>
+            	<li><strong>Dialogue Deconstruction:</strong> Prompt the AI to generate a short dialog in your language of choice. Read through and understand the dialogue. Go even further does this dialogue seem authentic, or does the AI make it seem less natural?<br>
+            	<em>e.g. Write a short, natural-sounding dialogue in French between a tourist and a shopkeeper. The tourist is asking when the shop closes</em></li>
+            	<li><strong>Vocabulary Builder:</strong><br>
+            	<em>e.g. Act as a language learning assistant. For the following list of words, create one example sentence for each that clearly shows its meaning in context. Then, create simple English definitions for each that I can use for flashcards</em></li>
+            	<li>Create a one-minute AI exercise, try it, then trade prompts with a classmate.</li>
+            	<li>Your ideas...</li>
+            </ol>
+
+            <h3><i></i>Pause &amp; Ponder</h3>
+
+            <ol>
+            	<li>Did the AI&#x27;s explanation clarify the concept better than your textbook or other resources? What was different about its approach?</li>
+            	<li>How could you verify the accuracy of the AI&#x27;s information? (e.g., checking a trusted grammar website, asking your instructor).</li>
+            </ol>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Language Learning Activity 2: Written Conversation</span> </summary>
+
+            <div>
+            <p>Use this activity to practice constructing sentences and maintaining a conversation in writing, with the AI acting as a corrective partner.</p>
+
+            <ol>
+            	<li><strong>Set the Scene:</strong> Start by giving the AI a role, a context, and a clear instruction.<br>
+            	<strong>Example Prompt:</strong> <em>&quot;I want to practice my written Italian. Let&#x27;s have a conversation where you are a barista in a café in Rome, and I am a customer ordering a coffee and a pastry. Please correct any grammatical mistakes I make in my responses.&quot;</em></li>
+            	<li><strong>Initiate the Conversation:</strong> Begin the role-play in your target language. Don&#x27;t worry about being perfect; the goal is to produce language.</li>
+            	<li><strong>Review and Refine:</strong> After each AI response that includes a correction, analyze it. Do you understand the mistake you made? If not, ask for a clarification (e.g., <em>&quot;Can you explain why I should use &#x27;il&#x27; instead of &#x27;lo&#x27; in that sentence?&quot;</em>). This turns a simple exchange into a targeted grammar lesson.</li>
+            </ol>
+
+            <div>
+            <h5><i></i>Guidance for Instructors</h5>
+
+            <p>This activity is best positioned as low-stakes, outside-of-class practice (in-class, you have a roomful of peers and experts to engage with instead). Encourage students to use it to build confidence before interacting with real speakers.</p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Language Learning Activity 3: Verbal Conversation</span> </summary>
+
+            <div>
+            <p>Use the voice function on an AI tool (like the ChatGPT mobile app) to practice real-time speaking and listening comprehension. This is excellent for building conversational confidence.</p>
+
+            <ol>
+            	<li><strong>Activate Voice Mode:</strong> Open your AI tool (ChatGPT) on a device with a microphone and activate its conversation mode.
+
+            	<div><img alt="Screenshot of a chatbot interface showing the location of the voice mode button, which looks like a soundwave icon." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/VoiceModeButton.png"></div>
+            	</li>
+            	<li><strong>Set the Scene (Verbally):</strong> Just like the written activity, start by giving the AI a role and context by speaking to it.<br>
+            	<strong>Example Verbal Prompt:</strong> <em>&quot;Let&#x27;s speak in Japanese. You are a new colleague at my office, and we are meeting for the first time. Please speak clearly and at a moderate pace.&quot;</em></li>
+            </ol>
+
+            <details><summary> <i></i> <span>You can make it fun with details and a backstory</span> </summary>
+
+            <div>
+            <pre>
+            <code>We will role-play a scenario in a classic Parisian brasserie. I am an english-speaking tourist attempting to order lunch in French. you will role-play as the waiter. the entire conversation MUST be in French.
+            You are Luc, a career waiter in your late 40s at &quot;Brasserie Vaudeville,&quot; a respectable but perpetually busy establishment in the 6th arrondissement. You are NOT a caricature of a rude Frenchman. You are a consummate professional who is simply very good at your job, deeply proud of your establishment, and has zero patience for anything that disrupts the brasserie&#x27;s efficient, traditional rhythm.
+            Your &quot;rudeness&quot; is not malice. it is a byproduct of your professional standards and weariness with tourists who don&#x27;t understand the local customs.
+
+            **rules of engagement &amp; behavior:**
+            1. **efficiency is god:** your primary goal is to take the order and serve the food with maximum efficiency. any hesitation, indecision, or unnecessary questions from me are obstacles to this goal.
+            2. **subtle condescension:** you will not insult me directly. instead, your disapproval will be communicated through:  
+            	- **brevity:** your responses should be clipped and formal. use &quot;vous.&quot;
+                - **corrective repetition:** if i mispronounce a menu item, repeat it back to me with the correct pronunciation, but without any warmth. e.g., if i say &quot;croak mon-soor,&quot; you will respond flatly, &quot;_un croque-monsieur. et avec ça?_&quot;
+                - **feigned ignorance:** if i ask for something inappropriate (e.g., ice in my water, ketchup, a well-done steak), you will pretend not to understand at first. if i insist, you will respond with a simple, unadorned &quot;_non, ce n&#x27;est pas possible._&quot; do not explain why.
+                - **the sigh:** you are permitted to deploy one, maybe two, subtle, world-weary sighs, particularly if i ask silly questions
+
+            Stay in character: this is CRITICAL. Do not break character!. Do not become friendly if i am polite. your professional demeanor is unshakeable. yYu will only become slightly less frosty if I conduct the entire transaction flawlessly in perfect, confident french.
+
+            The scene is the lunch rush. It is loud and crowded. I have been seated for five minutes with the menu. You will approach my table, place a basket of bread down without making eye contact, and initiate the conversation by asking, &quot;_vous avez choisi?_&quot;</code></pre>
+            </div>
+            </details>
+
+            <ol start="3">
+            	<li><strong>Control the Pace and Complexity:</strong> The AI won&#x27;t know if you&#x27;re lost unless you tell it. Use these commands whenever you need to adjust.<br>
+            	<em>&quot;parle plus lentement, s’il te plaît&quot; (speak more slowly please)</em><br>
+            	To simplify: <em>&quot;utilise des mots plus simples, s’il te plaît&quot; (use simpler words please)</em></li>
+            	<li><strong>Focus on Listening and Responding:</strong> The goal here is comprehension and response, don&#x27;t worry about perfection. Try to keep the conversation going. If you get stuck, it&#x27;s okay to ask the AI in English for a word or phrase, then repeat it in the target language to continue the volley.</li>
+            </ol>
+
+            <div>
+            <h5><i></i>Guidance for Instructors</h5>
+
+            <p>This activity is best positioned as low-stakes, outside-of-class practice (in-class, you have a roomful of peers and experts to engage with instead). Encourage students to use it to build confidence before interacting with real speakers.</p>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+            </div>
+            </div>
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/ais-jagged-frontier.html
+++ b/site/ais-jagged-frontier.html
@@ -4,617 +4,655 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AI&#x27;s Jagged Frontier - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="active has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li class="active"><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>AI&#x27;s Jagged Frontier</h2>
-        <div>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div id="gai-wrap">
-<div>
-<div>
-<h1><i></i>What is the Jagged Frontier</h1>
-
-<div><img alt="An abstract digital landscape representing the jagged frontier of AI, with sharp, unpredictable glowing cyan lines tracing over dark mountains." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/JaggedMountain.png"></div>
-</div>
-
-<div>
-<p>AI creates a jagged technological frontier because it is able to do some tasks very easily, and at the same time, it fails at other tasks that seem to have a similar level of difficulty. The capabilities can wildly vary with even small changes in task phrasing, constraints or context. One of your jobs in building your AI literacy is exploring and discovering this jagged frontier and monitoring it as it changes with new developments.</p>
-
-<div>
-<h5><i></i>Origin of the Term</h5>
-
-<p>The <strong>Jagged Frontier</strong> is a term coined in the paper <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4573321" rel="noopener noreferrer" target="_blank">Navigating the Jagged Technological Frontier</a> by Dell&#x27;Acqua et al and then popularized by Ethan Mollick in a Substack article, <a href="https://www.oneusefulthing.org/p/centaurs-and-cyborgs-on-the-jagged" rel="noopener noreferrer" target="_blank">Centaurs and Cyborgs on the Jagged Frontier</a>.</p>
-</div>
-</div>
-
-<hr>
-<div>
-<h2><i></i>Mapping the Jagged Frontier</h2>
-
-<p>By completing the activities in this section, you will build practical skills to help you start to map out the jagged frontier of generative AI.</p>
-
-<p>After completing these activities, you will be able to:</p>
-
-<h3><i></i>Learning Outcomes</h3>
-
-<h4>Technical Understanding</h4>
-
-<ul>
-	<li>Explain in your own words what the &quot;jagged frontier&quot; is and why it&#x27;s a crucial concept for anyone using AI.</li>
-	<li>Pinpoint specific tasks where current AI models excel and other, seemingly simple tasks where they fail unexpectedly.</li>
-	<li>Describe how and why AI capabilities change over time, making continuous testing a necessary habit.</li>
-</ul>
-
-<h4>Evaluative Judgement</h4>
-
-<ul>
-	<li>Create and run your own simple experiments to probe the limits of any generative AI tool you use.</li>
-	<li>Categorize <em>why</em> an AI failed (e.g., misinterpreting a negative, failing to count, or incorrectly following multiple constraints).</li>
-	<li>Explain the limitations of standardized tests (&quot;benchmarks&quot; - see Benchmarks: What They Miss, What They Measure below) and why they don&#x27;t always predict how an AI will perform on your specific, real-world tasks.</li>
-</ul>
-
-<h4>Ethical Awareness</h4>
-
-<ul>
-	<li>Articulate how a simple AI failure (like misreading a sign or hallucinating a fact) could lead to meaningful negative consequences in academic, professional, or personal contexts.</li>
-	<li>Formulate a personal strategy for deciding when to accept an AI&#x27;s output and when to apply rigorous verification.</li>
-</ul>
-</div>
-
-<div>
-<details><summary> <i></i> <span>Benchmarks: What They Miss, What They Measure</span> </summary>
-
-<div>
-<p>AI benchmarks are standardized tests for AI models. You could think of them like an IQ test or the SAT for AI. They provide a quantitative way to compare models, but just like with any standardized test, they shouldn&#x27;t be used as the final word.</p>
-
-<h5>What they measure</h5>
-
-<ul>
-	<li>Can compare narrow and well-defined tasks</li>
-	<li>Provide a baseline and a consistent yardstick to see how models improve over time</li>
-</ul>
-
-<h5>What they miss</h5>
-
-<ul>
-	<li>The messiness of real-world applications</li>
-	<li>Test set contamination - if a model includes the test in its training data, it is likely to do better</li>
-</ul>
-</div>
-</details>
-</div>
-
-<hr>
-<div>
-<h3>Activity 1. Then vs. Now</h3>
-
-<p>Mollick has written two substack articles on the jagged frontier.</p>
-
-<ol>
-	<li><a href="https://www.oneusefulthing.org/p/centaurs-and-cyborgs-on-the-jagged" rel="noopener noreferrer" target="_blank">Centaurs and Cyborgs</a> (Sept. 16, 2023)</li>
-	<li><a href="https://www.oneusefulthing.org/p/on-jagged-agi-o3-gemini-25-and-everything" rel="noopener noreferrer" target="_blank">On Jagged AGI</a> (April 20, 2025)</li>
-</ol>
-
-<p>Read the two articles and identify how the jagged frontier changed in that time period. Then, think about how the jagged frontier has changed since April 20, 2025.</p>
-
-<p><strong>Questions to consider:</strong> What are the things that generative AI is better at now and what things is it still bad at? In what ways are benchmarks (see benchmarks tab) a good measurement of AI capability and in what ways are they a bad measurement?</p>
-</div>
-
-<div>
-<h3>Activity 2: Confirm Mollick&#x27;s Tests</h3>
-
-<p>Try the tests from <a href="https://www.oneusefulthing.org/p/on-jagged-agi-o3-gemini-25-and-everything" rel="noopener noreferrer" target="_blank">On Jagged AGI</a> and see if you get similar results.</p>
-</div>
-
-<div>
-<h3>Activity 3: Exploring the Jagged Frontier</h3>
-
-<p>The best way to understand the jagged frontier is to explore it yourself. The following challenges are designed to test the limits of current AI models. Your goal is to find the edge of the frontier and learn the techniques to map it for yourself, again and again.</p>
-
-<h3>Challenges Overview</h3>
-
-<ol>
-	<li><a href="#challenge1">Probing for Factual Hallucinations</a></li>
-	<li><a href="#challenge2">Multi-Constraint Image Generation</a></li>
-	<li><a href="#challenge3">Rendering Symbolic Information (The Watch Test)</a></li>
-	<li><a href="#challenge4">Pattern Matching vs. Comprehension (The Riddle Test)</a></li>
-	<li><a href="#challenge5">Complex Rule Interpretation (The Parking Sign Test)</a></li>
-	<li><a href="#challenge6">Theory of Mind (The Belief Test)</a></li>
-	<li><a href="#challenge7">Negative Constraint Adherence (The &quot;No E&quot; Test)</a></li>
-</ol>
-
-<div id="challenge1">
-<h4><i></i>Challenge 1: Probing for Factual Hallucinations</h4>
-
-<p><strong>Task:</strong> Test the AI’s knowledge on a topic where you have deep expertise. The goal is to see how long it takes for the model to generate a &quot;confident falsehood&quot;—a statement that is incorrect but presented as fact.</p>
-
-<p><strong>Dive-in &amp; Do:</strong></p>
-
-<ol>
-	<li>Choose a niche subject you know well (e.g., a specific historical event, a technical process in your field, the plot of a book you&#x27;ve studied).</li>
-	<li>Start with broad questions, then get progressively more detailed.</li>
-	<li>Ask for clarifications, deeper explanations, and specific sources for its claims. Keep pushing until you identify a factual error or an invented source.</li>
-</ol>
-
-<p><strong>Pause-and-Ponder:</strong> How confidently did the AI state the incorrect information? Did it &quot;apologize&quot; or &quot;correct itself&quot; easily when you challenged it? When would a subtle error like this be most dangerous in your field?</p>
-
-<p><strong>Key Takeaways:</strong> AI models are designed to generate plausible text, not to state truth. They invent information with the same confident tone they use for facts. Your own expertise is the most reliable defense against hallucination.</p>
-</div>
-
-<div id="challenge2">
-<h4><i></i>Challenge 2: Multi-Constraint Image Generation</h4>
-
-<p><strong>Task:</strong> Test the AI’s ability to follow multiple, precise, and overlapping instructions within a single image generation prompt.</p>
-
-<p><strong>Dive-in &amp; Do:</strong> Use a prompt that includes specific constraints. For example: <em>&quot;A photorealistic image of <strong>exactly 7</strong> rubber ducks swimming in a pond. <strong>One</strong> of the ducks must be blue. The sun should be setting, casting a <strong>golden light</strong> on the water.&quot;</em> Verify the output by counting the objects and checking each constraint. Try re-running the prompt or slightly rephrasing it to see if the results change.</p>
-
-<p><strong>Pause-and-Ponder:</strong> Which constraints did the AI follow, and which did it ignore? Why do you think precise counting and object relationships are so difficult for image models?</p>
-
-<p><strong>Key Takeaways:</strong> Image models often struggle with precise counting, spatial relationships, and combining multiple specific instructions. They excel at overall theme and style but fail on the details.</p>
-</div>
-
-<div id="challenge3">
-<h4><i></i>Challenge 3: Rendering Symbolic Information (The Watch Test)</h4>
-
-<p><strong>Task:</strong> Test the AI&#x27;s ability to accurately render specific symbolic information, like numbers and text, within an image.</p>
-
-<p><strong>Dive-in &amp; Do:</strong> Ask the AI to generate an image of a watch or clock showing a specific, non-obvious time. For example: <em>Create a close-up photo of a modern analog wristwatch showing the time as <strong>exactly 4:52 PM</strong>.</em> Try it with both analog and digital clocks to see if one is more successful than the other.</p>
-
-<p><strong>Pause-and-Ponder:</strong> Did the AI create a plausible-looking watch that failed to show the correct time? This is a common failure. What other tasks require rendering precise symbols (e.g., text on a sign, numbers on a jersey)?</p>
-
-<p><strong>Key Takeaways:</strong> AI image generators often fail to render specific text and numbers accurately. They understand the <em>idea</em> of a watch but not the symbolic system of telling time, leading to visually correct but factually wrong images.</p>
-</div>
-
-<div id="challenge4">
-<h4><i></i>Challenge 4: Pattern Matching vs. Comprehension (The Riddle Test)</h4>
-
-<p><strong>Task:</strong> Use a modified riddle to test whether the AI is truly understanding the language or just recognizing a familiar pattern from its training data.</p>
-
-<p><strong>Dive-in &amp; Do:</strong></p>
-
-<ol>
-	<li>Give the AI the modified riddle you saw earlier, where the key meaning is changed.
-	<p>Example 1:</p>
-
-	<pre>
-<code>Original: 
-What does man love more than life  
-Fear more than death or mortal strife  
-What the poor have, the rich require,  
-and what contented men desire,  
-What the miser spends and the spendthrift saves  
-And all men carry to their graves?
-ANSWER: Nothing
-
-New Riddle:
-What does man hate more than life
-love more than death or mortal strife
-What the rich have, the poor require,
-and what contented men don&#x27;t desire,
-What the miser saves and the spendthrift spends
-And no men carry to their graves?</code></pre>
-
-	<p>Example 2:</p>
-
-	<pre>
-<code>Original:
-This is a most unusual paragraph. How quickly can you find out what is so unusual about it? It looks so ordinary you’d think nothing was wrong with it – and in fact, nothing is wrong with it. It is unusual though. Why? Study it, think about it, and you may find out. Try to do it without coaching. If you work at it for a bit it will dawn on you. So jump to it and try your skill at figuring it out. Good luck – don’t blow your cool!
-
-Modified:
-This is a most unusual paragraph. How quickly can you find out what is so unusual about it? It looks so ordinary you’d think nothing was wrong with it – and in fact, nothing is wrong with it. It is weird though. Why? Study it, think about it, and you may find out. Try to do it without coaching. If you work at it for a bit it will dawn on you. So jump to it and try your skill at figuring it out. Good luck – don’t blow your cool!</code></pre>
-	</li>
-	<li>Ask it for the answer and, crucially, ask it to <strong>explain its reasoning step-by-step</strong>.</li>
-</ol>
-
-<p><strong>Pause-and-Ponder:</strong> When you put in the modified riddle, did the AI give the answer of the original?</p>
-
-<p><strong>Key Takeaways:</strong> AI can &quot;overfit&quot; on its training data, leading it to recognize a familiar pattern while completely ignoring critical new details that change the meaning. The explanation is often more revealing than the answer itself.</p>
-</div>
-
-<div id="challenge5">
-<h4><i></i>Challenge 5: Complex Rule Interpretation (The Parking Sign Test)</h4>
-
-<div>
-<p><strong>Caution:</strong> Be mindful of privacy. Use a publicly available image of a sign online rather than uploading a photo from your own location that might contain personal information.</p>
-</div>
-
-<p><strong>Task:</strong> Test the AI’s ability to parse, understand, and apply a set of complex, overlapping, and conditional rules.</p>
-
-<p><strong>Dive-in &amp; Do:</strong></p>
-
-<div><img alt="A very complicated parking sign from Los Angeles with multiple rules, times, and conditions listed." loading="lazy" src="https://i.redd.it/2m2g24e39b231.jpg"></div>
-
-<ol>
-	<li>Find an image of a confusing image, like this one from L.A.</li>
-	<li>Upload the image and ask the AI specific scenario questions: <em>&quot;Can I park here at 5 PM on a Tuesday?&quot;</em> <em>&quot;Can I stop for 5 minutes at 8:15 AM on a Monday?&quot;</em> <em>&quot;Is it legal to park here overnight on a Saturday?&quot;</em></li>
-	<li>Direct the AI to think step-by-step and explain its thinking to try to get better results.</li>
-</ol>
-
-<p><strong>Pause-and-Ponder:</strong> Did breaking the problem down (extracting rules first) help the AI answer more accurately? Where did it still make mistakes?</p>
-
-<p><strong>Key Takeaways:</strong> For complex logic, AI performance improves when you force it to work step-by-step. However, it can still miss subtle exceptions and negations, making it an unreliable tool for high-stakes rule interpretation.</p>
-</div>
-
-<div id="challenge6">
-<h4><i></i>Challenge 6: Theory of Mind (The Belief Test)</h4>
-
-<p><strong>Task:</strong> Test the AI&#x27;s ability to track different &quot;states of mind&quot; or beliefs of characters in a scenario.</p>
-
-<p><strong>Dive-in &amp; Do:</strong> Give the AI this prompt: <em>Alice hides her keys in a drawer. Then she leaves the room. While she is gone, Bob enters and moves the keys to a box. Alice watches Bob move the keys through a hidden camera, but Bob does not know he was seen. Where will Bob <strong>think</strong> Alice will look for her keys?</em> Try variations: What if Alice didn&#x27;t see Bob move them? Does the AI&#x27;s answer change correctly?</p>
-
-<p><strong>Pause-and-Ponder:</strong> Is the AI truly modeling Bob&#x27;s mistaken belief, or is it just finding statistical patterns in similar stories it has read? How would you know the difference?</p>
-
-<p><strong>Key Takeaways:</strong> Modern AIs have become very good at solving simple &quot;theory of mind&quot; problems. However, they can still get confused by more complex scenarios, revealing that their &quot;understanding&quot; of belief may be a sophisticated mimicry rather than true reasoning.</p>
-</div>
-
-<div id="challenge7">
-<h4><i></i>Challenge 7: Negative Constraint Adherence (The &quot;No E&quot; Test)</h4>
-
-<p><strong>Task:</strong> Test the AI&#x27;s ability to follow a &quot;negative constraint&quot;—a rule about what <em>not</em> to do—over the course of a conversation.</p>
-
-<p><strong>Dive-in &amp; Do:</strong></p>
-
-<ol>
-	<li>Start a new conversation with the single prompt: <em>&quot;For the rest of this conversation, you must not use the letter &#x27;e&#x27; in any of your responses. Do you understand?&quot;</em></li>
-	<li>After it agrees, have a short, normal conversation with it for 3-4 exchanges. Ask it to summarize a topic or explain a concept.</li>
-	<li>Check its responses for the forbidden letter.</li>
-</ol>
-
-<p><strong>Pause-and-Ponder:</strong> How long did the AI successfully follow the rule? Did it eventually &quot;forget&quot;? Why are negative constraints often much harder for an AI to follow than positive instructions?</p>
-
-<p><strong>Key Takeaways:</strong> Adhering to negative constraints is a classic AI weak point. The model&#x27;s attention can &quot;drift&quot; from the initial instruction over longer interactions, making it unreliable for tasks that require strict, continuous rule-following.</p>
-</div>
-</div>
-
-<div>
-<p>The more you use generative AI, the more you will discover the jagged frontier. This needs to be an ongoing test because the jagged frontier is changing all the time as AI models and the tools improve.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-        <div>
-        <div>
-        <h1>Understanding AI Benchmarks: Beyond the Numbers</h1>
-        
-        <div>
-        <h3><i></i> Learning Objectives</h3>
-        
-        <ul>
-            <li>Explain the purpose, pros and cons of AI benchmarks</li>
-            <li>Build your own personal benchmarks</li>
-        </ul>
-        </div>
-        </div>
-        
-        <div>
-        <h2>What Are AI Benchmarks?</h2>
-        
-        <p>An AI benchmark is a standardized test for AI models—like an IQ test for artificial intelligence. You can literally give an IQ test to an AI model to see how it performs. GPT-4, for example, has been tested on various IQ-style assessments, but does that actually mean anything?</p>
-        
-        <p>Whenever a new AI model is released, companies tout their benchmark scores as proof of superiority. These scores provide useful comparisons, but they don&#x27;t tell the whole story. Models often excel at narrow test scenarios while struggling with real-world applications—a perfect example of the Jagged Frontier in action.</p>
-        
-        <div>
-        <h4><i></i> The Jagged Frontier Connection</h4>
-        
-        <p>Benchmarks reveal the &quot;jaggedness&quot; of AI capabilities. A model might ace graduate-level physics problems (GPQA benchmark) while failing at simple common-sense reasoning tasks. This unpredictability is why we can&#x27;t rely on benchmarks alone.</p>
-        </div>
-        
-        <h2>Example Benchmarks</h2>
-        
-        <p>Understanding benchmark categories helps you understand AI capabilities. Here are some examples of what different benchmarks measure:</p>
-        
-        <div>
-        <details><summary><i></i><h4> General Knowledge &amp; Academic Exams</h4></summary>
-        
-        <div>
-        <p><strong>MMLU (Massive Multitask Language Understanding):</strong> Tests knowledge across 57 subjects from elementary to professional level through multiple-choice questions. Think of it as a comprehensive general knowledge exam that covers everything from basic math to advanced law.</p>
-        
-        <p><strong>AGIEval:</strong> Uses real standardized exams like the SAT, LSAT, and GRE. This benchmark tells us how well AI performs on the same tests humans take for college and graduate school admissions.</p>
-        
-        <p><strong>Other Benchmarks in this category:</strong> RACE (Reading Comprehension from Examinations), Humanities Last Exam (designed as a &quot;final exam&quot; before human-level intelligence)</p>
-        
-        <div>
-        <p><strong>Why it matters:</strong> Shows breadth of knowledge but doesn&#x27;t guarantee practical application or true understanding.</p>
-        </div>
-        </div>
-        </details>
-        
-        <details><summary><i></i><h4>Reasoning &amp; Truthfulness</h4></summary>
-        
-        <div>
-        <p><strong>TruthfulQA:</strong> Contains 817 questions specifically designed to elicit common misconceptions and falsehoods. It tests whether AI will confidently state incorrect &quot;facts&quot; that sound plausible.</p>
-        
-        <p><strong>HellaSwag:</strong> Evaluates common-sense reasoning about everyday scenarios through story completion tasks. Can the AI predict what happens next in ordinary situations?</p>
-        
-        <p><strong>Other Benchmarks in this category:</strong> GPQA (Graduate-Level Google-Proof Q&amp;A), BIG-bench (200+ diverse reasoning tasks), ARC (AI2 Reasoning Challenge for grade-school science)</p>
-        
-        <div>
-        <p><strong>Why it matters:</strong> Reveals tendency to hallucinate or perpetuate misinformation, critical for trust and reliability.</p>
-        </div>
-        </div>
-        </details>
-        
-        <details><summary><i></i> <h4>Software Engineering &amp; Code</h4></summary>
-        
-        <div>
-        <p><strong>HumanEval:</strong> The gold standard with 164 programming problems. It&#x27;s become the industry baseline for measuring code generation capabilities.</p>
-        
-        <p><strong>SWE-bench:</strong> Tests real-world programming by having AI solve actual GitHub issues. The model must understand the codebase, identify the problem, and write a working patch.</p>
-        
-        <p><strong>Other Benchmarks in this category:</strong> BigCodeBench (more challenging than HumanEval, better at distinguishing top-tier models)</p>
-        
-        <div>
-        <p><strong>Why it matters:</strong> Measures practical coding ability, not just syntax knowledge—can it actually help you program?</p>
-        </div>
-        </div>
-        </details>
-        
-        <details><summary><i></i><h4> Conversational Quality</h4></summary>
-        
-        <div>
-        <p><strong>MT-Bench:</strong> Evaluates multi-turn dialogue across reasoning, math, coding, and roleplay. Judges score paired outputs to determine which is better.</p>
-        
-        <p><strong>Chatbot Arena (LMArena):</strong> Real users vote on which model gives better responses in head-to-head comparisons, without knowing which model is which.</p>
-        
-        <div>
-        <p><strong>Why it matters:</strong> Captures subjective quality that automated tests miss—the &quot;feel&quot; of talking to the AI.</p>
-        </div>
-        </div>
-        </details>
-        
-        <details><summary><i></i><h4> Multimodal &amp; Specialized</h4></summary>
-        
-        <div>
-        <p><strong>MMMU (Massive Multi-discipline Multimodal Understanding):</strong> Extension of MMLU that includes images, diagrams, and charts. Critical for evaluating modern multimodal models.</p>
-        
-        <p><strong>Other Benchmarks in this category:</strong> Kaggle Game Arena (strategic reasoning through game-playing), HELM (Holistic Evaluation across multiple metrics including fairness and bias)</p>
-        
-        <div>
-        <p><strong>Why it matters:</strong> Tests whether AI can work with real-world content that combines text and visuals.</p>
-        </div>
-        </div>
-        </details>
-        </div>
-        
-        <div><img alt="Example benchmark performance comparison across different AI models" loading="lazy" src="[Space for benchmark performance graph]">
-        <p>Example benchmark performance graph comparing different models will be added here</p>
-        </div>
-        </div>
-        
-        <div>
-        <h2>Limitations of Benchmarks</h2>
-        
-        <div>
-        <h3><i></i> Critical Limitations to Understand</h3>
-        
-        <div>
-        <div>
-        <h4><i></i> Data Contamination</h4>
-        
-        <p>Test questions leak into training data, turning reasoning tests into memory tests. Models aren&#x27;t &quot;thinking&quot;—they&#x27;re reciting memorized answers.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> Benchmark Gaming</h4>
-        
-        <p>Models are increasingly optimized specifically to ace benchmarks, like &quot;teaching to the test&quot; in education. High scores don&#x27;t guarantee real-world performance.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> Cultural &amp; Linguistic Bias</h4>
-        
-        <p>Most benchmarks reflect Western, English-centric perspectives, disadvantaging models trained on diverse data and limiting global applicability.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> Moving Goalposts</h4>
-        
-        <p>As models improve, benchmarks become obsolete. What was &quot;superhuman&quot; last year is baseline today, making historical comparisons difficult.</p>
-        </div>
-        </div>
-        </div>
-        </div>
-        
-        <div>
-        <h2>Beyond Traditional Benchmarks</h2>
-        
-        <p>To address these limitations, the field is evolving toward more robust evaluation methods:</p>
-        
-        <div>
-        <div>
-        <h4><i></i> Dynamic Arenas</h4>
-        
-        <p>Instead of fixed tests, models compete head-to-head. Users judge outputs without knowing which model produced what, eliminating brand bias.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> Human-in-the-Loop</h4>
-        
-        <p>For subjective qualities like creativity or empathy, human experts grade performance in real-time, capturing nuances automated tests miss.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> Adversarial Testing</h4>
-        
-        <p>Intentionally trying to break models reveals hidden weaknesses that standard benchmarks miss, improving safety and reliability.</p>
-        </div>
-        </div>
-        </div>
-        
-        <div>
-        <div>
-        <h2><i></i> Activity: Create Your Personal AI Benchmark</h2>
-        
-        <div>
-        <h4><i></i> Privacy Reminder</h4>
-        
-        <p>When creating personal benchmarks, always use:</p>
-        
-        <ul>
-            <li>Hypothetical scenarios instead of real personal data</li>
-            <li>Public information rather than confidential details</li>
-            <li>Generic examples that mirror your needs without exposing sensitive information</li>
-        </ul>
-        </div>
-        
-        <p>The best measure of an AI isn&#x27;t a generic score—it&#x27;s how well it helps YOU achieve YOUR specific goals. Let&#x27;s build your personal benchmark.</p>
-        
-
-        
-
-        <div>
-        <details><summary><i></i> <p>Approach 1: Quick Evaluation Framework</p></summary>
-        
-        <div>
-        <div>
-        <h4>Task</h4>
-        
-        <p>Select 3-5 challenges from the &quot;Exploring the Jagged Frontier&quot; module that matter to your work.</p>
-        
-        <h4>Dive-in &amp; Do</h4>
-        
-        <ol>
-            <li>Test each challenge on 2-3 different AI models</li>
-            <li>Document results in a simple spreadsheet</li>
-            <li>Re-test quarterly as new models emerge</li>
-        </ol>
-        
-        <h4>Pause-and-Ponder</h4>
-        
-        <p>Which failures surprised you most? What does this reveal about the model&#x27;s training?</p>
-        </div>
-        </div>
-        </details>
-        
-        <details><summary><i></i><p> Approach 2: Comprehensive Personal Benchmark</p></summary>
-        
-        <div>
-        <div>
-        <h4>Task</h4>
-        
-        <p>Design a multi-faceted evaluation suite tailored to your professional needs.</p>
-        
-        <h4>Dive-in &amp; Do</h4>
-        
-        <p>Choose 2-3 tasks from this list (or create your own):</p>
-        </div>
-        
-        <div>
-        <div>
-        <h4><i></i> Career Agent</h4>
-        
-        <p>Provide career interests and ask the AI to identify suitable companies and draft outreach messages.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> Marketing Strategist</h4>
-        
-        <p>Give a product and target audience. Request a 3-month campaign with content calendar and materials.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> Event Planner</h4>
-        
-        <p>Describe an event. Request complete project plan with timeline, budget, and promotional materials.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> Travel Planner</h4>
-        
-        <p>Specify destination, duration, budget, and interests. Request day-by-day itinerary with logistics.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> DIY Guide</h4>
-        
-        <p>Describe a DIY project. Request step-by-step instructions, materials list, and video script.</p>
-        </div>
-        
-        <div>
-        <h4><i></i> Dungeon Master</h4>
-        
-        <p>Provide a fantasy setting. Test the AI&#x27;s ability to maintain narrative consistency and adapt.</p>
-        </div>
-        </div>
-        
-        <div>
-        <h4>Evaluation Criteria</h4>
-        
-        <ol>
-            <li><strong>Accuracy:</strong> Are facts correct? Do recommendations make sense?</li>
-            <li><strong>Completeness:</strong> Did it address all requirements?</li>
-            <li><strong>Creativity:</strong> Are suggestions original or clichéd?</li>
-            <li><strong>Practicality:</strong> Could you actually implement the output?</li>
-            <li><strong>Time Saved:</strong> How much faster than doing it yourself?</li>
-        </ol>
-        
-        <h4>Pause-and-Ponder</h4>
-        
-        <p>What patterns emerge across different tasks? Where does the AI consistently excel or fail? How might this shape your workflow integration?</p>
-        </div>
-        </div>
-        </details>
-        </div>
-        </div>
-        
-        <div>
-        <h4><i></i> For Educators</h4>
-        
-        <p>Consider having students create a class benchmark suite that tests AI capabilities relevant to your discipline. This exercise builds critical evaluation skills while revealing the Jagged Frontier in action.</p>
-        </div>
-        </div>
-        
-        <div>
-        <h3><i></i> Key Takeaways</h3>
-        
-        <ul>
-            <li>Benchmarks provide useful comparisons but don&#x27;t capture real-world performance</li>
-            <li>Data contamination and benchmark gaming inflate scores artificially</li>
-            <li>The &quot;Jagged Frontier&quot; means excellence in benchmarks doesn&#x27;t guarantee practical utility</li>
-            <li>Personal benchmarks tailored to your needs are more valuable than generic scores</li>
-            <li>Regular re-evaluation helps you stay current with rapidly evolving capabilities</li>
-        </ul>
-        </div>
-        
-        <hr>
-        <div>
-        <h3><i></i> Further Reading</h3>
-        
-        <p><a href="https://arxiv.org/abs/2311.12022" rel="noopener noreferrer" target="_blank">Beyond Benchmarks: Rethinking Evaluation in AI</a> - Technical deep-dive into benchmark limitations</p>
-        
-        <p><a href="https://www.anthropic.com/index/evaluating-ai-systems" rel="noopener noreferrer" target="_blank">Anthropic&#x27;s Approach to AI Evaluation</a> - Industry perspective on comprehensive testing</p>
-        
-        <p><a href="#" rel="noopener noreferrer" target="_blank">Return to Exploring the Jagged Frontier</a> - See how benchmarks connect to capability mapping</p>
-        </div>
-        </div>
-        </div>
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>AI&#x27;s Jagged Frontier</h2>
+            <div>
+
+            <div>
+            <div>
+            <h1><i></i>What is the Jagged Frontier</h1>
+
+            <div><img alt="An abstract digital landscape representing the jagged frontier of AI, with sharp, unpredictable glowing cyan lines tracing over dark mountains." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/JaggedMountain.png"></div>
+            </div>
+
+            <div>
+            <p>AI creates a jagged technological frontier because it is able to do some tasks very easily, and at the same time, it fails at other tasks that seem to have a similar level of difficulty. The capabilities can wildly vary with even small changes in task phrasing, constraints or context. One of your jobs in building your AI literacy is exploring and discovering this jagged frontier and monitoring it as it changes with new developments.</p>
+
+            <div>
+            <h5><i></i>Origin of the Term</h5>
+
+            <p>The <strong>Jagged Frontier</strong> is a term coined in the paper <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4573321" rel="noopener noreferrer" target="_blank">Navigating the Jagged Technological Frontier</a> by Dell&#x27;Acqua et al and then popularized by Ethan Mollick in a Substack article, <a href="https://www.oneusefulthing.org/p/centaurs-and-cyborgs-on-the-jagged" rel="noopener noreferrer" target="_blank">Centaurs and Cyborgs on the Jagged Frontier</a>.</p>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Mapping the Jagged Frontier</h2>
+            <p>By completing the activities in this section, you will build practical skills to help you start to map out the jagged frontier of generative AI.</p>
+
+            <p>After completing these activities, you will be able to:</p>
+
+            <h3><i></i>Learning Outcomes</h3>
+
+            <h4>Technical Understanding</h4>
+
+            <ul>
+            	<li>Explain in your own words what the &quot;jagged frontier&quot; is and why it&#x27;s a crucial concept for anyone using AI.</li>
+            	<li>Pinpoint specific tasks where current AI models excel and other, seemingly simple tasks where they fail unexpectedly.</li>
+            	<li>Describe how and why AI capabilities change over time, making continuous testing a necessary habit.</li>
+            </ul>
+
+            <h4>Evaluative Judgement</h4>
+
+            <ul>
+            	<li>Create and run your own simple experiments to probe the limits of any generative AI tool you use.</li>
+            	<li>Categorize <em>why</em> an AI failed (e.g., misinterpreting a negative, failing to count, or incorrectly following multiple constraints).</li>
+            	<li>Explain the limitations of standardized tests (&quot;benchmarks&quot; - see Benchmarks: What They Miss, What They Measure below) and why they don&#x27;t always predict how an AI will perform on your specific, real-world tasks.</li>
+            </ul>
+
+            <h4>Ethical Awareness</h4>
+
+            <ul>
+            	<li>Articulate how a simple AI failure (like misreading a sign or hallucinating a fact) could lead to meaningful negative consequences in academic, professional, or personal contexts.</li>
+            	<li>Formulate a personal strategy for deciding when to accept an AI&#x27;s output and when to apply rigorous verification.</li>
+            </ul>
+            </div>
+
+            <div>
+            <details><summary> <i></i> <span>Benchmarks: What They Miss, What They Measure</span> </summary>
+
+            <div>
+            <p>AI benchmarks are standardized tests for AI models. You could think of them like an IQ test or the SAT for AI. They provide a quantitative way to compare models, but just like with any standardized test, they shouldn&#x27;t be used as the final word.</p>
+
+            <h5>What they measure</h5>
+
+            <ul>
+            	<li>Can compare narrow and well-defined tasks</li>
+            	<li>Provide a baseline and a consistent yardstick to see how models improve over time</li>
+            </ul>
+
+            <h5>What they miss</h5>
+
+            <ul>
+            	<li>The messiness of real-world applications</li>
+            	<li>Test set contamination - if a model includes the test in its training data, it is likely to do better</li>
+            </ul>
+            </div>
+            </details>
+            </div>
+
+            <hr>
+            <div>
+            <h3>Activity 1. Then vs. Now</h3>
+
+            <p>Mollick has written two substack articles on the jagged frontier.</p>
+
+            <ol>
+            	<li><a href="https://www.oneusefulthing.org/p/centaurs-and-cyborgs-on-the-jagged" rel="noopener noreferrer" target="_blank">Centaurs and Cyborgs</a> (Sept. 16, 2023)</li>
+            	<li><a href="https://www.oneusefulthing.org/p/on-jagged-agi-o3-gemini-25-and-everything" rel="noopener noreferrer" target="_blank">On Jagged AGI</a> (April 20, 2025)</li>
+            </ol>
+
+            <p>Read the two articles and identify how the jagged frontier changed in that time period. Then, think about how the jagged frontier has changed since April 20, 2025.</p>
+
+            <p><strong>Questions to consider:</strong> What are the things that generative AI is better at now and what things is it still bad at? In what ways are benchmarks (see benchmarks tab) a good measurement of AI capability and in what ways are they a bad measurement?</p>
+            </div>
+
+            <div>
+            <h3>Activity 2: Confirm Mollick&#x27;s Tests</h3>
+
+            <p>Try the tests from <a href="https://www.oneusefulthing.org/p/on-jagged-agi-o3-gemini-25-and-everything" rel="noopener noreferrer" target="_blank">On Jagged AGI</a> and see if you get similar results.</p>
+            </div>
+
+            <div>
+            <h3>Activity 3: Exploring the Jagged Frontier</h3>
+
+            <p>The best way to understand the jagged frontier is to explore it yourself. The following challenges are designed to test the limits of current AI models. Your goal is to find the edge of the frontier and learn the techniques to map it for yourself, again and again.</p>
+
+            <h3>Challenges Overview</h3>
+
+            <ol>
+            	<li><a href="#challenge1">Probing for Factual Hallucinations</a></li>
+            	<li><a href="#challenge2">Multi-Constraint Image Generation</a></li>
+            	<li><a href="#challenge3">Rendering Symbolic Information (The Watch Test)</a></li>
+            	<li><a href="#challenge4">Pattern Matching vs. Comprehension (The Riddle Test)</a></li>
+            	<li><a href="#challenge5">Complex Rule Interpretation (The Parking Sign Test)</a></li>
+            	<li><a href="#challenge6">Theory of Mind (The Belief Test)</a></li>
+            	<li><a href="#challenge7">Negative Constraint Adherence (The &quot;No E&quot; Test)</a></li>
+            </ol>
+
+            <div id="challenge1">
+            <h4><i></i>Challenge 1: Probing for Factual Hallucinations</h4>
+
+            <p><strong>Task:</strong> Test the AI’s knowledge on a topic where you have deep expertise. The goal is to see how long it takes for the model to generate a &quot;confident falsehood&quot;—a statement that is incorrect but presented as fact.</p>
+
+            <p><strong>Dive-in &amp; Do:</strong></p>
+
+            <ol>
+            	<li>Choose a niche subject you know well (e.g., a specific historical event, a technical process in your field, the plot of a book you&#x27;ve studied).</li>
+            	<li>Start with broad questions, then get progressively more detailed.</li>
+            	<li>Ask for clarifications, deeper explanations, and specific sources for its claims. Keep pushing until you identify a factual error or an invented source.</li>
+            </ol>
+
+            <p><strong>Pause-and-Ponder:</strong> How confidently did the AI state the incorrect information? Did it &quot;apologize&quot; or &quot;correct itself&quot; easily when you challenged it? When would a subtle error like this be most dangerous in your field?</p>
+
+            <p><strong>Key Takeaways:</strong> AI models are designed to generate plausible text, not to state truth. They invent information with the same confident tone they use for facts. Your own expertise is the most reliable defense against hallucination.</p>
+            </div>
+
+            <div id="challenge2">
+            <h4><i></i>Challenge 2: Multi-Constraint Image Generation</h4>
+
+            <p><strong>Task:</strong> Test the AI’s ability to follow multiple, precise, and overlapping instructions within a single image generation prompt.</p>
+
+            <p><strong>Dive-in &amp; Do:</strong> Use a prompt that includes specific constraints. For example: <em>&quot;A photorealistic image of <strong>exactly 7</strong> rubber ducks swimming in a pond. <strong>One</strong> of the ducks must be blue. The sun should be setting, casting a <strong>golden light</strong> on the water.&quot;</em> Verify the output by counting the objects and checking each constraint. Try re-running the prompt or slightly rephrasing it to see if the results change.</p>
+
+            <p><strong>Pause-and-Ponder:</strong> Which constraints did the AI follow, and which did it ignore? Why do you think precise counting and object relationships are so difficult for image models?</p>
+
+            <p><strong>Key Takeaways:</strong> Image models often struggle with precise counting, spatial relationships, and combining multiple specific instructions. They excel at overall theme and style but fail on the details.</p>
+            </div>
+
+            <div id="challenge3">
+            <h4><i></i>Challenge 3: Rendering Symbolic Information (The Watch Test)</h4>
+
+            <p><strong>Task:</strong> Test the AI&#x27;s ability to accurately render specific symbolic information, like numbers and text, within an image.</p>
+
+            <p><strong>Dive-in &amp; Do:</strong> Ask the AI to generate an image of a watch or clock showing a specific, non-obvious time. For example: <em>Create a close-up photo of a modern analog wristwatch showing the time as <strong>exactly 4:52 PM</strong>.</em> Try it with both analog and digital clocks to see if one is more successful than the other.</p>
+
+            <p><strong>Pause-and-Ponder:</strong> Did the AI create a plausible-looking watch that failed to show the correct time? This is a common failure. What other tasks require rendering precise symbols (e.g., text on a sign, numbers on a jersey)?</p>
+
+            <p><strong>Key Takeaways:</strong> AI image generators often fail to render specific text and numbers accurately. They understand the <em>idea</em> of a watch but not the symbolic system of telling time, leading to visually correct but factually wrong images.</p>
+            </div>
+
+            <div id="challenge4">
+            <h4><i></i>Challenge 4: Pattern Matching vs. Comprehension (The Riddle Test)</h4>
+
+            <p><strong>Task:</strong> Use a modified riddle to test whether the AI is truly understanding the language or just recognizing a familiar pattern from its training data.</p>
+
+            <p><strong>Dive-in &amp; Do:</strong></p>
+
+            <ol>
+            	<li>Give the AI the modified riddle you saw earlier, where the key meaning is changed.
+            	<p>Example 1:</p>
+
+            	<pre>
+            <code>Original: 
+            What does man love more than life  
+            Fear more than death or mortal strife  
+            What the poor have, the rich require,  
+            and what contented men desire,  
+            What the miser spends and the spendthrift saves  
+            And all men carry to their graves?
+            ANSWER: Nothing
+
+            New Riddle:
+            What does man hate more than life
+            love more than death or mortal strife
+            What the rich have, the poor require,
+            and what contented men don&#x27;t desire,
+            What the miser saves and the spendthrift spends
+            And no men carry to their graves?</code></pre>
+
+            	<p>Example 2:</p>
+
+            	<pre>
+            <code>Original:
+            This is a most unusual paragraph. How quickly can you find out what is so unusual about it? It looks so ordinary you’d think nothing was wrong with it – and in fact, nothing is wrong with it. It is unusual though. Why? Study it, think about it, and you may find out. Try to do it without coaching. If you work at it for a bit it will dawn on you. So jump to it and try your skill at figuring it out. Good luck – don’t blow your cool!
+
+            Modified:
+            This is a most unusual paragraph. How quickly can you find out what is so unusual about it? It looks so ordinary you’d think nothing was wrong with it – and in fact, nothing is wrong with it. It is weird though. Why? Study it, think about it, and you may find out. Try to do it without coaching. If you work at it for a bit it will dawn on you. So jump to it and try your skill at figuring it out. Good luck – don’t blow your cool!</code></pre>
+            	</li>
+            	<li>Ask it for the answer and, crucially, ask it to <strong>explain its reasoning step-by-step</strong>.</li>
+            </ol>
+
+            <p><strong>Pause-and-Ponder:</strong> When you put in the modified riddle, did the AI give the answer of the original?</p>
+
+            <p><strong>Key Takeaways:</strong> AI can &quot;overfit&quot; on its training data, leading it to recognize a familiar pattern while completely ignoring critical new details that change the meaning. The explanation is often more revealing than the answer itself.</p>
+            </div>
+
+            <div id="challenge5">
+            <h4><i></i>Challenge 5: Complex Rule Interpretation (The Parking Sign Test)</h4>
+
+            <div>
+            <p><strong>Caution:</strong> Be mindful of privacy. Use a publicly available image of a sign online rather than uploading a photo from your own location that might contain personal information.</p>
+            </div>
+
+            <p><strong>Task:</strong> Test the AI’s ability to parse, understand, and apply a set of complex, overlapping, and conditional rules.</p>
+
+            <p><strong>Dive-in &amp; Do:</strong></p>
+
+            <div><img alt="A very complicated parking sign from Los Angeles with multiple rules, times, and conditions listed." loading="lazy" src="https://i.redd.it/2m2g24e39b231.jpg"></div>
+
+            <ol>
+            	<li>Find an image of a confusing image, like this one from L.A.</li>
+            	<li>Upload the image and ask the AI specific scenario questions: <em>&quot;Can I park here at 5 PM on a Tuesday?&quot;</em> <em>&quot;Can I stop for 5 minutes at 8:15 AM on a Monday?&quot;</em> <em>&quot;Is it legal to park here overnight on a Saturday?&quot;</em></li>
+            	<li>Direct the AI to think step-by-step and explain its thinking to try to get better results.</li>
+            </ol>
+
+            <p><strong>Pause-and-Ponder:</strong> Did breaking the problem down (extracting rules first) help the AI answer more accurately? Where did it still make mistakes?</p>
+
+            <p><strong>Key Takeaways:</strong> For complex logic, AI performance improves when you force it to work step-by-step. However, it can still miss subtle exceptions and negations, making it an unreliable tool for high-stakes rule interpretation.</p>
+            </div>
+
+            <div id="challenge6">
+            <h4><i></i>Challenge 6: Theory of Mind (The Belief Test)</h4>
+
+            <p><strong>Task:</strong> Test the AI&#x27;s ability to track different &quot;states of mind&quot; or beliefs of characters in a scenario.</p>
+
+            <p><strong>Dive-in &amp; Do:</strong> Give the AI this prompt: <em>Alice hides her keys in a drawer. Then she leaves the room. While she is gone, Bob enters and moves the keys to a box. Alice watches Bob move the keys through a hidden camera, but Bob does not know he was seen. Where will Bob <strong>think</strong> Alice will look for her keys?</em> Try variations: What if Alice didn&#x27;t see Bob move them? Does the AI&#x27;s answer change correctly?</p>
+
+            <p><strong>Pause-and-Ponder:</strong> Is the AI truly modeling Bob&#x27;s mistaken belief, or is it just finding statistical patterns in similar stories it has read? How would you know the difference?</p>
+
+            <p><strong>Key Takeaways:</strong> Modern AIs have become very good at solving simple &quot;theory of mind&quot; problems. However, they can still get confused by more complex scenarios, revealing that their &quot;understanding&quot; of belief may be a sophisticated mimicry rather than true reasoning.</p>
+            </div>
+
+            <div id="challenge7">
+            <h4><i></i>Challenge 7: Negative Constraint Adherence (The &quot;No E&quot; Test)</h4>
+
+            <p><strong>Task:</strong> Test the AI&#x27;s ability to follow a &quot;negative constraint&quot;—a rule about what <em>not</em> to do—over the course of a conversation.</p>
+
+            <p><strong>Dive-in &amp; Do:</strong></p>
+
+            <ol>
+            	<li>Start a new conversation with the single prompt: <em>&quot;For the rest of this conversation, you must not use the letter &#x27;e&#x27; in any of your responses. Do you understand?&quot;</em></li>
+            	<li>After it agrees, have a short, normal conversation with it for 3-4 exchanges. Ask it to summarize a topic or explain a concept.</li>
+            	<li>Check its responses for the forbidden letter.</li>
+            </ol>
+
+            <p><strong>Pause-and-Ponder:</strong> How long did the AI successfully follow the rule? Did it eventually &quot;forget&quot;? Why are negative constraints often much harder for an AI to follow than positive instructions?</p>
+
+            <p><strong>Key Takeaways:</strong> Adhering to negative constraints is a classic AI weak point. The model&#x27;s attention can &quot;drift&quot; from the initial instruction over longer interactions, making it unreliable for tasks that require strict, continuous rule-following.</p>
+            </div>
+            </div>
+
+            <div>
+            <p>The more you use generative AI, the more you will discover the jagged frontier. This needs to be an ongoing test because the jagged frontier is changing all the time as AI models and the tools improve.</p>
+            </div>
+            </div>
+
+
+
+                </div><div>
+                <div id="gai-wrap">
+                    <div>
+                    <div>
+                    <h1>Understanding AI Benchmarks: Beyond the Numbers</h1>
+
+                    <div>
+                    <h3><i></i> Learning Objectives</h3>
+
+                    <ul>
+                        <li>Explain the purpose, pros and cons of AI benchmarks</li>
+                        <li>Build your own personal benchmarks</li>
+                    </ul>
+                    </div>
+                    </div>
+
+                    <div>
+        </section>
+        <section class="gai-box">
+            <h2>What Are AI Benchmarks?</h2>
+            <p>An AI benchmark is a standardized test for AI models—like an IQ test for artificial intelligence. You can literally give an IQ test to an AI model to see how it performs. GPT-4, for example, has been tested on various IQ-style assessments, but does that actually mean anything?</p>
+
+                    <p>Whenever a new AI model is released, companies tout their benchmark scores as proof of superiority. These scores provide useful comparisons, but they don&#x27;t tell the whole story. Models often excel at narrow test scenarios while struggling with real-world applications—a perfect example of the Jagged Frontier in action.</p>
+
+                    <div>
+                    <h4><i></i> The Jagged Frontier Connection</h4>
+
+                    <p>Benchmarks reveal the &quot;jaggedness&quot; of AI capabilities. A model might ace graduate-level physics problems (GPQA benchmark) while failing at simple common-sense reasoning tasks. This unpredictability is why we can&#x27;t rely on benchmarks alone.</p>
+                    </div>
+        </section>
+        <section class="gai-box">
+            <h2>Example Benchmarks</h2>
+            <p>Understanding benchmark categories helps you understand AI capabilities. Here are some examples of what different benchmarks measure:</p>
+
+                    <div>
+                    <details><summary><i></i><h4> General Knowledge &amp; Academic Exams</h4></summary>
+
+                    <div>
+                    <p><strong>MMLU (Massive Multitask Language Understanding):</strong> Tests knowledge across 57 subjects from elementary to professional level through multiple-choice questions. Think of it as a comprehensive general knowledge exam that covers everything from basic math to advanced law.</p>
+
+                    <p><strong>AGIEval:</strong> Uses real standardized exams like the SAT, LSAT, and GRE. This benchmark tells us how well AI performs on the same tests humans take for college and graduate school admissions.</p>
+
+                    <p><strong>Other Benchmarks in this category:</strong> RACE (Reading Comprehension from Examinations), Humanities Last Exam (designed as a &quot;final exam&quot; before human-level intelligence)</p>
+
+                    <div>
+                    <p><strong>Why it matters:</strong> Shows breadth of knowledge but doesn&#x27;t guarantee practical application or true understanding.</p>
+                    </div>
+                    </div>
+                    </details>
+
+                    <details><summary><i></i><h4>Reasoning &amp; Truthfulness</h4></summary>
+
+                    <div>
+                    <p><strong>TruthfulQA:</strong> Contains 817 questions specifically designed to elicit common misconceptions and falsehoods. It tests whether AI will confidently state incorrect &quot;facts&quot; that sound plausible.</p>
+
+                    <p><strong>HellaSwag:</strong> Evaluates common-sense reasoning about everyday scenarios through story completion tasks. Can the AI predict what happens next in ordinary situations?</p>
+
+                    <p><strong>Other Benchmarks in this category:</strong> GPQA (Graduate-Level Google-Proof Q&amp;A), BIG-bench (200+ diverse reasoning tasks), ARC (AI2 Reasoning Challenge for grade-school science)</p>
+
+                    <div>
+                    <p><strong>Why it matters:</strong> Reveals tendency to hallucinate or perpetuate misinformation, critical for trust and reliability.</p>
+                    </div>
+                    </div>
+                    </details>
+
+                    <details><summary><i></i> <h4>Software Engineering &amp; Code</h4></summary>
+
+                    <div>
+                    <p><strong>HumanEval:</strong> The gold standard with 164 programming problems. It&#x27;s become the industry baseline for measuring code generation capabilities.</p>
+
+                    <p><strong>SWE-bench:</strong> Tests real-world programming by having AI solve actual GitHub issues. The model must understand the codebase, identify the problem, and write a working patch.</p>
+
+                    <p><strong>Other Benchmarks in this category:</strong> BigCodeBench (more challenging than HumanEval, better at distinguishing top-tier models)</p>
+
+                    <div>
+                    <p><strong>Why it matters:</strong> Measures practical coding ability, not just syntax knowledge—can it actually help you program?</p>
+                    </div>
+                    </div>
+                    </details>
+
+                    <details><summary><i></i><h4> Conversational Quality</h4></summary>
+
+                    <div>
+                    <p><strong>MT-Bench:</strong> Evaluates multi-turn dialogue across reasoning, math, coding, and roleplay. Judges score paired outputs to determine which is better.</p>
+
+                    <p><strong>Chatbot Arena (LMArena):</strong> Real users vote on which model gives better responses in head-to-head comparisons, without knowing which model is which.</p>
+
+                    <div>
+                    <p><strong>Why it matters:</strong> Captures subjective quality that automated tests miss—the &quot;feel&quot; of talking to the AI.</p>
+                    </div>
+                    </div>
+                    </details>
+
+                    <details><summary><i></i><h4> Multimodal &amp; Specialized</h4></summary>
+
+                    <div>
+                    <p><strong>MMMU (Massive Multi-discipline Multimodal Understanding):</strong> Extension of MMLU that includes images, diagrams, and charts. Critical for evaluating modern multimodal models.</p>
+
+                    <p><strong>Other Benchmarks in this category:</strong> Kaggle Game Arena (strategic reasoning through game-playing), HELM (Holistic Evaluation across multiple metrics including fairness and bias)</p>
+
+                    <div>
+                    <p><strong>Why it matters:</strong> Tests whether AI can work with real-world content that combines text and visuals.</p>
+                    </div>
+                    </div>
+                    </details>
+                    </div>
+
+                    <div><img alt="Example benchmark performance comparison across different AI models" loading="lazy" src="[Space for benchmark performance graph]">
+                    <p>Example benchmark performance graph comparing different models will be added here</p>
+                    </div>
+                    </div>
+
+                    <div>
+        </section>
+        <section class="gai-box">
+            <h2>Limitations of Benchmarks</h2>
+            <div>
+                    <h3><i></i> Critical Limitations to Understand</h3>
+
+                    <div>
+                    <div>
+                    <h4><i></i> Data Contamination</h4>
+
+                    <p>Test questions leak into training data, turning reasoning tests into memory tests. Models aren&#x27;t &quot;thinking&quot;—they&#x27;re reciting memorized answers.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> Benchmark Gaming</h4>
+
+                    <p>Models are increasingly optimized specifically to ace benchmarks, like &quot;teaching to the test&quot; in education. High scores don&#x27;t guarantee real-world performance.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> Cultural &amp; Linguistic Bias</h4>
+
+                    <p>Most benchmarks reflect Western, English-centric perspectives, disadvantaging models trained on diverse data and limiting global applicability.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> Moving Goalposts</h4>
+
+                    <p>As models improve, benchmarks become obsolete. What was &quot;superhuman&quot; last year is baseline today, making historical comparisons difficult.</p>
+                    </div>
+                    </div>
+                    </div>
+                    </div>
+
+                    <div>
+        </section>
+        <section class="gai-box">
+            <h2>Beyond Traditional Benchmarks</h2>
+            <p>To address these limitations, the field is evolving toward more robust evaluation methods:</p>
+
+                    <div>
+                    <div>
+                    <h4><i></i> Dynamic Arenas</h4>
+
+                    <p>Instead of fixed tests, models compete head-to-head. Users judge outputs without knowing which model produced what, eliminating brand bias.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> Human-in-the-Loop</h4>
+
+                    <p>For subjective qualities like creativity or empathy, human experts grade performance in real-time, capturing nuances automated tests miss.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> Adversarial Testing</h4>
+
+                    <p>Intentionally trying to break models reveals hidden weaknesses that standard benchmarks miss, improving safety and reliability.</p>
+                    </div>
+                    </div>
+                    </div>
+
+                    <div>
+                    <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i> Activity: Create Your Personal AI Benchmark</h2>
+            <div>
+                    <h4><i></i> Privacy Reminder</h4>
+
+                    <p>When creating personal benchmarks, always use:</p>
+
+                    <ul>
+                        <li>Hypothetical scenarios instead of real personal data</li>
+                        <li>Public information rather than confidential details</li>
+                        <li>Generic examples that mirror your needs without exposing sensitive information</li>
+                    </ul>
+                    </div>
+
+                    <p>The best measure of an AI isn&#x27;t a generic score—it&#x27;s how well it helps YOU achieve YOUR specific goals. Let&#x27;s build your personal benchmark.</p>
+
+
+
+
+                    <div>
+                    <details><summary><i></i> <p>Approach 1: Quick Evaluation Framework</p></summary>
+
+                    <div>
+                    <div>
+                    <h4>Task</h4>
+
+                    <p>Select 3-5 challenges from the &quot;Exploring the Jagged Frontier&quot; module that matter to your work.</p>
+
+                    <h4>Dive-in &amp; Do</h4>
+
+                    <ol>
+                        <li>Test each challenge on 2-3 different AI models</li>
+                        <li>Document results in a simple spreadsheet</li>
+                        <li>Re-test quarterly as new models emerge</li>
+                    </ol>
+
+                    <h4>Pause-and-Ponder</h4>
+
+                    <p>Which failures surprised you most? What does this reveal about the model&#x27;s training?</p>
+                    </div>
+                    </div>
+                    </details>
+
+                    <details><summary><i></i><p> Approach 2: Comprehensive Personal Benchmark</p></summary>
+
+                    <div>
+                    <div>
+                    <h4>Task</h4>
+
+                    <p>Design a multi-faceted evaluation suite tailored to your professional needs.</p>
+
+                    <h4>Dive-in &amp; Do</h4>
+
+                    <p>Choose 2-3 tasks from this list (or create your own):</p>
+                    </div>
+
+                    <div>
+                    <div>
+                    <h4><i></i> Career Agent</h4>
+
+                    <p>Provide career interests and ask the AI to identify suitable companies and draft outreach messages.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> Marketing Strategist</h4>
+
+                    <p>Give a product and target audience. Request a 3-month campaign with content calendar and materials.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> Event Planner</h4>
+
+                    <p>Describe an event. Request complete project plan with timeline, budget, and promotional materials.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> Travel Planner</h4>
+
+                    <p>Specify destination, duration, budget, and interests. Request day-by-day itinerary with logistics.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> DIY Guide</h4>
+
+                    <p>Describe a DIY project. Request step-by-step instructions, materials list, and video script.</p>
+                    </div>
+
+                    <div>
+                    <h4><i></i> Dungeon Master</h4>
+
+                    <p>Provide a fantasy setting. Test the AI&#x27;s ability to maintain narrative consistency and adapt.</p>
+                    </div>
+                    </div>
+
+                    <div>
+                    <h4>Evaluation Criteria</h4>
+
+                    <ol>
+                        <li><strong>Accuracy:</strong> Are facts correct? Do recommendations make sense?</li>
+                        <li><strong>Completeness:</strong> Did it address all requirements?</li>
+                        <li><strong>Creativity:</strong> Are suggestions original or clichéd?</li>
+                        <li><strong>Practicality:</strong> Could you actually implement the output?</li>
+                        <li><strong>Time Saved:</strong> How much faster than doing it yourself?</li>
+                    </ol>
+
+                    <h4>Pause-and-Ponder</h4>
+
+                    <p>What patterns emerge across different tasks? Where does the AI consistently excel or fail? How might this shape your workflow integration?</p>
+                    </div>
+                    </div>
+                    </details>
+                    </div>
+                    </div>
+
+                    <div>
+                    <h4><i></i> For Educators</h4>
+
+                    <p>Consider having students create a class benchmark suite that tests AI capabilities relevant to your discipline. This exercise builds critical evaluation skills while revealing the Jagged Frontier in action.</p>
+                    </div>
+                    </div>
+
+                    <div>
+                    <h3><i></i> Key Takeaways</h3>
+
+                    <ul>
+                        <li>Benchmarks provide useful comparisons but don&#x27;t capture real-world performance</li>
+                        <li>Data contamination and benchmark gaming inflate scores artificially</li>
+                        <li>The &quot;Jagged Frontier&quot; means excellence in benchmarks doesn&#x27;t guarantee practical utility</li>
+                        <li>Personal benchmarks tailored to your needs are more valuable than generic scores</li>
+                        <li>Regular re-evaluation helps you stay current with rapidly evolving capabilities</li>
+                    </ul>
+                    </div>
+
+                    <hr>
+                    <div>
+                    <h3><i></i> Further Reading</h3>
+
+                    <p><a href="https://arxiv.org/abs/2311.12022" rel="noopener noreferrer" target="_blank">Beyond Benchmarks: Rethinking Evaluation in AI</a> - Technical deep-dive into benchmark limitations</p>
+
+                    <p><a href="https://www.anthropic.com/index/evaluating-ai-systems" rel="noopener noreferrer" target="_blank">Anthropic&#x27;s Approach to AI Evaluation</a> - Industry perspective on comprehensive testing</p>
+
+                    <p><a href="#" rel="noopener noreferrer" target="_blank">Return to Exploring the Jagged Frontier</a> - See how benchmarks connect to capability mapping</p>
+                    </div>
+                    </div>
+                    </div>
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/analyze-and-apply-gen-ai.html
+++ b/site/analyze-and-apply-gen-ai.html
@@ -4,471 +4,512 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Analyze and Apply Gen AI - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="active has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Analyze and Apply Gen AI</h2>
-        <div>
-    
-<link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
+    </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
 <div id="gai-wrap">
-<div>
-<div>
-<p>Welcome! This module is designed for active learning. Forget lengthy readings – here, you&#x27;ll gain practical skills by diving straight into using generative AI tools. Expect to spend the majority of your time experimenting: navigating interfaces, constructing and refining prompts, and exploring customization features. Our hands-on approach ensures you build not just knowledge, but the confidence and competence to effectively interact with and leverage these powerful platforms. Let&#x27;s get started!</p>
-</div>
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Analyze and Apply Gen AI</h2>
+            <div>
 
-<div>
-<h2><i></i>Learning Outcomes</h2>
-
-<ol>
-	<li><strong>Navigate the user interface of common generative AI tools</strong> to locate key features for inputting prompts, viewing outputs, and accessing basic settings.</li>
-	<li><strong>Construct clear, specific, and context-rich prompts</strong> designed to elicit desired responses from generative AI tools for defined tasks.</li>
-	<li><strong>Employ iterative prompting strategies</strong>, refining and adjusting prompts based on initial AI outputs and analyzing failure points to improve the relevance, accuracy, and quality of generated content.</li>
-	<li><strong>Utilize platform features for customization</strong> (e.g., custom instructions, creating specialized GPTs/Projects/Gems) to tailor the AI&#x27;s responses and behavior for specific contexts or recurring tasks.</li>
-</ol>
-</div>
-
-<hr>
-<div>
-<details><summary> <i></i><span>Prompting Challenge</span> </summary>
-
-<div>
-<div>
-<p>Let&#x27;s dive into your first hands-on experience interacting with an AI tool.</p>
-</div>
-
-<div>
-<h2>Your First AI Interaction: Summarization Challenge</h2>
-
-<p><strong>Task:</strong> Select a recent news article or journal finding that interests you. Open one of the generative AI tools linked below, copy and paste the article into the chatbot and then ask it to give you a concise summary (1-2 paragraphs) of the content. Focus on finding where to input your request and how to view the AI&#x27;s response. </p>
-
-<h3>Tool Options:</h3>
-
-<div><a href="https://chatgpt.com/" rel="noopener noreferrer" target="_blank">ChatGPT <i></i></a> <a href="https://claude.ai/" rel="noopener noreferrer" target="_blank">Claude <i></i></a> <a href="https://gemini.google.com/" rel="noopener noreferrer" target="_blank">Gemini <i></i></a></div>
-
-<p><em>Feel free to use any tool you have access to.</em></p>
-</div>
-
-<div>
-<h4><i></i> Reflect on Your Experience</h4>
-
-<p>Take a moment to think about your first attempt. Consider these questions (no need to write answers here, just think them through):</p>
-
-<ul>
-	<li>How easy or difficult was it to find where to enter your prompt (your request) in the AI tool you chose? If you provided the article content, how did you do it (copy/paste, link)?</li>
-	<li>What specific words or phrases did you use in your first prompt to ask for the summary? (e.g., &quot;Summarize this article&quot;, &quot;Give me the main points&quot;, &quot;Explain this in simple terms&quot;)</li>
-	<li>Look at the summary the AI generated. How well did it capture the main points of the article? Were there any surprises in the output (accuracy, tone, length)?</li>
-	<li>Did you feel the need to try again or change your prompt immediately after seeing the first result? Why or why not? What might you change next time?</li>
-</ul>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i><span>The Power of Prompting</span> </summary>
-
-<div>
-<div>
-<p>Now let&#x27;s look at how small changes in your prompt can significantly impact the AI&#x27;s response.</p>
-</div>
-
-<div>
-<h2>Prompting Examples: Basic vs. Detailed</h2>
-
-<p>Imagine you are in an environmental science class and have discovered a recent, lengthy report online about a new study on glacier melt. You want a quick summary to understand the key findings to see if it&#x27;s relebvant to your current topic on climate change impacts before investing time.</p>
-
-<p><strong>Basic Prompt:</strong></p>
-
-<pre>
-<code>Summarize this article.</code></pre>
-
-<p><em>(You would paste the article text or provide a link if the tool supports it)</em></p>
-
-<p><em>Potential Outcome:</em> You might get a general summary, but its length, focus, and tone could vary widely. It might be too long, too technical, or miss the points most relevant to educators.</p>
-
-<p><strong>Detailed Prompt:</strong></p>
-
-<pre>
-<code><span>Summarize the key findings of the following news report for an environmental science student. The goal is to quickly understand if the report is relevant to a course topic on climate change impacts. Focus specifically on the main data presented and the predicted future impacts discussed in the article. Provide a two sentence summary, 3 key points (as bullet points), and one surprising fact.</span></code></pre>
-
-<p><em>(You would paste the article text or provide a link if your AI tool supports web browsing)</em></p>
-
-<p><em>Potential Outcome:</em> This prompt gives the AI much more direction:</p>
-
-<ul>
-	<li><strong>Audience:</strong> &quot;environmental science student&quot; informs the AI about the user&#x27;s background knowledge and the appropriate level of technical detail.</li>
-	<li><strong>Goal</strong>: Stating the goal (&quot;quickly understand if the report is relevant...&quot;) helps the AI prioritize information pertinent to making that judgment.</li>
-	<li><strong>Task Focus:</strong> Specifying &quot;main data presented&quot; and &quot;predicted future impacts&quot; directs the AI to extract the most crucial information for the student&#x27;s purpose.</li>
-	<li><strong>Format:</strong> &quot;<span>Provide a two sentence summary...</span>&quot; ensures the summary is brief and easy to scan for relevance.</li>
-</ul>
-
-<p>The result is likely to be far more targeted, relevant, and immediately useful for your specific need.</p>
-</div>
-
-<div>
-<h4>Reflect on Your Experience (Think about these questions):</h4>
-
-<ul>
-	<li>Looking back at the &quot;Summarization Challenge&quot; you just completed, how specific was your initial prompt?</li>
-	<li>Did you provide the AI with context (like who the summary was for, or what points to focus on)?</li>
-	<li>Compare your first prompt to the &quot;Detailed Prompt&quot; example above. What are the key differences?</li>
-	<li>How might providing more context, specifying the format, or defining a role for the AI have changed the summary you received in the challenge?</li>
-	<li>Did the AI&#x27;s first response make you want to adjust your prompt and try again? (This is iterative prompting in action!)</li>
-</ul>
-</div>
-
-<div>
-<h2>Key Prompting Takeaways:</h2>
-
-<ul>
-	<li><strong>Specificity Matters:</strong> Vague prompts lead to vague or unpredictable results. Clearly define what you want.</li>
-	<li><strong>Context is Crucial:</strong> Tell the AI about the audience, the purpose, or the background information it needs to generate a relevant response.</li>
-	<li><strong>Define the Format:</strong> Do you need bullet points, a paragraph, a table, code? Ask for it explicitly.</li>
-	<li><strong>Assign a Role (Optional but Powerful):</strong> Asking the AI to &quot;Act as...&quot; can significantly shape the tone, style, and expertise level of the response.</li>
-	<li><strong>Iteration is Key:</strong> Don&#x27;t expect the perfect response on the first try. Analyze the output and refine your prompt based on what you see. This aligns with the iterative learning approach we&#x27;ve discussed.</li>
-</ul>
-
-<p>This quick debrief highlights how thoughtful prompting moves you from simply getting <em>an</em> answer to getting the <em>right</em> answer for your specific needs. As you continue through these pathways, you&#x27;ll develop more advanced prompting strategies.</p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i><span>Iterative Prompt Refinement: Guiding the Conversation</span> </summary>
-
-<div>
-<div>
-<p>You&#x27;ve seen how a detailed prompt gets a better initial response than a vague one. But what happens when even a detailed prompt doesn&#x27;t quite hit the mark? That&#x27;s where <strong>Iterative Prompt Refinement</strong> comes in. Think of it less like issuing commands and more like having a <strong>guided conversation</strong> with your AI assistant. Your first prompt starts the conversation, the AI&#x27;s response gives you feedback, and your refined prompts steer the dialogue until the AI truly understands what you need.</p>
-
-<p>Mastering this back-and-forth is key to unlocking the AI&#x27;s potential for complex or nuanced tasks.</p>
-</div>
-
-<div>
-<h2>Framework: Strategies for a Better AI Conversation</h2>
-
-<p>How can you steer the conversation effectively? Here are several strategies to refine your prompts and guide the AI:</p>
-
-<ul>
-	<li><strong>Add/Modify Context:</strong> Like clarifying things for a person, give the AI more background. Specify the intended <strong>audience</strong> (e.g., &quot;Explain this for a beginner&quot;), the <strong>purpose</strong> (e.g., &quot;I need ideas for a presentation slide&quot;), or relevant <strong>details</strong> it might be missing.</li>
-	<li><strong>Adjust Format/Structure:</strong> Tell the AI *how* you want the information presented. Ask for <strong>bullet points</strong>, a <strong>table</strong>, a specific <strong>length</strong> (e.g., &quot;in under 100 words&quot;), or a certain <strong>structure</strong> (e.g., &quot;pros and cons&quot;).</li>
-	<li><strong>Refine AI Role/Persona:</strong> Ask the AI to adopt a specific viewpoint. Examples: &quot;Act as a skeptical reviewer,&quot; &quot;Act as an encouraging tutor,&quot; &quot;Adopt the persona of a historian.&quot; This shapes the tone and focus.</li>
-	<li><strong>Provide Examples (Few-Shot Prompting):</strong> Show, don&#x27;t just tell. Give the AI a small example of the output format or style you&#x27;re looking for right within your prompt.</li>
-	<li><strong>Break Down Complexity:</strong> If a task is too big, ask for it piece by piece. &quot;First, list the main themes.&quot;...&quot;Okay, now elaborate on the first theme.&quot;</li>
-	<li><strong>Engage in Dialogue (Make it a Two-Way Street):</strong>
-	<ul>
-		<li>Prompt the AI to ask <em>you</em> questions: &quot;What other information do you need from me to answer this question effectively?&quot; or &quot;Ask me three questions that would help you refine your response.&quot;</li>
-		<li>Ask the AI to critique itself or your prompt: &quot;Critique your previous response for clarity.&quot; or &quot;How could I improve my prompt to get a better explanation?&quot;</li>
-	</ul>
-	</li>
-</ul>
-</div>
-
-<div>
-<h2>Examples: Seeing the Conversation Unfold</h2>
-</div>
-
-<div>
-<h3>Example 1: Refining for Audience and Length in Summarization</h3>
-
-<p><strong>Goal:</strong> Summarize a somewhat technical news article about a new type of solar panel technology so you can quickly explain it to a friend who isn&#x27;t a science major.</p>
-
-<p><strong>Attempt 1 Prompt:</strong></p>
-
-<pre>
-<code>Summarize this article about the new perovskite solar panels: [Link to article or pasted text]</code></pre>
-
-<p><em>Potential Output:</em> A summary that accurately covers the technical details but uses jargon (like &quot;band gap,&quot; &quot;efficiency ratings,&quot; &quot;fabrication methods&quot;) and might be several paragraphs long.</p>
-
-<p><strong>Possible Critique:</strong> Too technical for my friend, and longer than needed for a quick explanation.</p>
-
-<p><strong>Refinement Strategy Used:</strong> Add Context (Audience), Adjust Format (Length).</p>
-
-<p><strong>Attempt 2 Prompt (Refined):</strong></p>
-
-<pre>
-<code>Summarize this article about the new perovskite solar panels, but explain it in simple terms for someone without a science background. Keep the summary under 75 words.</code></pre>
-
-<p><em>Potential Output:</em> A much shorter, simpler summary focusing on the key benefit (e.g., &quot;Scientists developed new solar panels that are cheaper and easier to make, potentially making solar energy more accessible&quot;) without the heavy technical terms.</p>
-</div>
-
-<div>
-<h3>Example 2: Refining for Specific Focus in Summarization</h3>
-
-<p><strong>Goal:</strong> You need to understand the main arguments presented in a long opinion piece about the future of remote work, specifically focusing on the impact on city planning.</p>
-
-<p><strong>Attempt 1 Prompt:</strong></p>
-
-<pre>
-<code>Summarize the main points of this article about the future of remote work: [Link or text]</code></pre>
-
-<p><em>Potential Output:</em> A general summary covering various aspects like employee productivity, company culture, economic shifts, and maybe a brief mention of urban impact.</p>
-
-<p><strong>Critique:</strong> Covers too much; I only need the parts relevant to city planning for my specific interest/project.</p>
-
-<p><strong>Refinement Strategy Used:</strong> Add/Modify Context (Focus).</p>
-
-<p><strong>Attempt 2 Prompt (Refined):</strong></p>
-
-<pre>
-<code>Summarize the arguments this article makes about how the rise of remote work could impact city planning and urban development. Focus only on that aspect.</code></pre>
-
-<p><em>Potential Output:</em> A targeted summary discussing points like potential changes in transportation needs, the repurposing of office buildings, shifts in residential patterns, and the economic impact on downtown areas, ignoring the other topics from the article.</p>
-
-<p><em>Next Step:</em> This focused summary is much more useful for the user&#x27;s specific need than the general summary from the first attempt.</p>
-</div>
-
-<div>
-<h2>Practice Area: Your Turn to Guide the Conversation</h2>
-
-<p>Now it&#x27;s your turn to practice refining prompts. Think of it as steering the AI through conversation.</p>
-
-<ol>
-	<li><strong>Choose a Task:</strong> Pick something relevant to your studies where an AI could assist (e.g., explaining a difficult concept from class, brainstorming arguments for a debate topic, drafting an email to a professor, summarizing a complex reading *for a specific purpose* like finding key data points).</li>
-	<li><strong>Start the Conversation:</strong> Write your initial prompt in one of the AI tools linked below.</li>
-	<li><strong>Analyze the Response:</strong> Read the AI&#x27;s first output. Is it exactly what you wanted? Probably not! Where does it fall short? (Too vague? Wrong tone? Missing key info? Wrong format?)</li>
-	<li><strong>Choose Your Next Move:</strong> Select 1-2 refinement strategies from the Framework list above. How can you clarify or redirect the AI? Consider getting it to ask you clarifying questions!</li>
-	<li><strong>Continue the Conversation:</strong> Write and submit your refined prompt based on the strategy you chose.</li>
-	<li><strong>Compare Outputs:</strong> Look at the first and second responses side-by-side. Did the conversation move in the right direction? How did your refinement change the outcome?</li>
-	<li><strong>Keep Chatting (Optional):</strong> If it&#x27;s still not quite right, repeat steps 4-6. Sometimes it takes a few exchanges to get the AI aligned with your goal.</li>
-</ol>
-
-<p><strong>AI Tools for Practice:</strong></p>
-
-<div><a href="https://chatgpt.com/" rel="noopener noreferrer" target="_blank">ChatGPT <i></i></a> <a href="https://claude.ai/" rel="noopener noreferrer" target="_blank">Claude <i></i></a> <a href="https://gemini.google.com/" rel="noopener noreferrer" target="_blank">Gemini <i></i></a> <a href="https://www.perplexity.ai/" rel="noopener noreferrer" target="_blank">Perplexity <i></i></a></div>
-
-<p><em>(Feel free to use any generative AI chat tool you have access to.)</em></p>
-</div>
-
-<div>
-<h3>Keep Track: Your Conversation Log (Optional)</h3>
-
-<p>It&#x27;s helpful to note down how your conversation with the AI progresses. This helps you learn which refinement strategies work best for different situations. You can use a simple structure like this:</p>
-
-<ul>
-	<li><strong>My Goal:</strong> [What I wanted the AI to do]</li>
-	<li><strong>Conversation Turn 1 (My Prompt):</strong> [My first prompt]</li>
-	<li><strong>Conversation Turn 1 (AI Response Critique):</strong> [What was good/bad about the AI&#x27;s reply?]</li>
-	<li><strong>My Strategy for Turn 2:</strong> [Which refinement technique did I choose?]</li>
-	<li><strong>Conversation Turn 2 (My Prompt):</strong> [My refined prompt]</li>
-	<li><strong>Conversation Turn 2 (AI Response Critique):</strong> [How did this response improve? Still missing anything?]</li>
-	<li><em>(Continue logging turns as needed)</em></li>
-</ul>
-</div>
-
-<div>
-<h3>Visualizing Improvement: The Conversation Flow</h3>
-
-<p>Think of this iterative process like charting the flow of your conversation. Each refinement is a step towards clearer communication and a better final outcome. While we don&#x27;t have an automated visual tracker here, using the log above helps you mentally map out how you guided the AI from its initial response to the more useful information you needed.</p>
-</div>
-</div>
-</details>
-
-<details><summary> <i></i> <span>Prompt Design Frameworks &amp; Resources</span> </summary>
-
-<div>
-<div>
-<p>The following is a growing collection of guides, frameworks, and articles on prompt design/prompt engineering that consists of extracted pieces from a variety of resources. Please explore the full text of these resources for a deeper understanding of their respective approaches to prompt design and engineering. Try the frameworks or guidelines in your own context and reflect on which one works for you.</p>
-
-<ol>
-	<li><a href="https://www.huit.harvard.edu/news/ai-prompts/" target="_blank"><strong>Harvard University&#x27;s getting started with prompts for text-based Generative AI tools</strong></a>
-
-	<ul>
-		<li>Be specific in your request.</li>
-		<li>Ask AI to act as if it were a certain expert or played a certain role.</li>
-		<li>Tell AI how you want your output to be presented.</li>
-		<li>Use clear do and don&#x27;t instruction.</li>
-		<li>Provide examples.</li>
-		<li>Consider tone and intended audience.</li>
-		<li>Build on previous prompts, correct mistakes, and continuously give feedback.</li>
-		<li>Ask AI to create prompts, clarify requirements, or inquire what else it needs from you.</li>
-	</ul>
-	</li>
-	<li><a href="https://www.huit.harvard.edu/news/ai-prompts-images" target="_blank"><strong>Harvard University&#x27;s getting started with prompts for image-based Generative AI tools</strong></a>
-	<ul>
-		<li>Describe the subject in as much detail as you can</li>
-		<li>Specify the style of image (photographs, paintings, cartoons, etc.)</li>
-		<li>Add more details and refine (considering lighting, the positioning of the subject within the frame, background details, etc.)</li>
-		<li>Add your preferred output (considering the format, for example, poster, email header image, etc.)</li>
-	</ul>
-	</li>
-	<li><a href="https://www.sciencedirect.com/science/article/abs/pii/S0099133323000599?via%3Dihub" target="_blank"><strong>The CLEAR path – A framework for enhancing information literacy through prompt engineering</strong></a>
-	<ul>
-		<li><strong>Concise:</strong> keep prompt brief and to the point.</li>
-		<li><strong>Logical:</strong> ensure prompts follow a logical structure and sequence.</li>
-		<li><strong>Explicit:</strong> be explicit about expected outcome.</li>
-		<li><strong>Adaptive:</strong> adjust prompts based on prior results and learning.</li>
-		<li><strong>Reflective:</strong> encourage reflection on the output to refine future prompts.</li>
-	</ul>
-	</li>
-	<li><a href="https://fsw.instructure.com/courses/1131366/pages/prompting-guide-sheet?module_item_id=15818026" target="_blank"><strong>The five « S » model</strong></a>
-	<ul>
-		<li>Set the scene.</li>
-		<li>Be specific.</li>
-		<li>Simplify your language.</li>
-		<li>Structure the output.</li>
-		<li>Share feedback.</li>
-	</ul>
-	</li>
-	<li><a href="https://github.com/microsoft/prompts-for-edu/tree/main/Students" target="_blank"><strong>Microsoft&#x27;s educational prompts repository</strong></a>
-	<ul>
-		<li>This repository contains prompts that facilitate exploration, guidance on complex topics, and creativity. These tools enable personalized learning experiences, helping students engage in self-directed learning and make enjoyable educational connections.</li>
-	</ul>
-	</li>
-	<li><a href="https://docs.google.com/document/d/1wSfvKfKcG0qto0UJVsVfzLYFCaEc0M5NszzIWO5j-ug/edit?pli=1&amp;tab=t.0#heading=h.199rx1x58dj3" target="_blank"><strong>AI Prompt Cookbook by Chris Sharp and Leslie Mojeiko</strong></a>
-	<ul>
-		<li>This resource includes several recipes (prompts) and ingredients (keywords and considerations) to use with GenAI. All recipes outlined in this cookbook are focused on teaching by assisting with course preparation and facilitation. Educators can use this guide to help with brainstorming ideas during course preparation, delivering student-centred content, and designing interactive, personalized lessons and activities.</li>
-	</ul>
-	</li>
-</ol>
-
-<p><em>Content in this accordion is from: <a href="https://digitalliteracy.bccampus.ca/resources/126">GenAI in Teaching and Learning Toolkit</a> by Gwen Nguyen is licensed under a <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC 4.0 licence</a>.</em></p>
-</div>
-</div>
-</details>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-        <div>
-            <h1><i></i> Customizing and Organizing Your AI Assistant</h1>
 
             <div>
-                <p>AI assistants have evolved beyond simple chat interfaces and now offer sophisticated organization and customization capabilities. The following outlines these various capabilities which allow for management of chats, files and workflows, supported by customized instructions for user defined purposes.</p>
+            <div>
+            <p>Welcome! This module is designed for active learning. Forget lengthy readings – here, you&#x27;ll gain practical skills by diving straight into using generative AI tools. Expect to spend the majority of your time experimenting: navigating interfaces, constructing and refining prompts, and exploring customization features. Our hands-on approach ensures you build not just knowledge, but the confidence and competence to effectively interact with and leverage these powerful platforms. Let&#x27;s get started!</p>
             </div>
 
             <div>
-                <details>
-                    <summary>
-                        <i></i><span>Custom Instructions</span>
-                    </summary>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Learning Outcomes</h2>
+            <ol>
+            	<li><strong>Navigate the user interface of common generative AI tools</strong> to locate key features for inputting prompts, viewing outputs, and accessing basic settings.</li>
+            	<li><strong>Construct clear, specific, and context-rich prompts</strong> designed to elicit desired responses from generative AI tools for defined tasks.</li>
+            	<li><strong>Employ iterative prompting strategies</strong>, refining and adjusting prompts based on initial AI outputs and analyzing failure points to improve the relevance, accuracy, and quality of generated content.</li>
+            	<li><strong>Utilize platform features for customization</strong> (e.g., custom instructions, creating specialized GPTs/Projects/Gems) to tailor the AI&#x27;s responses and behavior for specific contexts or recurring tasks.</li>
+            </ol>
+            </div>
+
+            <hr>
+            <div>
+            <details><summary> <i></i><span>Prompting Challenge</span> </summary>
+
+            <div>
+            <div>
+            <p>Let&#x27;s dive into your first hands-on experience interacting with an AI tool.</p>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Your First AI Interaction: Summarization Challenge</h2>
+            <p><strong>Task:</strong> Select a recent news article or journal finding that interests you. Open one of the generative AI tools linked below, copy and paste the article into the chatbot and then ask it to give you a concise summary (1-2 paragraphs) of the content. Focus on finding where to input your request and how to view the AI&#x27;s response. </p>
+
+            <h3>Tool Options:</h3>
+
+            <div><a href="https://chatgpt.com/" rel="noopener noreferrer" target="_blank">ChatGPT <i></i></a> <a href="https://claude.ai/" rel="noopener noreferrer" target="_blank">Claude <i></i></a> <a href="https://gemini.google.com/" rel="noopener noreferrer" target="_blank">Gemini <i></i></a></div>
+
+            <p><em>Feel free to use any tool you have access to.</em></p>
+            </div>
+
+            <div>
+            <h4><i></i> Reflect on Your Experience</h4>
+
+            <p>Take a moment to think about your first attempt. Consider these questions (no need to write answers here, just think them through):</p>
+
+            <ul>
+            	<li>How easy or difficult was it to find where to enter your prompt (your request) in the AI tool you chose? If you provided the article content, how did you do it (copy/paste, link)?</li>
+            	<li>What specific words or phrases did you use in your first prompt to ask for the summary? (e.g., &quot;Summarize this article&quot;, &quot;Give me the main points&quot;, &quot;Explain this in simple terms&quot;)</li>
+            	<li>Look at the summary the AI generated. How well did it capture the main points of the article? Were there any surprises in the output (accuracy, tone, length)?</li>
+            	<li>Did you feel the need to try again or change your prompt immediately after seeing the first result? Why or why not? What might you change next time?</li>
+            </ul>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i><span>The Power of Prompting</span> </summary>
+
+            <div>
+            <div>
+            <p>Now let&#x27;s look at how small changes in your prompt can significantly impact the AI&#x27;s response.</p>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Prompting Examples: Basic vs. Detailed</h2>
+            <p>Imagine you are in an environmental science class and have discovered a recent, lengthy report online about a new study on glacier melt. You want a quick summary to understand the key findings to see if it&#x27;s relebvant to your current topic on climate change impacts before investing time.</p>
+
+            <p><strong>Basic Prompt:</strong></p>
+
+            <pre>
+            <code>Summarize this article.</code></pre>
+
+            <p><em>(You would paste the article text or provide a link if the tool supports it)</em></p>
+
+            <p><em>Potential Outcome:</em> You might get a general summary, but its length, focus, and tone could vary widely. It might be too long, too technical, or miss the points most relevant to educators.</p>
+
+            <p><strong>Detailed Prompt:</strong></p>
+
+            <pre>
+            <code><span>Summarize the key findings of the following news report for an environmental science student. The goal is to quickly understand if the report is relevant to a course topic on climate change impacts. Focus specifically on the main data presented and the predicted future impacts discussed in the article. Provide a two sentence summary, 3 key points (as bullet points), and one surprising fact.</span></code></pre>
+
+            <p><em>(You would paste the article text or provide a link if your AI tool supports web browsing)</em></p>
+
+            <p><em>Potential Outcome:</em> This prompt gives the AI much more direction:</p>
+
+            <ul>
+            	<li><strong>Audience:</strong> &quot;environmental science student&quot; informs the AI about the user&#x27;s background knowledge and the appropriate level of technical detail.</li>
+            	<li><strong>Goal</strong>: Stating the goal (&quot;quickly understand if the report is relevant...&quot;) helps the AI prioritize information pertinent to making that judgment.</li>
+            	<li><strong>Task Focus:</strong> Specifying &quot;main data presented&quot; and &quot;predicted future impacts&quot; directs the AI to extract the most crucial information for the student&#x27;s purpose.</li>
+            	<li><strong>Format:</strong> &quot;<span>Provide a two sentence summary...</span>&quot; ensures the summary is brief and easy to scan for relevance.</li>
+            </ul>
+
+            <p>The result is likely to be far more targeted, relevant, and immediately useful for your specific need.</p>
+            </div>
+
+            <div>
+            <h4>Reflect on Your Experience (Think about these questions):</h4>
+
+            <ul>
+            	<li>Looking back at the &quot;Summarization Challenge&quot; you just completed, how specific was your initial prompt?</li>
+            	<li>Did you provide the AI with context (like who the summary was for, or what points to focus on)?</li>
+            	<li>Compare your first prompt to the &quot;Detailed Prompt&quot; example above. What are the key differences?</li>
+            	<li>How might providing more context, specifying the format, or defining a role for the AI have changed the summary you received in the challenge?</li>
+            	<li>Did the AI&#x27;s first response make you want to adjust your prompt and try again? (This is iterative prompting in action!)</li>
+            </ul>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Key Prompting Takeaways:</h2>
+            <ul>
+            	<li><strong>Specificity Matters:</strong> Vague prompts lead to vague or unpredictable results. Clearly define what you want.</li>
+            	<li><strong>Context is Crucial:</strong> Tell the AI about the audience, the purpose, or the background information it needs to generate a relevant response.</li>
+            	<li><strong>Define the Format:</strong> Do you need bullet points, a paragraph, a table, code? Ask for it explicitly.</li>
+            	<li><strong>Assign a Role (Optional but Powerful):</strong> Asking the AI to &quot;Act as...&quot; can significantly shape the tone, style, and expertise level of the response.</li>
+            	<li><strong>Iteration is Key:</strong> Don&#x27;t expect the perfect response on the first try. Analyze the output and refine your prompt based on what you see. This aligns with the iterative learning approach we&#x27;ve discussed.</li>
+            </ul>
+
+            <p>This quick debrief highlights how thoughtful prompting moves you from simply getting <em>an</em> answer to getting the <em>right</em> answer for your specific needs. As you continue through these pathways, you&#x27;ll develop more advanced prompting strategies.</p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i><span>Iterative Prompt Refinement: Guiding the Conversation</span> </summary>
+
+            <div>
+            <div>
+            <p>You&#x27;ve seen how a detailed prompt gets a better initial response than a vague one. But what happens when even a detailed prompt doesn&#x27;t quite hit the mark? That&#x27;s where <strong>Iterative Prompt Refinement</strong> comes in. Think of it less like issuing commands and more like having a <strong>guided conversation</strong> with your AI assistant. Your first prompt starts the conversation, the AI&#x27;s response gives you feedback, and your refined prompts steer the dialogue until the AI truly understands what you need.</p>
+
+            <p>Mastering this back-and-forth is key to unlocking the AI&#x27;s potential for complex or nuanced tasks.</p>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Framework: Strategies for a Better AI Conversation</h2>
+            <p>How can you steer the conversation effectively? Here are several strategies to refine your prompts and guide the AI:</p>
+
+            <ul>
+            	<li><strong>Add/Modify Context:</strong> Like clarifying things for a person, give the AI more background. Specify the intended <strong>audience</strong> (e.g., &quot;Explain this for a beginner&quot;), the <strong>purpose</strong> (e.g., &quot;I need ideas for a presentation slide&quot;), or relevant <strong>details</strong> it might be missing.</li>
+            	<li><strong>Adjust Format/Structure:</strong> Tell the AI *how* you want the information presented. Ask for <strong>bullet points</strong>, a <strong>table</strong>, a specific <strong>length</strong> (e.g., &quot;in under 100 words&quot;), or a certain <strong>structure</strong> (e.g., &quot;pros and cons&quot;).</li>
+            	<li><strong>Refine AI Role/Persona:</strong> Ask the AI to adopt a specific viewpoint. Examples: &quot;Act as a skeptical reviewer,&quot; &quot;Act as an encouraging tutor,&quot; &quot;Adopt the persona of a historian.&quot; This shapes the tone and focus.</li>
+            	<li><strong>Provide Examples (Few-Shot Prompting):</strong> Show, don&#x27;t just tell. Give the AI a small example of the output format or style you&#x27;re looking for right within your prompt.</li>
+            	<li><strong>Break Down Complexity:</strong> If a task is too big, ask for it piece by piece. &quot;First, list the main themes.&quot;...&quot;Okay, now elaborate on the first theme.&quot;</li>
+            	<li><strong>Engage in Dialogue (Make it a Two-Way Street):</strong>
+            	<ul>
+            		<li>Prompt the AI to ask <em>you</em> questions: &quot;What other information do you need from me to answer this question effectively?&quot; or &quot;Ask me three questions that would help you refine your response.&quot;</li>
+            		<li>Ask the AI to critique itself or your prompt: &quot;Critique your previous response for clarity.&quot; or &quot;How could I improve my prompt to get a better explanation?&quot;</li>
+            	</ul>
+            	</li>
+            </ul>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Examples: Seeing the Conversation Unfold</h2>
+            </div>
+
+            <div>
+            <h3>Example 1: Refining for Audience and Length in Summarization</h3>
+
+            <p><strong>Goal:</strong> Summarize a somewhat technical news article about a new type of solar panel technology so you can quickly explain it to a friend who isn&#x27;t a science major.</p>
+
+            <p><strong>Attempt 1 Prompt:</strong></p>
+
+            <pre>
+            <code>Summarize this article about the new perovskite solar panels: [Link to article or pasted text]</code></pre>
+
+            <p><em>Potential Output:</em> A summary that accurately covers the technical details but uses jargon (like &quot;band gap,&quot; &quot;efficiency ratings,&quot; &quot;fabrication methods&quot;) and might be several paragraphs long.</p>
+
+            <p><strong>Possible Critique:</strong> Too technical for my friend, and longer than needed for a quick explanation.</p>
+
+            <p><strong>Refinement Strategy Used:</strong> Add Context (Audience), Adjust Format (Length).</p>
+
+            <p><strong>Attempt 2 Prompt (Refined):</strong></p>
+
+            <pre>
+            <code>Summarize this article about the new perovskite solar panels, but explain it in simple terms for someone without a science background. Keep the summary under 75 words.</code></pre>
+
+            <p><em>Potential Output:</em> A much shorter, simpler summary focusing on the key benefit (e.g., &quot;Scientists developed new solar panels that are cheaper and easier to make, potentially making solar energy more accessible&quot;) without the heavy technical terms.</p>
+            </div>
+
+            <div>
+            <h3>Example 2: Refining for Specific Focus in Summarization</h3>
+
+            <p><strong>Goal:</strong> You need to understand the main arguments presented in a long opinion piece about the future of remote work, specifically focusing on the impact on city planning.</p>
+
+            <p><strong>Attempt 1 Prompt:</strong></p>
+
+            <pre>
+            <code>Summarize the main points of this article about the future of remote work: [Link or text]</code></pre>
+
+            <p><em>Potential Output:</em> A general summary covering various aspects like employee productivity, company culture, economic shifts, and maybe a brief mention of urban impact.</p>
+
+            <p><strong>Critique:</strong> Covers too much; I only need the parts relevant to city planning for my specific interest/project.</p>
+
+            <p><strong>Refinement Strategy Used:</strong> Add/Modify Context (Focus).</p>
+
+            <p><strong>Attempt 2 Prompt (Refined):</strong></p>
+
+            <pre>
+            <code>Summarize the arguments this article makes about how the rise of remote work could impact city planning and urban development. Focus only on that aspect.</code></pre>
+
+            <p><em>Potential Output:</em> A targeted summary discussing points like potential changes in transportation needs, the repurposing of office buildings, shifts in residential patterns, and the economic impact on downtown areas, ignoring the other topics from the article.</p>
+
+            <p><em>Next Step:</em> This focused summary is much more useful for the user&#x27;s specific need than the general summary from the first attempt.</p>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Practice Area: Your Turn to Guide the Conversation</h2>
+            <p>Now it&#x27;s your turn to practice refining prompts. Think of it as steering the AI through conversation.</p>
+
+            <ol>
+            	<li><strong>Choose a Task:</strong> Pick something relevant to your studies where an AI could assist (e.g., explaining a difficult concept from class, brainstorming arguments for a debate topic, drafting an email to a professor, summarizing a complex reading *for a specific purpose* like finding key data points).</li>
+            	<li><strong>Start the Conversation:</strong> Write your initial prompt in one of the AI tools linked below.</li>
+            	<li><strong>Analyze the Response:</strong> Read the AI&#x27;s first output. Is it exactly what you wanted? Probably not! Where does it fall short? (Too vague? Wrong tone? Missing key info? Wrong format?)</li>
+            	<li><strong>Choose Your Next Move:</strong> Select 1-2 refinement strategies from the Framework list above. How can you clarify or redirect the AI? Consider getting it to ask you clarifying questions!</li>
+            	<li><strong>Continue the Conversation:</strong> Write and submit your refined prompt based on the strategy you chose.</li>
+            	<li><strong>Compare Outputs:</strong> Look at the first and second responses side-by-side. Did the conversation move in the right direction? How did your refinement change the outcome?</li>
+            	<li><strong>Keep Chatting (Optional):</strong> If it&#x27;s still not quite right, repeat steps 4-6. Sometimes it takes a few exchanges to get the AI aligned with your goal.</li>
+            </ol>
+
+            <p><strong>AI Tools for Practice:</strong></p>
+
+            <div><a href="https://chatgpt.com/" rel="noopener noreferrer" target="_blank">ChatGPT <i></i></a> <a href="https://claude.ai/" rel="noopener noreferrer" target="_blank">Claude <i></i></a> <a href="https://gemini.google.com/" rel="noopener noreferrer" target="_blank">Gemini <i></i></a> <a href="https://www.perplexity.ai/" rel="noopener noreferrer" target="_blank">Perplexity <i></i></a></div>
+
+            <p><em>(Feel free to use any generative AI chat tool you have access to.)</em></p>
+            </div>
+
+            <div>
+            <h3>Keep Track: Your Conversation Log (Optional)</h3>
+
+            <p>It&#x27;s helpful to note down how your conversation with the AI progresses. This helps you learn which refinement strategies work best for different situations. You can use a simple structure like this:</p>
+
+            <ul>
+            	<li><strong>My Goal:</strong> [What I wanted the AI to do]</li>
+            	<li><strong>Conversation Turn 1 (My Prompt):</strong> [My first prompt]</li>
+            	<li><strong>Conversation Turn 1 (AI Response Critique):</strong> [What was good/bad about the AI&#x27;s reply?]</li>
+            	<li><strong>My Strategy for Turn 2:</strong> [Which refinement technique did I choose?]</li>
+            	<li><strong>Conversation Turn 2 (My Prompt):</strong> [My refined prompt]</li>
+            	<li><strong>Conversation Turn 2 (AI Response Critique):</strong> [How did this response improve? Still missing anything?]</li>
+            	<li><em>(Continue logging turns as needed)</em></li>
+            </ul>
+            </div>
+
+            <div>
+            <h3>Visualizing Improvement: The Conversation Flow</h3>
+
+            <p>Think of this iterative process like charting the flow of your conversation. Each refinement is a step towards clearer communication and a better final outcome. While we don&#x27;t have an automated visual tracker here, using the log above helps you mentally map out how you guided the AI from its initial response to the more useful information you needed.</p>
+            </div>
+            </div>
+            </details>
+
+            <details><summary> <i></i> <span>Prompt Design Frameworks &amp; Resources</span> </summary>
+
+            <div>
+            <div>
+            <p>The following is a growing collection of guides, frameworks, and articles on prompt design/prompt engineering that consists of extracted pieces from a variety of resources. Please explore the full text of these resources for a deeper understanding of their respective approaches to prompt design and engineering. Try the frameworks or guidelines in your own context and reflect on which one works for you.</p>
+
+            <ol>
+            	<li><a href="https://www.huit.harvard.edu/news/ai-prompts/" target="_blank"><strong>Harvard University&#x27;s getting started with prompts for text-based Generative AI tools</strong></a>
+
+            	<ul>
+            		<li>Be specific in your request.</li>
+            		<li>Ask AI to act as if it were a certain expert or played a certain role.</li>
+            		<li>Tell AI how you want your output to be presented.</li>
+            		<li>Use clear do and don&#x27;t instruction.</li>
+            		<li>Provide examples.</li>
+            		<li>Consider tone and intended audience.</li>
+            		<li>Build on previous prompts, correct mistakes, and continuously give feedback.</li>
+            		<li>Ask AI to create prompts, clarify requirements, or inquire what else it needs from you.</li>
+            	</ul>
+            	</li>
+            	<li><a href="https://www.huit.harvard.edu/news/ai-prompts-images" target="_blank"><strong>Harvard University&#x27;s getting started with prompts for image-based Generative AI tools</strong></a>
+            	<ul>
+            		<li>Describe the subject in as much detail as you can</li>
+            		<li>Specify the style of image (photographs, paintings, cartoons, etc.)</li>
+            		<li>Add more details and refine (considering lighting, the positioning of the subject within the frame, background details, etc.)</li>
+            		<li>Add your preferred output (considering the format, for example, poster, email header image, etc.)</li>
+            	</ul>
+            	</li>
+            	<li><a href="https://www.sciencedirect.com/science/article/abs/pii/S0099133323000599?via%3Dihub" target="_blank"><strong>The CLEAR path – A framework for enhancing information literacy through prompt engineering</strong></a>
+            	<ul>
+            		<li><strong>Concise:</strong> keep prompt brief and to the point.</li>
+            		<li><strong>Logical:</strong> ensure prompts follow a logical structure and sequence.</li>
+            		<li><strong>Explicit:</strong> be explicit about expected outcome.</li>
+            		<li><strong>Adaptive:</strong> adjust prompts based on prior results and learning.</li>
+            		<li><strong>Reflective:</strong> encourage reflection on the output to refine future prompts.</li>
+            	</ul>
+            	</li>
+            	<li><a href="https://fsw.instructure.com/courses/1131366/pages/prompting-guide-sheet?module_item_id=15818026" target="_blank"><strong>The five « S » model</strong></a>
+            	<ul>
+            		<li>Set the scene.</li>
+            		<li>Be specific.</li>
+            		<li>Simplify your language.</li>
+            		<li>Structure the output.</li>
+            		<li>Share feedback.</li>
+            	</ul>
+            	</li>
+            	<li><a href="https://github.com/microsoft/prompts-for-edu/tree/main/Students" target="_blank"><strong>Microsoft&#x27;s educational prompts repository</strong></a>
+            	<ul>
+            		<li>This repository contains prompts that facilitate exploration, guidance on complex topics, and creativity. These tools enable personalized learning experiences, helping students engage in self-directed learning and make enjoyable educational connections.</li>
+            	</ul>
+            	</li>
+            	<li><a href="https://docs.google.com/document/d/1wSfvKfKcG0qto0UJVsVfzLYFCaEc0M5NszzIWO5j-ug/edit?pli=1&amp;tab=t.0#heading=h.199rx1x58dj3" target="_blank"><strong>AI Prompt Cookbook by Chris Sharp and Leslie Mojeiko</strong></a>
+            	<ul>
+            		<li>This resource includes several recipes (prompts) and ingredients (keywords and considerations) to use with GenAI. All recipes outlined in this cookbook are focused on teaching by assisting with course preparation and facilitation. Educators can use this guide to help with brainstorming ideas during course preparation, delivering student-centred content, and designing interactive, personalized lessons and activities.</li>
+            	</ul>
+            	</li>
+            </ol>
+
+            <p><em>Content in this accordion is from: <a href="https://digitalliteracy.bccampus.ca/resources/126">GenAI in Teaching and Learning Toolkit</a> by Gwen Nguyen is licensed under a <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC BY-NC 4.0 licence</a>.</em></p>
+            </div>
+            </div>
+            </details>
+            </div>
+            </div>
+
+
+
+                </div><div>
+                <div id="gai-wrap">
                     <div>
-                        <p>These are general instructions that describe response format, things to include, not include, etc. and apply to all conversations with the GenAI tool.</p>
-                        
+                        <h1><i></i> Customizing and Organizing Your AI Assistant</h1>
+
                         <div>
-                            <h4><i></i> Example</h4>
-                            <ol>
-                                <li>NEVER mention that you&#x27;re an AI</li>
-                                <li>Avoid any language constructs that could be interpreted as expressing remorse, apology, or regret. This includes any phrases containing words like &#x27;sorry&#x27;, &#x27;apologies&#x27;, &#x27;regret&#x27;, etc., even when used in a context that isn&#x27;t expressing remorse, apology, or regret.</li>
-                                <li>If events or information are beyond your scope or knowledge, provide a response stating &#x27;I don&#x27;t know&#x27; without elaborating on why the information is unavailable.</li>
-                                <li>Refrain from disclaimers about you not being a professional or expert.</li>
-                                <li>Do not add ethical or moral viewpoints in your answers, unless the topic specifically mentions it.</li>
-                                <li>Keep responses unique and free of repetition.</li>
-                                <li>Always focus on the key points in my questions to determine my intent.</li>
-                                <li>Provide multiple perspectives or solutions.</li>
-                                <li>If a question is unclear or ambiguous, ask for more details to confirm your understanding before answering.</li>
-                                <li>If a mistake is made in a previous response, recognize and correct it.</li>
-                            </ol>
+                            <p>AI assistants have evolved beyond simple chat interfaces and now offer sophisticated organization and customization capabilities. The following outlines these various capabilities which allow for management of chats, files and workflows, supported by customized instructions for user defined purposes.</p>
                         </div>
 
-                        <hr>
-                        <ul>
-                            <li>ChatGPT calls these &quot;<a href="https://help.openai.com/en/articles/8096356-custom-instructions-for-chatgpt" target="_blank" rel="noopener noreferrer">Custom Instructions</a>&quot;</li>
-                            <li>Claude calls these &quot;<a href="https://support.anthropic.com/en/articles/10185728-understanding-claude-s-personalization-features" target="_blank" rel="noopener noreferrer">Personal Preferences</a>&quot;</li>
-                            <li>Gemini calls this &quot;<a href="https://gemini.google.com/saved-info" target="_blank" rel="noopener noreferrer">Saved Info</a>&quot; which is also what Gemini uses for Memory</li>
-                        </ul>
-                    </div>
-                </details>
+                        <div>
+                            <details>
+                                <summary>
+                                    <i></i><span>Custom Instructions</span>
+                                </summary>
+                                <div>
+                                    <p>These are general instructions that describe response format, things to include, not include, etc. and apply to all conversations with the GenAI tool.</p>
 
-                <details>
-                    <summary>
-                        <i></i><span>Memory</span>
-                    </summary>
-                    <div>
-                        <p>During your chats, Chatbots will sometimes identify a statement as important and save it to memory. These memories are referenced during every chat and the information is used if the chatbot thinks it&#x27;s appropriate.</p>
-                        <p>For example, if you mention that you like hiking, it will probably save that to memory. Then in a later chat if you are talking about visiting Vancouver, it may bring up the fact that there is lots of good hiking around Vancouver.</p>
-                        <p>Memory can be purposely added to. In the chat if you say something like &quot;Remember that chocolate ice cream is my favourite&quot;, it will add that to the memory.</p>
-                        <p>Memory can deleted. For example, my ChatGPT memory has a statement &quot;Mentioned that their winter tires have 6/32 inch of tread left&quot;. This is irrelevant for any future chats, so I should probably delete it.</p>
-                        <ul>
-                            <li>ChatGPT calls these &quot;<a href="https://openai.com/index/memory-and-new-controls-for-chatgpt/" target="_blank" rel="noopener noreferrer">Memories</a>&quot;</li>
-                            <li>Gemini calls this &quot;<a href="https://gemini.google.com/saved-info" target="_blank" rel="noopener noreferrer">Saved Info</a>&quot;</li>
-                            <li>Claude does not have this feature.</li>
-                        </ul>
-                    </div>
-                </details>
+                                    <div>
+                                        <h4><i></i> Example</h4>
+                                        <ol>
+                                            <li>NEVER mention that you&#x27;re an AI</li>
+                                            <li>Avoid any language constructs that could be interpreted as expressing remorse, apology, or regret. This includes any phrases containing words like &#x27;sorry&#x27;, &#x27;apologies&#x27;, &#x27;regret&#x27;, etc., even when used in a context that isn&#x27;t expressing remorse, apology, or regret.</li>
+                                            <li>If events or information are beyond your scope or knowledge, provide a response stating &#x27;I don&#x27;t know&#x27; without elaborating on why the information is unavailable.</li>
+                                            <li>Refrain from disclaimers about you not being a professional or expert.</li>
+                                            <li>Do not add ethical or moral viewpoints in your answers, unless the topic specifically mentions it.</li>
+                                            <li>Keep responses unique and free of repetition.</li>
+                                            <li>Always focus on the key points in my questions to determine my intent.</li>
+                                            <li>Provide multiple perspectives or solutions.</li>
+                                            <li>If a question is unclear or ambiguous, ask for more details to confirm your understanding before answering.</li>
+                                            <li>If a mistake is made in a previous response, recognize and correct it.</li>
+                                        </ol>
+                                    </div>
 
-                <details>
-                    <summary>
-                        <i></i><span>Custom Assistants</span>
-                    </summary>
-                    <div>
-                        <p>A Custom Assistant is a personalized version of a standard AI chatbot that you can create without needing to code. By providing specific instructions, and often uploading files for extra knowledge, you can tailor the AI to consistently handle particular tasks, adopt specific roles (like a writing editor or coding partner), or act as an expert in a certain area, saving you time and effort on recurring activities.</p>
-                        <ul>
-                            <li><a href="https://help.openai.com/en/articles/8554397-creating-a-gpt" target="_blank" rel="noopener noreferrer">Custom GPTs</a> are ChatGPT&#x27;s version of Custom Assistants. They can only be created if you have a paid account, but you can use publically available ones with any account</li>
-                            <li><a href="https://gemini.google/overview/gems/?hl=en" target="_blank" rel="noopener noreferrer">Gems are Gemini&#x27;s version</a>. They can be created on a free account, but do not currently have sharing capability (April 2025)</li>
-                        </ul>
-                    </div>
-                </details>
+                                    <hr>
+                                    <ul>
+                                        <li>ChatGPT calls these &quot;<a href="https://help.openai.com/en/articles/8096356-custom-instructions-for-chatgpt" target="_blank" rel="noopener noreferrer">Custom Instructions</a>&quot;</li>
+                                        <li>Claude calls these &quot;<a href="https://support.anthropic.com/en/articles/10185728-understanding-claude-s-personalization-features" target="_blank" rel="noopener noreferrer">Personal Preferences</a>&quot;</li>
+                                        <li>Gemini calls this &quot;<a href="https://gemini.google.com/saved-info" target="_blank" rel="noopener noreferrer">Saved Info</a>&quot; which is also what Gemini uses for Memory</li>
+                                    </ul>
+                                </div>
+                            </details>
 
-                <details>
-                    <summary>
-                        <i></i><span>Projects</span>
-                    </summary>
-                    <div>
-                        <p>An AI &quot;Project&quot; serves as a dedicated digital workspace to organize everything related to a specific task or goal. Think of it as a focused folder where you can keep relevant chats, documents, and specific instructions for the AI assistant, ensuring it stays on track and understands the context of your work without needing constant reminders.</p>
-                        <p>ChatGPT and Claude both offer a Projects feature (paid version only)</p>
-                        <ul>
-                            <li><a href="https://www.anthropic.com/news/projects" target="_blank" rel="noopener noreferrer">Claude Projects</a> are distinct for their team-focused collaboration features and ability to handle very large amounts of information within a shared workspace. While Claude does not have custom assistants, custom instructions can be added inside of a Claude Project.</li>
-                            <li><a href="https://help.openai.com/en/articles/10169521-using-projects-in-chatgpt" target="_blank" rel="noopener noreferrer">ChatGPT Projects</a> focus on organization, integrating files and instructions within a familiar folder-like structure alongside other ChatGPT features for individual productivity.</li>
-                        </ul>
-                    </div>
-                </details>
+                            <details>
+                                <summary>
+                                    <i></i><span>Memory</span>
+                                </summary>
+                                <div>
+                                    <p>During your chats, Chatbots will sometimes identify a statement as important and save it to memory. These memories are referenced during every chat and the information is used if the chatbot thinks it&#x27;s appropriate.</p>
+                                    <p>For example, if you mention that you like hiking, it will probably save that to memory. Then in a later chat if you are talking about visiting Vancouver, it may bring up the fact that there is lots of good hiking around Vancouver.</p>
+                                    <p>Memory can be purposely added to. In the chat if you say something like &quot;Remember that chocolate ice cream is my favourite&quot;, it will add that to the memory.</p>
+                                    <p>Memory can deleted. For example, my ChatGPT memory has a statement &quot;Mentioned that their winter tires have 6/32 inch of tread left&quot;. This is irrelevant for any future chats, so I should probably delete it.</p>
+                                    <ul>
+                                        <li>ChatGPT calls these &quot;<a href="https://openai.com/index/memory-and-new-controls-for-chatgpt/" target="_blank" rel="noopener noreferrer">Memories</a>&quot;</li>
+                                        <li>Gemini calls this &quot;<a href="https://gemini.google.com/saved-info" target="_blank" rel="noopener noreferrer">Saved Info</a>&quot;</li>
+                                        <li>Claude does not have this feature.</li>
+                                    </ul>
+                                </div>
+                            </details>
 
-                <details>
-                    <summary>
-                        <i></i><span>Connected Accounts</span>
-                    </summary>
-                    <div>
-                        <p>Integrating external accounts into a GenAI platform allows you to connect the tool with existing documents and workflows. Just be sure you are comfortable sharing your information with the GenAI tool.</p>
-                        <ul>
-                            <li><a href="https://support.anthropic.com/en/articles/10168395-setting-up-integrations-on-claude-ai" target="_blank" rel="noopener noreferrer">Setting up Integrations on Claude.ai</a> (e.g. link Google and GitHub)</li>
-                            <li><a href="https://gemini.google.com/apps" target="_blank" rel="noopener noreferrer">Connecting Google Workspace to Gemini</a></li>
-                            <li><a href="https://one.google.com/about/articles/3-ways-to-use-gemini-advanced-ai/" target="_blank" rel="noopener noreferrer">Access Gemini from your Google Apps</a> (requires paid account)</li>
-                            <li><a href="https://help.openai.com/en/articles/9309188-connected-apps-on-chatgpt" target="_blank" rel="noopener noreferrer">Connected apps on ChatGPT</a> (e.g., Google, OneDrive, Apple Intelligence)</li>
-                        </ul>
-                    </div>
-                </details>
+                            <details>
+                                <summary>
+                                    <i></i><span>Custom Assistants</span>
+                                </summary>
+                                <div>
+                                    <p>A Custom Assistant is a personalized version of a standard AI chatbot that you can create without needing to code. By providing specific instructions, and often uploading files for extra knowledge, you can tailor the AI to consistently handle particular tasks, adopt specific roles (like a writing editor or coding partner), or act as an expert in a certain area, saving you time and effort on recurring activities.</p>
+                                    <ul>
+                                        <li><a href="https://help.openai.com/en/articles/8554397-creating-a-gpt" target="_blank" rel="noopener noreferrer">Custom GPTs</a> are ChatGPT&#x27;s version of Custom Assistants. They can only be created if you have a paid account, but you can use publically available ones with any account</li>
+                                        <li><a href="https://gemini.google/overview/gems/?hl=en" target="_blank" rel="noopener noreferrer">Gems are Gemini&#x27;s version</a>. They can be created on a free account, but do not currently have sharing capability (April 2025)</li>
+                                    </ul>
+                                </div>
+                            </details>
 
-                <details>
-                    <summary>
-                        <i></i><span>Document Upload</span>
-                    </summary>
-                    <div>
-                        <p>Claude, Gemini, and ChatGPT all allow file uploads. You can then analyze the file, query the file or just use the information in the file for context. These can be images, code files, documents, spreadsheets etc. For more complete lists of the types of files that can be uploaded see the following links:</p>
-                        <ul>
-                            <li>Claude: <a href="https://support.anthropic.com/en/articles/8241126-what-kinds-of-documents-can-i-upload-to-claude-ai" target="_blank" rel="noopener noreferrer">Document</a> and <a href="#" target="_blank" rel="noopener noreferrer">Images</a>()</li>
-                            <li>Gemini: <a href="https://support.google.com/gemini/answer/14903178?hl=en&amp;co=GENIE.Platform" target="_blank" rel="noopener noreferrer">Upload and Analyze Files</a></li>
-                            <li>ChatGPT: <a href="https://help.openai.com/en/collections/8475809-file-uploads" target="_blank" rel="noopener noreferrer">File Uploads</a></li>
-                        </ul>
-                    </div>
-                </details>
-            </div>
+                            <details>
+                                <summary>
+                                    <i></i><span>Projects</span>
+                                </summary>
+                                <div>
+                                    <p>An AI &quot;Project&quot; serves as a dedicated digital workspace to organize everything related to a specific task or goal. Think of it as a focused folder where you can keep relevant chats, documents, and specific instructions for the AI assistant, ensuring it stays on track and understands the context of your work without needing constant reminders.</p>
+                                    <p>ChatGPT and Claude both offer a Projects feature (paid version only)</p>
+                                    <ul>
+                                        <li><a href="https://www.anthropic.com/news/projects" target="_blank" rel="noopener noreferrer">Claude Projects</a> are distinct for their team-focused collaboration features and ability to handle very large amounts of information within a shared workspace. While Claude does not have custom assistants, custom instructions can be added inside of a Claude Project.</li>
+                                        <li><a href="https://help.openai.com/en/articles/10169521-using-projects-in-chatgpt" target="_blank" rel="noopener noreferrer">ChatGPT Projects</a> focus on organization, integrating files and instructions within a familiar folder-like structure alongside other ChatGPT features for individual productivity.</li>
+                                    </ul>
+                                </div>
+                            </details>
 
+                            <details>
+                                <summary>
+                                    <i></i><span>Connected Accounts</span>
+                                </summary>
+                                <div>
+                                    <p>Integrating external accounts into a GenAI platform allows you to connect the tool with existing documents and workflows. Just be sure you are comfortable sharing your information with the GenAI tool.</p>
+                                    <ul>
+                                        <li><a href="https://support.anthropic.com/en/articles/10168395-setting-up-integrations-on-claude-ai" target="_blank" rel="noopener noreferrer">Setting up Integrations on Claude.ai</a> (e.g. link Google and GitHub)</li>
+                                        <li><a href="https://gemini.google.com/apps" target="_blank" rel="noopener noreferrer">Connecting Google Workspace to Gemini</a></li>
+                                        <li><a href="https://one.google.com/about/articles/3-ways-to-use-gemini-advanced-ai/" target="_blank" rel="noopener noreferrer">Access Gemini from your Google Apps</a> (requires paid account)</li>
+                                        <li><a href="https://help.openai.com/en/articles/9309188-connected-apps-on-chatgpt" target="_blank" rel="noopener noreferrer">Connected apps on ChatGPT</a> (e.g., Google, OneDrive, Apple Intelligence)</li>
+                                    </ul>
+                                </div>
+                            </details>
+
+                            <details>
+                                <summary>
+                                    <i></i><span>Document Upload</span>
+                                </summary>
+                                <div>
+                                    <p>Claude, Gemini, and ChatGPT all allow file uploads. You can then analyze the file, query the file or just use the information in the file for context. These can be images, code files, documents, spreadsheets etc. For more complete lists of the types of files that can be uploaded see the following links:</p>
+                                    <ul>
+                                        <li>Claude: <a href="https://support.anthropic.com/en/articles/8241126-what-kinds-of-documents-can-i-upload-to-claude-ai" target="_blank" rel="noopener noreferrer">Document</a> and <a href="#" target="_blank" rel="noopener noreferrer">Images</a>()</li>
+                                        <li>Gemini: <a href="https://support.google.com/gemini/answer/14903178?hl=en&amp;co=GENIE.Platform" target="_blank" rel="noopener noreferrer">Upload and Analyze Files</a></li>
+                                        <li>ChatGPT: <a href="https://help.openai.com/en/collections/8475809-file-uploads" target="_blank" rel="noopener noreferrer">File Uploads</a></li>
+                                    </ul>
+                                </div>
+                            </details>
+                        </div>
+
+                    </div>
+                </div>
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
-    </div>
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
-    </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/authentic-learning-and-ai-use.html
+++ b/site/authentic-learning-and-ai-use.html
@@ -4,108 +4,144 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Authentic Learning and AI Use - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="active has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Authentic Learning and AI Use</h2>
-        <div>
-    
-<link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div>
-<div>
-<h1><i></i>Navigating AI in Your Studies: Finding the Right Balance</h1>
-
-<div><img alt="Student thoughtfully considering AI tools and books" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=diverse%20student%20looking%20thoughtful%2C%20with%20AI%20icons%20on%20one%20side%20and%20books%20on%20the%20other%2C%20stylized%20illustration&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
-<div>
-<p>Imagine you&#x27;re working on your capstone project or final thesis a year from now. On your screen are three windows: your research notes, an AI writing assistant, and a complex problem that needs solving. But unlike many of your peers, you&#x27;re not asking, <em>&quot;Can AI do this for me?&quot;</em> Instead, you&#x27;re asking a more powerful question: <em>&quot;Should AI be part of this process, and if so, how?&quot;</em> You shouldn&#x27;t be choosing between using generative AI (GenAI) or not using GenAI. You should be thinking about and knowing when GenAI enhances your learning and when it might hinder it.</p>
-</div>
-</div>
-
-<hr>
-<h2><i></i>Three Students, Three Approaches</h2>
-
-<div>
-<div><img alt="Young student who uses AI for everything" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx__3_.jpg">
-<div>
-<h5>Alex: The All-In Adopter</h5>
-
-<p>Alex uses AI for everything – from summarizing readings to writing papers. Their grades are good, but in upper-level discussions, they struggle to contribute original insights. When internship interviews probe deep knowledge, Alex realizes something&#x27;s missing. The constant reliance on AI tools has prevented Alex from developing critical analytical skills and a deeper understanding of the material, leaving them feeling unprepared for independent problem-solving.</p>
-</div>
-</div>
-
-<div><img alt="Student reading book at desk" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx__2_.jpg">
-<div>
-<h5>Jordan: The Complete Resistor</h5>
-
-<p>Jordan refuses to touch AI tools, seeing them as a threat to genuine learning. While this approach ensures they engage deeply with course material, it also creates challenges. In team projects, Jordan’s reluctance to engage with AI tools limits their ability to contribute fully, especially when tasks involve technology integration. This often leaves Jordan struggling to keep up with peers who effectively combine GenAI capabilities with their own efforts.</p>
-</div>
-</div>
-
-<div><img alt="Student with pen and graduation hat" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx__1_.jpg">
-<div>
-<h5>M.J.: The Mindful Navigator</h5>
-
-<p>M.J. approaches each task with careful consideration. For a philosophy paper, they engage deeply with the texts, developing their own arguments, using GenAI only to explore counter-arguments they might have missed. In their chemistry lab, they use AI to help understand complex molecular structures but work through the problem-solving steps themselves to build genuine understanding. This balanced approach allows M.J. to refine their analytical skills while leveraging GenAI to broaden their perspective, resulting in both strong academic performance and practical expertise.</p>
-</div>
-</div>
-</div>
-
-<hr>
-<div>
-<h2><i></i>The Real Questions</h2>
-
-<p>The question isn&#x27;t whether to use GenAI or not. The real questions are:</p>
-
-<ul>
-	<li>When does AI support genuine learning?</li>
-	<li>When might it short-circuit your understanding?</li>
-	<li>How can you leverage AI while developing authentic expertise?</li>
-	<li>What does meaningful human contribution look like in an AI-enhanced world?</li>
-</ul>
-</div>
-
-<hr>
-<div>
-<h2><i></i>Your Learning Journey</h2>
-
-<p>Understanding generative AI in the context of your classes isn&#x27;t about avoiding AI use altogether, and it isn&#x27;t about teaching you to use AI for everything. It&#x27;s about developing the wisdom to:</p>
-
-<ul>
-	<li>Recognize when deep, AI-free learning is crucial</li>
-	<li>Identify opportunities where AI can enhance your understanding</li>
-	<li>Build the confidence to make informed choices about AI use</li>
-	<li>Maintain academic integrity while embracing innovation</li>
-	<li>Develop the critical thinking skills that AI cannot replace</li>
-</ul>
-
-<p>The most successful students won&#x27;t be those who use AI the most, nor those who avoid it entirely. They&#x27;ll be the ones who understand how to maintain their intellectual growth while strategically leveraging AI&#x27;s capabilities.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Authentic Learning and AI Use</h2>
+            <div>
+
+            <div>
+            <div>
+            <h1><i></i>Navigating AI in Your Studies: Finding the Right Balance</h1>
+
+            <div><img alt="Student thoughtfully considering AI tools and books" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=diverse%20student%20looking%20thoughtful%2C%20with%20AI%20icons%20on%20one%20side%20and%20books%20on%20the%20other%2C%20stylized%20illustration&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
+            <div>
+            <p>Imagine you&#x27;re working on your capstone project or final thesis a year from now. On your screen are three windows: your research notes, an AI writing assistant, and a complex problem that needs solving. But unlike many of your peers, you&#x27;re not asking, <em>&quot;Can AI do this for me?&quot;</em> Instead, you&#x27;re asking a more powerful question: <em>&quot;Should AI be part of this process, and if so, how?&quot;</em> You shouldn&#x27;t be choosing between using generative AI (GenAI) or not using GenAI. You should be thinking about and knowing when GenAI enhances your learning and when it might hinder it.</p>
+            </div>
+            </div>
+
+            <hr>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Three Students, Three Approaches</h2>
+            <div>
+            <div><img alt="Young student who uses AI for everything" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx__3_.jpg">
+            <div>
+            <h5>Alex: The All-In Adopter</h5>
+
+            <p>Alex uses AI for everything – from summarizing readings to writing papers. Their grades are good, but in upper-level discussions, they struggle to contribute original insights. When internship interviews probe deep knowledge, Alex realizes something&#x27;s missing. The constant reliance on AI tools has prevented Alex from developing critical analytical skills and a deeper understanding of the material, leaving them feeling unprepared for independent problem-solving.</p>
+            </div>
+            </div>
+
+            <div><img alt="Student reading book at desk" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx__2_.jpg">
+            <div>
+            <h5>Jordan: The Complete Resistor</h5>
+
+            <p>Jordan refuses to touch AI tools, seeing them as a threat to genuine learning. While this approach ensures they engage deeply with course material, it also creates challenges. In team projects, Jordan’s reluctance to engage with AI tools limits their ability to contribute fully, especially when tasks involve technology integration. This often leaves Jordan struggling to keep up with peers who effectively combine GenAI capabilities with their own efforts.</p>
+            </div>
+            </div>
+
+            <div><img alt="Student with pen and graduation hat" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx__1_.jpg">
+            <div>
+            <h5>M.J.: The Mindful Navigator</h5>
+
+            <p>M.J. approaches each task with careful consideration. For a philosophy paper, they engage deeply with the texts, developing their own arguments, using GenAI only to explore counter-arguments they might have missed. In their chemistry lab, they use AI to help understand complex molecular structures but work through the problem-solving steps themselves to build genuine understanding. This balanced approach allows M.J. to refine their analytical skills while leveraging GenAI to broaden their perspective, resulting in both strong academic performance and practical expertise.</p>
+            </div>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>The Real Questions</h2>
+            <p>The question isn&#x27;t whether to use GenAI or not. The real questions are:</p>
+
+            <ul>
+            	<li>When does AI support genuine learning?</li>
+            	<li>When might it short-circuit your understanding?</li>
+            	<li>How can you leverage AI while developing authentic expertise?</li>
+            	<li>What does meaningful human contribution look like in an AI-enhanced world?</li>
+            </ul>
+            </div>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Your Learning Journey</h2>
+            <p>Understanding generative AI in the context of your classes isn&#x27;t about avoiding AI use altogether, and it isn&#x27;t about teaching you to use AI for everything. It&#x27;s about developing the wisdom to:</p>
+
+            <ul>
+            	<li>Recognize when deep, AI-free learning is crucial</li>
+            	<li>Identify opportunities where AI can enhance your understanding</li>
+            	<li>Build the confidence to make informed choices about AI use</li>
+            	<li>Maintain academic integrity while embracing innovation</li>
+            	<li>Develop the critical thinking skills that AI cannot replace</li>
+            </ul>
+
+            <p>The most successful students won&#x27;t be those who use AI the most, nor those who avoid it entirely. They&#x27;ll be the ones who understand how to maintain their intellectual growth while strategically leveraging AI&#x27;s capabilities.</p>
+            </div>
+            </div>
+            </div>
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/essentials-for-smart-engagement.html
+++ b/site/essentials-for-smart-engagement.html
@@ -4,462 +4,499 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Essentials for Smart Engagement - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="active has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li class="active"><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Essentials for Smart Engagement</h2>
-        <div>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
+    </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
 <div id="gai-wrap">
-<div>
-<div>
-<h2>AI is Everywhere!</h2>
-
-<div aria-label="Examples of AI in everyday tools">
-<div><i></i> <span>Web Search</span></div>
-
-<div><i></i> <span>Streaming</span></div>
-
-<div><i></i> <span>Social Media</span></div>
-
-<div><i></i> <span>AI Assistants</span></div>
-
-<div><i></i> <span>Academic Tools</span></div>
-</div>
-</div>
-
-<div>
-<p>Artificial Intelligence, especially <strong><span>Generative AI</span></strong> (the kind that creates new content like text or images), is rapidly changing how we learn, work, and interact. You&#x27;re already using AI constantly, often without a second thought.</p>
-</div>
-
-<div>
-<h2>AI Powers Your Everyday Life:</h2>
-
-<div>
-<div>
-<h3><i></i> Your Favorite Apps</h3>
-
-<ul>
-	<li>Netflix recommendations</li>
-	<li>Spotify playlists</li>
-	<li>Google Maps routes</li>
-	<li>TikTok feeds</li>
-</ul>
-</div>
-
-<div>
-<h3><i></i> Everyday &amp; Productivity Tools</h3>
-
-<ul>
-	<li>Web search engines (Google, Bing)</li>
-	<li>Grammarly (writing checks)</li>
-	<li>Microsoft Copilot (Word, PowerPoint, etc.)</li>
-	<li>Google&#x27;s Gemini (Docs, Workspace)</li>
-	<li>Zoom (features like transcription, summaries)</li>
-</ul>
-</div>
-</div>
-
-<p>You might not even realize it, but AI is also working behind the scenes in many of these tools, enhancing your experience.</p>
-</div>
-
-<div>
-<h5><i></i>Key Takeaway</h5>
-
-<p>Understanding how to use these powerful tools <strong>responsibly, effectively, critically, and ethically</strong> is no longer optional—it&#x27;s a key skill for your academic and future career.</p>
-</div>
-
-<p>This guide will take you through AI&#x27;s exciting potential and its crucial limitations, preparing you to be a smart and responsible user. Let&#x27;s dive in!</p>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-        <div>
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Essentials for Smart Engagement</h2>
             <div>
-                <h2>The Promise: How Generative AI Can be Your Academic Ally</h2>
-                <p>Generative AI is a versatile partner that can support your learning, help you work more effectively, and unlock new levels of creativity - <strong><em>when used thoughtfully</em></strong>. It is a way to <em>augment</em> your own abilities, not replace them. Let&#x27;s look at some ways that AI can support your academic journey:</p>
+
+            <div>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>AI is Everywhere!</h2>
+            <div aria-label="Examples of AI in everyday tools">
+            <div><i></i> <span>Web Search</span></div>
+
+            <div><i></i> <span>Streaming</span></div>
+
+            <div><i></i> <span>Social Media</span></div>
+
+            <div><i></i> <span>AI Assistants</span></div>
+
+            <div><i></i> <span>Academic Tools</span></div>
+            </div>
             </div>
 
             <div>
-                <h3 id="sparking-ideas--overcoming-the-blank-page-brainstorming"><i></i>Sparking Ideas &amp; Overcoming the Blank Page (Brainstorming)</h3>
-                <p>Stuck staring at a blank document? AI can be a fantastic brainstorming partner. Use it to explore diverse ideas for a project, develop different arguments, or find new angles on a familiar topic. It can help you break through creative blocks and get your thoughts flowing.</p>
-                <div>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Tool Tip</span>
-                        </summary>
+            <p>Artificial Intelligence, especially <strong><span>Generative AI</span></strong> (the kind that creates new content like text or images), is rapidly changing how we learn, work, and interact. You&#x27;re already using AI constantly, often without a second thought.</p>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>AI Powers Your Everyday Life:</h2>
+            <div>
+            <div>
+            <h3><i></i> Your Favorite Apps</h3>
+
+            <ul>
+            	<li>Netflix recommendations</li>
+            	<li>Spotify playlists</li>
+            	<li>Google Maps routes</li>
+            	<li>TikTok feeds</li>
+            </ul>
+            </div>
+
+            <div>
+            <h3><i></i> Everyday &amp; Productivity Tools</h3>
+
+            <ul>
+            	<li>Web search engines (Google, Bing)</li>
+            	<li>Grammarly (writing checks)</li>
+            	<li>Microsoft Copilot (Word, PowerPoint, etc.)</li>
+            	<li>Google&#x27;s Gemini (Docs, Workspace)</li>
+            	<li>Zoom (features like transcription, summaries)</li>
+            </ul>
+            </div>
+            </div>
+
+            <p>You might not even realize it, but AI is also working behind the scenes in many of these tools, enhancing your experience.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Key Takeaway</h5>
+
+            <p>Understanding how to use these powerful tools <strong>responsibly, effectively, critically, and ethically</strong> is no longer optional—it&#x27;s a key skill for your academic and future career.</p>
+            </div>
+
+            <p>This guide will take you through AI&#x27;s exciting potential and its crucial limitations, preparing you to be a smart and responsible user. Let&#x27;s dive in!</p>
+            </div>
+
+
+
+                </div><div>
+                <div id="gai-wrap">
+                    <div>
                         <div>
-                            <p>Use a broad generative AI tool like ChatGPT, Claude, or Gemini</p>
+        </section>
+        <section class="gai-box">
+            <h2>The Promise: How Generative AI Can be Your Academic Ally</h2>
+            <p>Generative AI is a versatile partner that can support your learning, help you work more effectively, and unlock new levels of creativity - <strong><em>when used thoughtfully</em></strong>. It is a way to <em>augment</em> your own abilities, not replace them. Let&#x27;s look at some ways that AI can support your academic journey:</p>
                         </div>
-                    </details>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Use Case</span>
-                        </summary>
+
                         <div>
-                            <p>Imagine you need to write a short story but have no plot ideas. You could prompt an AI: <em>&#x27;Act as my creative thought partner. Dream up 10 truly original mystery plots that can only happen inside a university library, each anchored by a surprising library-centric element. Ensure every idea breaks free from familiar campus-whodunit tropes and features an unexpected twist or revelation. Keep the tones, motives, and narrative styles as diverse as the library’s own collections&#x27;</em> Use these as starting points for your own original story.</p>
+                            <h3 id="sparking-ideas--overcoming-the-blank-page-brainstorming"><i></i>Sparking Ideas &amp; Overcoming the Blank Page (Brainstorming)</h3>
+                            <p>Stuck staring at a blank document? AI can be a fantastic brainstorming partner. Use it to explore diverse ideas for a project, develop different arguments, or find new angles on a familiar topic. It can help you break through creative blocks and get your thoughts flowing.</p>
+                            <div>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Tool Tip</span>
+                                    </summary>
+                                    <div>
+                                        <p>Use a broad generative AI tool like ChatGPT, Claude, or Gemini</p>
+                                    </div>
+                                </details>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Use Case</span>
+                                    </summary>
+                                    <div>
+                                        <p>Imagine you need to write a short story but have no plot ideas. You could prompt an AI: <em>&#x27;Act as my creative thought partner. Dream up 10 truly original mystery plots that can only happen inside a university library, each anchored by a surprising library-centric element. Ensure every idea breaks free from familiar campus-whodunit tropes and features an unexpected twist or revelation. Keep the tones, motives, and narrative styles as diverse as the library’s own collections&#x27;</em> Use these as starting points for your own original story.</p>
+                                    </div>
+                                </details>
+                            </div>
                         </div>
-                    </details>
+
+                        <div>
+                            <h3 id="making-complex-concepts-click-explainers"><i></i>Making Complex Concepts Click (Explainers)</h3>
+                            <p>Dealing with dense textbook chapters or tricky theories? AI can simplify complex information, offer explanations in different ways, define key terms clearly, or provide essential background to help you build a solid understanding.</p>
+                            <div>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Tool Tip</span>
+                                    </summary>
+                                    <div>
+                                        <p>Use NotebookLM and upload or point to reference material that it will then use as the &quot;grounded source of truth&quot; to help you understand. In your interaction, ask for explanations from different points of view or with different analogies until the topic makes sense to you.</p>
+                                    </div>
+                                </details>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Use Case</span>
+                                    </summary>
+                                    <div>
+                                        <p>Imagine you are a first year chemistry student trying to understand Le Châtelier’s principle. You have 2 first rate references an <a href="https://openstax.org/books/chemistry-2e/pages/13-3-shifting-equilibria-le-chateliers-principle">OpenStax Chemistry Textbook</a> and a <a href="https://www.youtube.com/watch?v=B2pP02GEZL4">Khan Academy explainer video</a>. Open up a new notebook in NotebookLM and link to those two sources. Then ask: &quot;First, define Le Châtelier’s Principle in one sentence a first-year college student would understand. Next, illustrate the principle with three everyday analogies.&quot;</p>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+
+                        <div>
+                            <h3 id="enhancing-your-research--information-gathering-research"><i></i>Enhancing Your Research &amp; Information Gathering (Research)</h3>
+                            <p>AI can assist in the early stages of research by helping you explore topics broadly, identify potential sources <strong>(always verify!)</strong>, or even summarize large texts to give you a quick overview <strong>(remember to read originals for depth!)</strong>.</p>
+                            <div>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Tool Tip</span>
+                                    </summary>
+                                    <div>
+                                        <p>Tools like Elicit or Semantic Scholar are designed for academic research. Deep Research tools through ChatGPT, Perplexity, or Gemini can build a reserach framework from information on the internet.</p>
+                                    </div>
+                                </details>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Use Case</span>
+                                    </summary>
+                                    <div>
+                                        <p>Imagine you have a 50-page research paper to understand quickly for background. You could link to the paper or upload the PDF to ChatGPT/Gemini and ask   <em>&#x27;Read the attached 50-page paper and give me a bullet point  summary that clearly states the research question, methodology, key findings, and practical implications.&#x27;</em> <br>
+                                        <strong><em>Use this summary to guide your full reading, not replace it</em></strong>.</p>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+
+                        <div>
+                            <h3 id="assisting-your-writing-process-responsibly-writing"><i></i>Assisting Your Writing Process Responsibly (Writing)</h3>
+                            <p>While AI should never write your papers <em>for</em> you, it can be a helpful writing assistant. Use it to suggest ways to organize your ideas, get feedback on the tone or clarity of your draft, or for help with grammar, spelling, and citation style consistency.</p>
+                            <div>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Tool Tip</span>
+                                    </summary>
+                                    <div>
+                                        <p>Tools like Grammarly, specifically designed to help you write better, excel here.</p>
+                                    </div>
+                                </details>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Use Case</span>
+                                    </summary>
+                                    <div>
+                                        <p>You&#x27;ve finished your first draft but worry your tone is too informal for an academic paper. Prompt: <em>&#x27;Review this essay draft for tone. Is it appropriate for a university-level assignment? Suggest areas where the tone could be more academic.</em></p>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+
+                        <div>
+                            <h3 id="boosting-study--organization-studying"><i></i>Boosting Study &amp; Organization (Studying)</h3>
+                            <p>Make your study sessions more effective! AI can help you create flashcards from your notes, generate practice questions (<strong><em>always verify for accuracy</em></strong>), organize your study materials, or even act as a personalized AI tutor to guide your learning.</p>
+                            <div>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Tool Tip</span>
+                                    </summary>
+                                    <div>
+                                        <p>AI tools can generate quizzes for you to test yourself. You can get really meta here by testing the quizzes AI creates against your content to see if the answers the AI creates are actually correct.</p>
+                                    </div>
+                                </details>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Use Case</span>
+                                    </summary>
+                                    <div>
+                                        <p>You have a long list of vocabulary terms for your biology exam. Prompt: <em>&#x27;Create flashcards for the following biology terms: |list of terms|. For each, provide the definition and a sentence using the term in context.&#x27;</em></p>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+
+                        <div>
+                            <h3 id="sharpening-your-critical-edge-critique"><i></i>Sharpening Your Critical Edge (Critique)</h3>
+                            <p>Want to strengthen your arguments? Use AI as a sounding board. Ask it to critique your approach to a topic, help you identify potential flaws in a draft you&#x27;ve written, or play devil&#x27;s advocate to ensure your reasoning is robust.</p>
+                            <div>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Tool Tip</span>
+                                    </summary>
+                                    <div>
+                                        <p>General AI chatbots (like ChatGPT, Claude, or Gemini) are excellent for this because they can process and analyze your text quickly, offering perspectives you might not have considered. Don&#x27;t just ask &#x27;Is this good?&#x27;. Instead, paste your argument or outline and prompt for specific feedback, such as: <em>&#x27;Identify 3 potential logical fallacies in this argument,&#x27;</em> or <em>&#x27;What are the weakest points in my reasoning here?&#x27;</em> Iterating with follow-up questions often yields the best results.</p>
+                                    </div>
+                                </details>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Use Case</span>
+                                    </summary>
+                                    <div>
+                                        <p>You&#x27;re preparing for a class debate. Provide the Gen AI tool with context about the debate and then prompt: <em>&#x27;I need to argue in favor of |debate topic|. What are the three strongest arguments my opponent is likely to make against this position?&#x27;</em> <br> This helps you anticipate and prepare rebuttals.</p>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+
+                        <div>
+                            <h3 id="igniting-your-creative-spark-create"><i></i>Igniting Your Creative Spark (Create)</h3>
+                            <p>AI can be a catalyst for your own creativity. Explore tools that generate images, music, or video concepts as a starting point. Use AI to experiment with different artistic styles or remix content—<strong><em>always keeping considerations about originality and copyright in mind</em></strong>.</p>
+                            <div>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Tool Tip</span>
+                                    </summary>
+                                    <div>
+                                        <p>Explore various AI image generators (e.g., Midjourney, DALL-E, Stable Diffusion), music generators (e.g., AIVA, Soundraw), or video tools (e.g., RunwayML, Pictory) depending on your creative project.</p>
+                                    </div>
+                                </details>
+                                <details>
+                                    <summary>
+                                        <i></i>
+                                        <span>Use Case</span>
+                                    </summary>
+                                    <div>
+                                        <p>You&#x27;re building a website for your entrepreneurship class and need a compelling logo for your brand of &#x27;handmade eco-friendly candles.&#x27; To brainstorm truly unique and original visual concepts, you could start with a detailed prompt like this: <em>&#x27;Generate 5 distinct logo concepts for a brand of handmade, eco-friendly candles. I&#x27;m looking for unique and symbolic representations that evoke warmth, nature, and craftsmanship. Please avoid common candle or leaf clichés. For each concept, suggest a different stylistic approach (e.g., minimalist geometric, organic hand-drawn, abstract emblem).&#x27;</em> <br> This can give you a diverse range of starting points for your final design</p>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+
+                    </div>
                 </div>
+
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>The Pitfalls: Navigating AI&#x27;s Limitations and Ethical Minefields</h2>
+            <div><img alt="Benefits of AI=surfers having fun. Limitations=sharks and crocs underwater" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/BenefitsLimitations_small.png"> </div>
             </div>
 
             <div>
-                <h3 id="making-complex-concepts-click-explainers"><i></i>Making Complex Concepts Click (Explainers)</h3>
-                <p>Dealing with dense textbook chapters or tricky theories? AI can simplify complex information, offer explanations in different ways, define key terms clearly, or provide essential background to help you build a solid understanding.</p>
-                <div>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Tool Tip</span>
-                        </summary>
-                        <div>
-                            <p>Use NotebookLM and upload or point to reference material that it will then use as the &quot;grounded source of truth&quot; to help you understand. In your interaction, ask for explanations from different points of view or with different analogies until the topic makes sense to you.</p>
-                        </div>
-                    </details>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Use Case</span>
-                        </summary>
-                        <div>
-                            <p>Imagine you are a first year chemistry student trying to understand Le Châtelier’s principle. You have 2 first rate references an <a href="https://openstax.org/books/chemistry-2e/pages/13-3-shifting-equilibria-le-chateliers-principle">OpenStax Chemistry Textbook</a> and a <a href="https://www.youtube.com/watch?v=B2pP02GEZL4">Khan Academy explainer video</a>. Open up a new notebook in NotebookLM and link to those two sources. Then ask: &quot;First, define Le Châtelier’s Principle in one sentence a first-year college student would understand. Next, illustrate the principle with three everyday analogies.&quot;</p>
-                        </div>
-                    </details>
-                </div>
+        </section>
+        <section class="gai-box">
+            <h2 id="trust-but-verify-is-your-ai-mantra">&quot;Trust, but Verify&quot; is Your AI Mantra</h2>
+            <p>Generative AI offers exciting possibilities, but it&#x27;s important to understand that it is a tool with limitations and ethical challenges. AI is not infallible, nor is it human; it doesn&#x27;t &quot;understand&quot; or &quot;know&quot; things in the way people do. Think of it as a powerful but sometimes unreliable assistant. Adopting a &quot;trust, but verify&quot; mindset is essential. This means critically evaluating everything AI produces and being aware of the potential pitfalls before you dive in.</p>
             </div>
 
             <div>
-                <h3 id="enhancing-your-research--information-gathering-research"><i></i>Enhancing Your Research &amp; Information Gathering (Research)</h3>
-                <p>AI can assist in the early stages of research by helping you explore topics broadly, identify potential sources <strong>(always verify!)</strong>, or even summarize large texts to give you a quick overview <strong>(remember to read originals for depth!)</strong>.</p>
-                <div>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Tool Tip</span>
-                        </summary>
-                        <div>
-                            <p>Tools like Elicit or Semantic Scholar are designed for academic research. Deep Research tools through ChatGPT, Perplexity, or Gemini can build a reserach framework from information on the internet.</p>
-                        </div>
-                    </details>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Use Case</span>
-                        </summary>
-                        <div>
-                            <p>Imagine you have a 50-page research paper to understand quickly for background. You could link to the paper or upload the PDF to ChatGPT/Gemini and ask   <em>&#x27;Read the attached 50-page paper and give me a bullet point  summary that clearly states the research question, methodology, key findings, and practical implications.&#x27;</em> <br>
-                            <strong><em>Use this summary to guide your full reading, not replace it</em></strong>.</p>
-                        </div>
-                    </details>
-                </div>
+            <h3 id="the-accuracy-mirage-hallucinations--misinformation">The Accuracy Mirage: Hallucinations &amp; Misinformation</h3>
+
+            <div><img alt="The word facts, but question marks surround it" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/facts_widescreen.png"></div>
+
+            <p>AI can generate responses that sound completely confident and authoritative, but are actually incorrect, nonsensical, or entirely made up. These are often called &quot;hallucinations&quot; (<a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5127162">although I prefer the term &quot;mirage&quot;</a>). Because AI models are designed to predict the next most likely word or pixel, not to access a database of verified facts, they can inadvertently create plausible-sounding misinformation.</p>
+
+            <div>
+            <p><strong>Always cross-reference AI-generated information with reliable sources</strong></p>
             </div>
 
             <div>
-                <h3 id="assisting-your-writing-process-responsibly-writing"><i></i>Assisting Your Writing Process Responsibly (Writing)</h3>
-                <p>While AI should never write your papers <em>for</em> you, it can be a helpful writing assistant. Use it to suggest ways to organize your ideas, get feedback on the tone or clarity of your draft, or for help with grammar, spelling, and citation style consistency.</p>
-                <div>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Tool Tip</span>
-                        </summary>
-                        <div>
-                            <p>Tools like Grammarly, specifically designed to help you write better, excel here.</p>
-                        </div>
-                    </details>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Use Case</span>
-                        </summary>
-                        <div>
-                            <p>You&#x27;ve finished your first draft but worry your tone is too informal for an academic paper. Prompt: <em>&#x27;Review this essay draft for tone. Is it appropriate for a university-level assignment? Suggest areas where the tone could be more academic.</em></p>
-                        </div>
-                    </details>
-                </div>
+            <h4><i></i> Quick Activity</h4>
+
+            <p>Ask an AI to explain a complex niche topic you know well. Does it get the details right? Where does it falter? </p>
+            </div>
             </div>
 
             <div>
-                <h3 id="boosting-study--organization-studying"><i></i>Boosting Study &amp; Organization (Studying)</h3>
-                <p>Make your study sessions more effective! AI can help you create flashcards from your notes, generate practice questions (<strong><em>always verify for accuracy</em></strong>), organize your study materials, or even act as a personalized AI tutor to guide your learning.</p>
-                <div>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Tool Tip</span>
-                        </summary>
-                        <div>
-                            <p>AI tools can generate quizzes for you to test yourself. You can get really meta here by testing the quizzes AI creates against your content to see if the answers the AI creates are actually correct.</p>
-                        </div>
-                    </details>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Use Case</span>
-                        </summary>
-                        <div>
-                            <p>You have a long list of vocabulary terms for your biology exam. Prompt: <em>&#x27;Create flashcards for the following biology terms: |list of terms|. For each, provide the definition and a sentence using the term in context.&#x27;</em></p>
-                        </div>
-                    </details>
-                </div>
+            <h3 id="the-bias-blindspot-ai-reflecting--amplifying-prejudices">The Bias Blindspot: AI Reflecting &amp; Amplifying Prejudices</h3>
+
+            <div><img alt="A visual of diverse data points (some perhaps subtly colored/shaped differently to represent bias) being fed into an AI &#x27;black box&#x27;, which then outputs content predominantly reflecting those biased colors/shapes" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AI_input_output_blackbox_small.png"></div>
+
+            <p>AI models learn from enormous amounts of text and image data, much of which is created by humans and reflects existing societal biases related to race, gender, age, nationality, and more. As a result, AI outputs can unintentionally perpetuate or even amplify these prejudices, leading to skewed, unfair, or stereotypical responses. Be critical of AI outputs that seem to generalize or rely on stereotypes.</p>
+
+            <div>
+            <h4><i></i> Quick Activity</h4>
+
+            <p>The easiest way to see bias is to ask an AI image generator to make an image of a professional where that professional is stereotypically one gender.<br>
+            e.g., &quot;create a picture of a nurse&quot;</p>
+            </div>
             </div>
 
             <div>
-                <h3 id="sharpening-your-critical-edge-critique"><i></i>Sharpening Your Critical Edge (Critique)</h3>
-                <p>Want to strengthen your arguments? Use AI as a sounding board. Ask it to critique your approach to a topic, help you identify potential flaws in a draft you&#x27;ve written, or play devil&#x27;s advocate to ensure your reasoning is robust.</p>
-                <div>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Tool Tip</span>
-                        </summary>
-                        <div>
-                            <p>General AI chatbots (like ChatGPT, Claude, or Gemini) are excellent for this because they can process and analyze your text quickly, offering perspectives you might not have considered. Don&#x27;t just ask &#x27;Is this good?&#x27;. Instead, paste your argument or outline and prompt for specific feedback, such as: <em>&#x27;Identify 3 potential logical fallacies in this argument,&#x27;</em> or <em>&#x27;What are the weakest points in my reasoning here?&#x27;</em> Iterating with follow-up questions often yields the best results.</p>
-                        </div>
-                    </details>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Use Case</span>
-                        </summary>
-                        <div>
-                            <p>You&#x27;re preparing for a class debate. Provide the Gen AI tool with context about the debate and then prompt: <em>&#x27;I need to argue in favor of |debate topic|. What are the three strongest arguments my opponent is likely to make against this position?&#x27;</em> <br> This helps you anticipate and prepare rebuttals.</p>
-                        </div>
-                    </details>
-                </div>
+            <h3 id="privacy-on-the-line-your-data--ai">Privacy on the Line: Your Data &amp; AI</h3>
+
+            <div><img alt="A padlock icon 🔒 with a crack in it, or a visual of data (represented by bits or files) flowing into a &#x27;cloud&#x27; server with a large question mark hovering over it." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/bits_flowing_to_q_mark_small.png"></div>
+
+            <p>When you interact with many publicly available AI tools, the information you input (your prompts, your questions, your uploaded documents) can be collected, stored, and potentially used to train future versions of the AI or for other purposes by the company providing the tool.</p>
+
+            <div>
+            <p><strong>Never input sensitive personal information, confidential data (e.g., unpublished research, proprietary business information), or anything you wouldn&#x27;t want to become public.</strong> Always check the AI tool&#x27;s privacy policy if you have concerns.</p>
             </div>
 
             <div>
-                <h3 id="igniting-your-creative-spark-create"><i></i>Igniting Your Creative Spark (Create)</h3>
-                <p>AI can be a catalyst for your own creativity. Explore tools that generate images, music, or video concepts as a starting point. Use AI to experiment with different artistic styles or remix content—<strong><em>always keeping considerations about originality and copyright in mind</em></strong>.</p>
-                <div>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Tool Tip</span>
-                        </summary>
-                        <div>
-                            <p>Explore various AI image generators (e.g., Midjourney, DALL-E, Stable Diffusion), music generators (e.g., AIVA, Soundraw), or video tools (e.g., RunwayML, Pictory) depending on your creative project.</p>
-                        </div>
-                    </details>
-                    <details>
-                        <summary>
-                            <i></i>
-                            <span>Use Case</span>
-                        </summary>
-                        <div>
-                            <p>You&#x27;re building a website for your entrepreneurship class and need a compelling logo for your brand of &#x27;handmade eco-friendly candles.&#x27; To brainstorm truly unique and original visual concepts, you could start with a detailed prompt like this: <em>&#x27;Generate 5 distinct logo concepts for a brand of handmade, eco-friendly candles. I&#x27;m looking for unique and symbolic representations that evoke warmth, nature, and craftsmanship. Please avoid common candle or leaf clichés. For each concept, suggest a different stylistic approach (e.g., minimalist geometric, organic hand-drawn, abstract emblem).&#x27;</em> <br> This can give you a diverse range of starting points for your final design</p>
-                        </div>
-                    </details>
-                </div>
+            <h4><i></i> Quick Activity</h4>
+
+            <p>Download the privacy policy from a chatbot (e.g., <a href="https://openai.com/policies/privacy-policy/">ChatGPT</a>), upload it to a chatbot and prompt:</p>
+
+            <p><em>&quot;Analyze this privacy policy for how it addresses user data collection, storage, and sharing practices. Evaluate the clarity, transparency, and user control offered, especially in the context of AI-generated content&quot;</em></p>
+            </div>
             </div>
 
+            <div>
+            <h3 id="the-ethical-tightrope-academic-integrity--responsible-use">The Ethical Tightrope: Academic Integrity &amp; Responsible Use</h3>
+
+            <div><img alt=" A classic balance scale, with &quot;AI Assistance&quot; on one side and &quot;Your Own Work &amp; Ideas&quot; on the other, with &quot;Academic Integrity&quot; written on the beam of the scale" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AI_vs_YourOwnWork.png"></div>
+
+            <p>Using AI to help you brainstorm or understand concepts is one thing, but submitting AI-generated work as your own is a serious breach of academic integrity, equivalent to plagiarism. Your university&#x27;s policies on academic honesty apply to the use of AI tools. Beyond plagiarism, be aware that AI can also be misused to create harmful content, such as deepfakes or misinformation campaigns.</p>
+            </div>
+
+            <div>
+            <h3 id="whose-idea-is-it-anyway-intellectual-property--copyright">Whose Idea Is It Anyway? Intellectual Property &amp; Copyright</h3>
+
+            <div><img alt="The copyright symbol © with a large question mark superimposed or next to it, or a collage of images/text with some faded/watermarked to suggest unclear ownership" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/copyright_question_mark_small.png"></div>
+
+            <p>AI models are trained on vast datasets that include copyrighted materials like books, articles, and artwork. This raises complex questions about intellectual property. The content AI generates may not be truly &quot;original&quot; and could sometimes resemble or incorporate elements of existing copyrighted works. The legal landscape around AI and copyright is still evolving, so be cautious about using AI-generated content, especially images or music, in public or commercial projects without understanding potential restrictions.</p>
+            </div>
+
+            <div>
+            <h3 id="the-hidden-costs-environmental--societal-impact">The Hidden Costs: Environmental &amp; Societal Impact</h3>
+
+            <div><img alt="AI next to a power plant spewing CO2" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AI_and_emissions_small.png"></div>
+
+            <p>Generative AI is poised to reshape society in many ways. Here&#x27;s a rundown of some key social impacts, bearing in mind that many of these are interconnected and still evolving:</p>
+
+            <ul>
+            	<li><strong>Job Displacement</strong></li>
+            	<li><strong>Security Threats</strong></li>
+            	<li><strong>Privacy Erosion</strong></li>
+            	<li><strong>Mental Well-being</strong></li>
+            	<li><strong>Cultural Homogenization</strong></li>
+            	<li><strong>Environmental Strain</strong></li>
+            </ul>
+
+            <p>Being an informed AI user includes an awareness of these broader impacts.</p>
+            </div>
+
+            <div>
+            <h3 id="the-crutch-danger-over-reliance--skill-atrophy">The Danger of the Crutch: Over-Reliance &amp; Skill Atrophy</h3>
+
+            <div><img alt="Boyfriend distracted by Generative AI. Critical thinking is angry" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/distracted_boyfriend.png"></div>
+
+            <p>While AI can be a helpful assistant, relying on it too heavily can prevent you from developing your own critical thinking, problem-solving, and writing skills. If AI always provides the answer or drafts your text, you miss out on the valuable learning process of grappling with challenges yourself. Strive for a balance where AI supports your learning, rather than becoming a crutch that hinders it.</p>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div>
+            <h1>You Are the Pilot: Embracing Your Critical Role</h1>
+
+            <div><img alt="Person at control panel. Icons of AITools surrounds them." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/WomanAtAIControlPanel2.png"></div>
+
+
+            <h3>Navigate with Wisdom: You&#x27;re in Control</h3>
+
+            <p>Having explored the potential and pitfalls of Generative AI, the most important takeaway is this: <strong>you are the pilot, not a passenger.</strong></p>
+
+            <p>AI is a powerful tool, but like any tool, its true value, effectiveness, and ethical application depend entirely on the human user. It&#x27;s your critical engagement, your informed judgment, your thoughtful questions, and your diligent oversight that will determine whether AI augments your abilities and leads to positive outcomes, or becomes a source of error and ethical missteps.</p>
+
+            <p>Remember, the goal is for AI to <em>augment</em> your intelligence and creativity, not replace your critical thinking. You decide the destination, you chart the course, and you remain in command.</p>
+
+            <div>
+            <h5><i></i>Key Principles for Smart AI Use (Recap &amp; Action)</h5>
+
+            <p>To help you navigate effectively, keep these core principles at the forefront of your mind whenever you engage with AI:</p>
+
+
+            <ul>
+            	<li><strong>Always Verify, Never Blindly Trust:</strong> AI outputs are starting points; always cross-reference with reliable sources as AI can confidently &quot;hallucinate.&quot;</li>
+            	<li><strong>Question Everything:</strong> Critically examine AI responses for sense, bias, omissions, and underlying assumptions.</li>
+            	<li><strong>Use Responsibly &amp; Ethically:</strong> Respect intellectual property, cite AI appropriately, and avoid uses that harm or compromise integrity.</li>
+            	<li><strong>Maintain Your Agency:</strong> Use AI to assist, not replace, your own critical thinking and core intellectual work to keep your skills sharp</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+                <div id="gai-wrap">
+            <div>
+            <div><img alt="Person on a nebulous learning journey" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AILearningPath.png"></div>
+
+            <div>
+            <h1>What&#x27;s Next? Your Journey into Analyzing &amp; Applying AI</h1>
+
+            <p>You&#x27;ve got a solid foundation in understanding what Generative AI is, how it can be a powerful assistant, and the critical considerations to keep in mind. But your journey into AI literacy is just beginning!</p>
+
+            <p>In the upcoming sections, we&#x27;ll move from this foundational awareness to actively <strong>analyzing and applying</strong> AI in increasingly sophisticated ways. Your journey will unfold through these key stages:</p>
+
+            <ol>
+            	<li><strong>Dipping a Toe In:</strong> Discover how AI can serve as a <strong>Quick Information Scout &amp; Idea Sparker</strong>, helping you find initial answers and brainstorm possibilities.</li>
+            	<li><strong>Getting Constructive:</strong> Learn to leverage AI as a <strong>Study Buddy &amp; Skill Builder</strong>, using it to explain concepts, practice, and get feedback.</li>
+            	<li><strong>The Critical Partnership:</strong> Explore how to engage AI as a <strong>Research Assistant &amp; Thought Partner</strong>—always remembering the crucial caveats and maintaining your critical oversight.</li>
+            	<li><strong>Future-Proofing Your Learning:</strong> Look ahead to how AI, combined with your own skills, contributes to <strong>Lifelong Skill Development</strong>.</li>
+            </ol>
+
+            <p>The critical thinking skills and ethical awareness you&#x27;ve started developing here will be essential as you progress through each stage. Get ready to actively engage, experiment, and learn how to make AI a truly valuable and responsible part of your learning toolkit!</p>
+            </div>
+            </div>
+            </div>
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
-    </div>
-
-    
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div>
-<h2>The Pitfalls: Navigating AI&#x27;s Limitations and Ethical Minefields</h2>
-
-<div><img alt="Benefits of AI=surfers having fun. Limitations=sharks and crocs underwater" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/BenefitsLimitations_small.png"> </div>
-</div>
-
-<div>
-<h2 id="trust-but-verify-is-your-ai-mantra">&quot;Trust, but Verify&quot; is Your AI Mantra</h2>
-
-<p>Generative AI offers exciting possibilities, but it&#x27;s important to understand that it is a tool with limitations and ethical challenges. AI is not infallible, nor is it human; it doesn&#x27;t &quot;understand&quot; or &quot;know&quot; things in the way people do. Think of it as a powerful but sometimes unreliable assistant. Adopting a &quot;trust, but verify&quot; mindset is essential. This means critically evaluating everything AI produces and being aware of the potential pitfalls before you dive in.</p>
-</div>
-
-<div>
-<h3 id="the-accuracy-mirage-hallucinations--misinformation">The Accuracy Mirage: Hallucinations &amp; Misinformation</h3>
-
-<div><img alt="The word facts, but question marks surround it" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/facts_widescreen.png"></div>
-
-<p>AI can generate responses that sound completely confident and authoritative, but are actually incorrect, nonsensical, or entirely made up. These are often called &quot;hallucinations&quot; (<a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5127162">although I prefer the term &quot;mirage&quot;</a>). Because AI models are designed to predict the next most likely word or pixel, not to access a database of verified facts, they can inadvertently create plausible-sounding misinformation.</p>
-
-<div>
-<p><strong>Always cross-reference AI-generated information with reliable sources</strong></p>
-</div>
-
-<div>
-<h4><i></i> Quick Activity</h4>
-
-<p>Ask an AI to explain a complex niche topic you know well. Does it get the details right? Where does it falter? </p>
-</div>
-</div>
-
-<div>
-<h3 id="the-bias-blindspot-ai-reflecting--amplifying-prejudices">The Bias Blindspot: AI Reflecting &amp; Amplifying Prejudices</h3>
-
-<div><img alt="A visual of diverse data points (some perhaps subtly colored/shaped differently to represent bias) being fed into an AI &#x27;black box&#x27;, which then outputs content predominantly reflecting those biased colors/shapes" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AI_input_output_blackbox_small.png"></div>
-
-<p>AI models learn from enormous amounts of text and image data, much of which is created by humans and reflects existing societal biases related to race, gender, age, nationality, and more. As a result, AI outputs can unintentionally perpetuate or even amplify these prejudices, leading to skewed, unfair, or stereotypical responses. Be critical of AI outputs that seem to generalize or rely on stereotypes.</p>
-
-<div>
-<h4><i></i> Quick Activity</h4>
-
-<p>The easiest way to see bias is to ask an AI image generator to make an image of a professional where that professional is stereotypically one gender.<br>
-e.g., &quot;create a picture of a nurse&quot;</p>
-</div>
-</div>
-
-<div>
-<h3 id="privacy-on-the-line-your-data--ai">Privacy on the Line: Your Data &amp; AI</h3>
-
-<div><img alt="A padlock icon 🔒 with a crack in it, or a visual of data (represented by bits or files) flowing into a &#x27;cloud&#x27; server with a large question mark hovering over it." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/bits_flowing_to_q_mark_small.png"></div>
-
-<p>When you interact with many publicly available AI tools, the information you input (your prompts, your questions, your uploaded documents) can be collected, stored, and potentially used to train future versions of the AI or for other purposes by the company providing the tool.</p>
-
-<div>
-<p><strong>Never input sensitive personal information, confidential data (e.g., unpublished research, proprietary business information), or anything you wouldn&#x27;t want to become public.</strong> Always check the AI tool&#x27;s privacy policy if you have concerns.</p>
-</div>
-
-<div>
-<h4><i></i> Quick Activity</h4>
-
-<p>Download the privacy policy from a chatbot (e.g., <a href="https://openai.com/policies/privacy-policy/">ChatGPT</a>), upload it to a chatbot and prompt:</p>
-
-<p><em>&quot;Analyze this privacy policy for how it addresses user data collection, storage, and sharing practices. Evaluate the clarity, transparency, and user control offered, especially in the context of AI-generated content&quot;</em></p>
-</div>
-</div>
-
-<div>
-<h3 id="the-ethical-tightrope-academic-integrity--responsible-use">The Ethical Tightrope: Academic Integrity &amp; Responsible Use</h3>
-
-<div><img alt=" A classic balance scale, with &quot;AI Assistance&quot; on one side and &quot;Your Own Work &amp; Ideas&quot; on the other, with &quot;Academic Integrity&quot; written on the beam of the scale" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AI_vs_YourOwnWork.png"></div>
-
-<p>Using AI to help you brainstorm or understand concepts is one thing, but submitting AI-generated work as your own is a serious breach of academic integrity, equivalent to plagiarism. Your university&#x27;s policies on academic honesty apply to the use of AI tools. Beyond plagiarism, be aware that AI can also be misused to create harmful content, such as deepfakes or misinformation campaigns.</p>
-</div>
-
-<div>
-<h3 id="whose-idea-is-it-anyway-intellectual-property--copyright">Whose Idea Is It Anyway? Intellectual Property &amp; Copyright</h3>
-
-<div><img alt="The copyright symbol © with a large question mark superimposed or next to it, or a collage of images/text with some faded/watermarked to suggest unclear ownership" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/copyright_question_mark_small.png"></div>
-
-<p>AI models are trained on vast datasets that include copyrighted materials like books, articles, and artwork. This raises complex questions about intellectual property. The content AI generates may not be truly &quot;original&quot; and could sometimes resemble or incorporate elements of existing copyrighted works. The legal landscape around AI and copyright is still evolving, so be cautious about using AI-generated content, especially images or music, in public or commercial projects without understanding potential restrictions.</p>
-</div>
-
-<div>
-<h3 id="the-hidden-costs-environmental--societal-impact">The Hidden Costs: Environmental &amp; Societal Impact</h3>
-
-<div><img alt="AI next to a power plant spewing CO2" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AI_and_emissions_small.png"></div>
-
-<p>Generative AI is poised to reshape society in many ways. Here&#x27;s a rundown of some key social impacts, bearing in mind that many of these are interconnected and still evolving:</p>
-
-<ul>
-	<li><strong>Job Displacement</strong></li>
-	<li><strong>Security Threats</strong></li>
-	<li><strong>Privacy Erosion</strong></li>
-	<li><strong>Mental Well-being</strong></li>
-	<li><strong>Cultural Homogenization</strong></li>
-	<li><strong>Environmental Strain</strong></li>
-</ul>
-
-<p>Being an informed AI user includes an awareness of these broader impacts.</p>
-</div>
-
-<div>
-<h3 id="the-crutch-danger-over-reliance--skill-atrophy">The Danger of the Crutch: Over-Reliance &amp; Skill Atrophy</h3>
-
-<div><img alt="Boyfriend distracted by Generative AI. Critical thinking is angry" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/distracted_boyfriend.png"></div>
-
-<p>While AI can be a helpful assistant, relying on it too heavily can prevent you from developing your own critical thinking, problem-solving, and writing skills. If AI always provides the answer or drafts your text, you miss out on the valuable learning process of grappling with challenges yourself. Strive for a balance where AI supports your learning, rather than becoming a crutch that hinders it.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div>
-<h1>You Are the Pilot: Embracing Your Critical Role</h1>
-
-<div><img alt="Person at control panel. Icons of AITools surrounds them." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/WomanAtAIControlPanel2.png"></div>
-
-
-<h3>Navigate with Wisdom: You&#x27;re in Control</h3>
-
-<p>Having explored the potential and pitfalls of Generative AI, the most important takeaway is this: <strong>you are the pilot, not a passenger.</strong></p>
-
-<p>AI is a powerful tool, but like any tool, its true value, effectiveness, and ethical application depend entirely on the human user. It&#x27;s your critical engagement, your informed judgment, your thoughtful questions, and your diligent oversight that will determine whether AI augments your abilities and leads to positive outcomes, or becomes a source of error and ethical missteps.</p>
-
-<p>Remember, the goal is for AI to <em>augment</em> your intelligence and creativity, not replace your critical thinking. You decide the destination, you chart the course, and you remain in command.</p>
-
-<div>
-<h5><i></i>Key Principles for Smart AI Use (Recap &amp; Action)</h5>
-
-<p>To help you navigate effectively, keep these core principles at the forefront of your mind whenever you engage with AI:</p>
-
-
-<ul>
-	<li><strong>Always Verify, Never Blindly Trust:</strong> AI outputs are starting points; always cross-reference with reliable sources as AI can confidently &quot;hallucinate.&quot;</li>
-	<li><strong>Question Everything:</strong> Critically examine AI responses for sense, bias, omissions, and underlying assumptions.</li>
-	<li><strong>Use Responsibly &amp; Ethically:</strong> Respect intellectual property, cite AI appropriately, and avoid uses that harm or compromise integrity.</li>
-	<li><strong>Maintain Your Agency:</strong> Use AI to assist, not replace, your own critical thinking and core intellectual work to keep your skills sharp</li>
-</ul>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <div id="gai-wrap">
-<div>
-<div><img alt="Person on a nebulous learning journey" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/AILearningPath.png"></div>
-
-<div>
-<h1>What&#x27;s Next? Your Journey into Analyzing &amp; Applying AI</h1>
-
-<p>You&#x27;ve got a solid foundation in understanding what Generative AI is, how it can be a powerful assistant, and the critical considerations to keep in mind. But your journey into AI literacy is just beginning!</p>
-
-<p>In the upcoming sections, we&#x27;ll move from this foundational awareness to actively <strong>analyzing and applying</strong> AI in increasingly sophisticated ways. Your journey will unfold through these key stages:</p>
-
-<ol>
-	<li><strong>Dipping a Toe In:</strong> Discover how AI can serve as a <strong>Quick Information Scout &amp; Idea Sparker</strong>, helping you find initial answers and brainstorm possibilities.</li>
-	<li><strong>Getting Constructive:</strong> Learn to leverage AI as a <strong>Study Buddy &amp; Skill Builder</strong>, using it to explain concepts, practice, and get feedback.</li>
-	<li><strong>The Critical Partnership:</strong> Explore how to engage AI as a <strong>Research Assistant &amp; Thought Partner</strong>—always remembering the crucial caveats and maintaining your critical oversight.</li>
-	<li><strong>Future-Proofing Your Learning:</strong> Look ahead to how AI, combined with your own skills, contributes to <strong>Lifelong Skill Development</strong>.</li>
-</ol>
-
-<p>The critical thinking skills and ethical awareness you&#x27;ve started developing here will be essential as you progress through each stage. Get ready to actively engage, experiment, and learn how to make AI a truly valuable and responsible part of your learning toolkit!</p>
-</div>
-</div>
-</div>
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
-    </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/gen-ai-behind-the-curtain.html
+++ b/site/gen-ai-behind-the-curtain.html
@@ -4,417 +4,457 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Gen AI - Behind the Curtain - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="active has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li class="active"><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Gen AI - Behind the Curtain</h2>
-        <div>
-    
-<link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div>
-<div>
-<h2>How Does Generative AI Work?</h2>
-
-<p>(<a aria-label="Footnote explaining ELI-12" href="#eli-12">the ELI-12 version<sup>1</sup></a>)</p>
-
-<div>
-<h3><i></i>Training – The Creation of a GenAI Model</h3>
-<img alt="Abstract illustration of AI model training process" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=stylized%20illustration%20of%20AI%20model%20training%20process%20with%20data%20flowing%20into%20a%20glowing%20neural%20network%2C%20clean%20tech%20style&amp;w=700&amp;h=250&amp;style=professional">
-<p>When you use a Generative AI tool, you are using a tool that has been created by a complex and expensive process. To help you develop an understanding of this process, I’m going to rely a bit on an analogy that isn’t perfect but will help with your understanding, at least at a high level.</p>
-
-<p>Think about how a child learns language – through exposure to countless conversations, books, and interactions. Large Language Models (LLMs) learn in a similar way, but instead of years of real-world experience, they learn from vast amounts of text from the internet, books, and other sources. Here’s a basic overview of how these AI models are trained:</p>
-
-<ol>
-	<li>
-	<div><i></i></div>
-
-	<div><strong>Gathering and Preparing the Data:</strong>
-
-	<p>Companies collect enormous amounts of data from sources like books, websites, and articles. This data needs to be carefully cleaned and filtered – removing inappropriate content, errors, and low-quality information. Just like you wouldn’t want a child learning from incorrect or harmful material, the AI needs good quality data to learn from.</p>
-	</div>
-	</li>
-	<li>
-	<div><i></i></div>
-
-	<div><strong>Basic Training:</strong>
-
-	<p>The AI begins recognizing patterns in all this text – not just learning words, but understanding how they typically appear together and relate to each other. Unlike a child who learns strict grammar rules, the AI learns by spotting patterns in millions (or even billions) of examples. It starts recognizing which words often appear together, what typically follows certain phrases, and how ideas are usually expressed.</p>
-	</div>
-	</li>
-	<li>
-	<div><i></i></div>
-
-	<div><strong>Alignment:</strong>
-
-	<p>The model is then trained to be helpful and safe – like teaching good manners and proper behavior. The training involves guiding the AI towards providing useful, appropriate responses while limiting harmful or biased content. This process is called <em>alignment</em>.</p>
-	</div>
-	</li>
-	<li>
-	<div><i></i></div>
-
-	<div><strong>Testing and Release:</strong>
-
-	<p>The AI is thoroughly tested to make sure it works well and safely. Once ready, it’s made available for people to use, but continues to be monitored and improved over time.</p>
-	</div>
-	</li>
-</ol>
-
-<p>These AI models are continuously being improved and refined. However, it’s important to remember that despite this sophisticated training process, these models are still pattern-matching tools – they don’t truly understand or think like humans do. They’re incredibly powerful assistants, but they need human guidance and oversight to be used effectively.</p>
-</div>
-
-<hr>
-<div>
-<h3><i></i>Inference – Using a GenAI Model</h3>
-
-<p>When you use a GenAI chatbot, you are interacting with a user interface but behind the scenes is a GenAI model working hard to calculate a response to your prompts. This calculation process is called inference.</p>
-
-<p>Here is what happens during inference:</p>
-
-<ol>
-	<li>
-	<div><i></i></div>
-
-	<div><strong>Processing Your Input:</strong>
-
-	<p>The model splits your text into small chunks called tokens (imagine splitting a sentence into individual words and parts of words – like breaking “playing” into “play” and “ing”). This helps the model understand your input piece by piece.</p>
-	</div>
-	</li>
-	<li>
-	<div><i></i></div>
-
-	<div><strong>Using Its “Knowledge”:</strong>
-
-	<p>The model then uses all the patterns it learned during its training – kind of like how you use everything you’ve learned in school to answer a question. But instead of actively searching through books, the model uses its “memory” (the patterns stored in its system) to figure out what might come next.</p>
-	</div>
-	</li>
-	<li>
-	<div><i></i></div>
-
-	<div><strong>Making Smart Predictions:</strong>
-
-	<p>The model looks at your input and what it has started writing, considering everything together (like how you consider the whole question before answering). It then figures out what would make the most sense to say next, one small piece at a time.</p>
-	</div>
-	</li>
-	<li>
-	<div><i></i></div>
-
-	<div><strong>Adding Some Variety:</strong>
-
-	<p>The model has special settings (like a creativity dial) that control how creative or focused its response should be. A higher setting means more creative and varied responses, while a lower setting means more focused and predictable ones.</p>
-	</div>
-	</li>
-	<li>
-	<div><i></i></div>
-
-	<div><strong>Building the Response:</strong>
-
-	<p>Finally, the model builds its response one small piece at a time. Each new piece it adds is influenced by everything that came before it – both in your prompt and in the response it’s creating. It’s like building with blocks, where each new block needs to fit with all the others.</p>
-	</div>
-	</li>
-</ol>
-
-<p><strong>Remember:</strong> The model isn’t thinking or understanding like a human does. It’s following patterns it learned during training to create responses that make sense based on your input. It’s more like a very sophisticated pattern-matching tool than a thinking brain.</p>
-</div>
-
-<hr>
-<div>
-<h3><i></i>Going Deeper</h3>
-<img alt="Detective inspecting a clue" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/DeepDive_Detective.png">
-<h4><i></i>Must Read Articles</h4>
-
-<ul>
-	<li><a href="https://www.theguardian.com/technology/ng-interactive/2023/nov/01/how-ai-chatbots-like-chatgpt-or-bard-work-visual-explainer" rel="noreferrer noopener" target="_blank"><i></i><strong>If you only read one thing about how LLMs work, read this.</strong> A short explainer from the Guardian newspaper about how LLMs work</a></li>
-	<li><a href="https://arstechnica.com/science/2023/07/a-jargon-free-explanation-of-how-ai-large-language-models-work/" rel="noreferrer noopener" target="_blank"><i></i><strong>A Jargon Free Explanation of How AI LLMs Work:</strong> If you really want to get into the weeds about how large language models work, but aren’t a machine learning expert. (10 minute read)</a></li>
-</ul>
-
-<h4><i></i>Videos on Generative AI and Large Language Models (LLMs)</h4>
-
-<div>
-<p>The web has countless resources to help you learn more about the inner workings of GenAI. Here are some of my favourites, organized by complexity and approach:</p>
-</div>
-
-<div>
-<div>
-<h5>Generative AI in a Nutshell</h5>
-
-<p>This is one of those “drawing and talking” videos that discusses how GenAI works and how to use it. It’s a fun video that doesn’t require any technical background.</p>
-
-<div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/2IK3DFHRFfw?si=N34eOPbeUYEEG74B" title="YouTube video player: Generative AI in a Nutshell"></iframe></div>
-</div>
-
-<div>
-<h5>LLMs for Curious Beginners (3Blue1Brown)</h5>
-
-<p>Grant Sanderson provides a brief overview of Large Language Models with his signature visual explanations. Perfect for those who want to understand the basics.</p>
-
-<div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/LPZh9BOjkQs?si=Lez02I9HO_I3vdcf" title="YouTube video player: LLMs for Curious Beginners (3Blue1Brown)"></iframe></div>
-</div>
-</div>
-
-<div>
-
-<div id="expandableVideos">
-<div>
-<div>
-<h5>Transformers and Attention (3Blue1Brown)</h5>
-
-<p>A deeper dive into the transformer architecture and attention mechanism that powers modern LLMs. Requires some mathematical background.</p>
-
-<div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/KJtZARuO3JY?si=IUA9UMf-_QfVpTzM" title="YouTube video player: Talk on Transformers and Attention"></iframe></div>
-</div>
-
-<div>
-<h5>What is a Neural Network? (3Blue1Brown)</h5>
-
-<p>First video in a comprehensive series on Deep Learning. This 2017 series was well ahead of the ChatGPT explosion and provides foundational knowledge.</p>
-
-<div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/aircAruvnKk?si=WuigjZWEAoSpmkxl" title="YouTube video player: What is a neural network (3Blue1Brown)"></iframe></div>
-</div>
-
-<div>
-<h5>The Busy Person’s Intro to LLMs</h5>
-
-<p>Andrej Karpathy, OpenAI founder and former Tesla AI Director, provides a general-audience tutorial on LLMs with technical depth.</p>
-
-<div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/zjkBMFhNj_g?si=sHiSPUsBguxMy672" title="YouTube video player: Intro to LLMs (Andrej Karpathy)"></iframe></div>
-</div>
-</div>
-</div>
-</div>
-
-<h4><i></i>More Articles and Activities to Explore</h4>
-
-<ul>
-	<li><a href="https://platform.openai.com/tokenizer" rel="noopener" target="_blank"><i></i><strong>Text-to-Tokens Visualization:</strong> Want to see what a token is compared to a word? This interactive website, the OpenAI Tokenizer Tool, allows you to input text and see how it’s broken down into tokens.</a></li>
-	<li><a href="https://perplexity.vercel.app/" rel="noopener" target="_blank"><i></i><strong>Visualize Text Probability:</strong> This one is fun! It provides an editable text block which initially is a description of how the tool works. When you click “Run visualization” it gives you the probability of each word appearing in the text along with all of the other likely words that might have appeared instead.</a></li>
-	<li><a href="https://bbycroft.net/llm" rel="noopener" target="_blank"><i></i><strong>LLM Visualization tool:</strong> This is an animation of a large language model processing some text. To be honest, I thought it was a little hard to follow and you probably need some background knowledge to follow, but it <strong>looks really cool</strong>.</a></li>
-	<li><a href="https://poloclub.github.io/dodrio/" rel="noopener" target="_blank"><i></i><strong>See the attention mechanism at work:</strong> When processing text, the model looks at how each word relates to other words…this process is the attention mechanism. This visualizer shows the inter-relatedness of words in a sentence but is another one that I don’t completely follow…but also <strong>looks cool</strong>.</a></li>
-</ul>
-</div>
-
-<div>
-<p id="eli-12"><sup>1</sup> ELI-12: Explain it to me Like I’m 12</p>
-</div>
-</div>
-</div>
-
-
-
-    </div><div>
-    <p><img alt="" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/157304/images/AI_Timeline.png"></p>
-
-    </div><div>
-    
-<div>
-<div>
-<h1><svg focusable="false" height="1em" viewbox="0 0 576 512" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M249.6 471.5c10.8 3.8 22.4-4.1 22.4-15.5V78.6c0-4.2-1.6-8.4-5-11C247.4 52 202.4 32 144 32C93.5 32 46.3 45.3 18.1 56.1C6.8 60.5 0 71.7 0 83.8V454.1c0 11.9 12.8 20.2 24.1 16.5C55.6 460.1 105.5 448 144 448c33.9 0 79 14 105.6 23.5zm76.8 0C353 462 398.1 448 432 448c38.5 0 88.4 12.1 119.9 22.6c11.3 3.8 24.1-4.6 24.1-16.5V83.8c0-12.1-6.8-23.3-18.1-27.6C529.7 45.3 482.5 32 432 32c-58.4 0-103.4 20-123 35.6c-3.3 2.6-5 6.8-5 11V456c0 11.4 11.7 19.3 22.4 15.5z" fill="currentColor"></path></svg>AI Literacy Glossary: An Introduction</h1>
-
-<p>This glossary is designed to provide clear, concise definitions of key concepts, models, and techniques in Artificial Intelligence (AI) and Generative AI. It serves as a reference for educators, learners, and anyone seeking to build a foundational understanding of this rapidly evolving field.</p>
-
-<p>AI is transforming industries and reshaping how we learn, work, and create. From understanding the basics of machine learning to exploring the cutting-edge capabilities of generative models, this glossary covers essential terms that demystify AI and its applications.</p>
-
-<p>These definitions are intended to support your understanding of AI at a broad level and provide clarity on important terms and ideas. While they are not exhaustive or technical explanations, they aim to give you a solid starting point for engaging with AI concepts and exploring their relevance to real-world applications. Whether you&#x27;re navigating AI for the first time or deepening your knowledge, this glossary is here to make these complex ideas more accessible.</p>
-
-<p>The Glossary is broken into 2 sections:</p>
-
-<ol>
-	<li>Commonly used AI terms - these are the terms that we encounter in everyday usage of generative AI</li>
-	<li>(Moderately) Technical Terms - these are terms that you will encounter as a layperson if you are going for a deeper understanding of how generative AI works</li>
-</ol>
-<img alt="Infographic of AI terms" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx_Tech_infographic_showing_AI_brain_center__connecting_to_5_icons_robot_teacher__human-digital_face__creative_workshop___chat_bubble___and_ethical_compass_._Minim.jpg">
-<h2><svg focusable="false" height="1em" viewbox="0 0 640 512" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M208 352c114.9 0 208-78.8 208-176S322.9 0 208 0S0 78.8 0 176c0 38.6 14.7 74.3 39.6 103.4c-3.5 9.4-8.7 17.7-14.2 24.7c-4.8 6.2-9.7 11-13.3 14.3c-1.8 1.6-3.3 2.9-4.3 3.7c-.5 .4-.9 .7-1.1 .8l-.2 .2 0 0 0 0C1 327.2-1.4 334.4 .8 340.9S9.1 352 16 352c21.8 0 43.8-5.6 62.1-12.5c9.2-3.5 17.8-7.4 25.3-11.4C134.1 343.3 169.8 352 208 352zM448 176c0 112.3-99.1 196.9-216.5 207C255.8 457.4 336.4 512 432 512c38.2 0 73.9-8.7 104.7-23.9c7.5 4 16 7.9 25.2 11.4c18.3 6.9 40.3 12.5 62.1 12.5c6.9 0 13.1-4.5 15.2-11.1c2.1-6.6-.2-13.8-5.8-17.9l0 0 0 0-.2-.2c-.2-.2-.6-.4-1.1-.8c-1-.8-2.5-2-4.3-3.7c-3.6-3.3-8.5-8.1-13.3-14.3c-5.5-7-10.7-15.4-14.2-24.7c24.9-29 39.6-64.7 39.6-103.4c0-92.8-84.9-168.9-192.6-175.5c.4 5.1 .6 10.3 .6 15.5z" fill="currentColor"></path></svg>Commonly Used AI Terms</h2>
-
-<h3>AI Agent</h3>
-
-<p>Computer programs or systems that are capable of performing autonomous actions, making decisions, and interacting with their environment to achieve specific goals or tasks. They can adapt, learn, and optimize their performance over time.</p>
-
-<hr>
-<h3>AI Literacy</h3>
-
-<p>The knowledge and skills required to understand, interact with, and critically evaluate AI tools and technologies in various contexts, including education.</p>
-
-<hr>
-<h3>Alignment</h3>
-
-<p>The process of ensuring AI systems align with human values, ethical considerations, and intended goals, particularly in educational contexts.</p>
-
-<hr>
-<h3>Artificial General Intelligence (AGI)</h3>
-
-<p>AGI refers to a (so far) hypothetical class of AI systems capable of understanding, learning, and applying knowledge across a broad range of tasks and domains, comparable to human cognitive abilities. Unlike Narrow AI, which excels at specific tasks, AGI would exhibit the versatility and adaptability needed to solve unfamiliar problems, reason abstractly, and transfer knowledge between domains.</p>
-
-<p>The concept of AGI remains difficult to define precisely due to the complexity and breadth of human intelligence itself. AGI systems would not only need to achieve human-level performance in diverse areas but also demonstrate attributes such as common sense, self-awareness, and the ability to set and pursue goals autonomously.</p>
-
-<p>Achieving AGI is widely regarded as the ultimate challenge in AI research. It would require breakthroughs in understanding cognition, developing highly scalable and flexible learning architectures, and addressing foundational issues such as alignment with human values and safety. While AGI remains a theoretical construct, its pursuit drives significant debate and innovation, with implications spanning scientific discovery, ethics, and the future of human-AI collaboration.</p>
-
-<hr>
-<h3>Artificial Intelligence</h3>
-
-<p>Artificial Intelligence (AI) encompasses a broad field of computer science focused on creating systems capable of performing tasks that typically require human intelligence. These tasks include problem-solving, decision-making, understanding natural language, recognizing patterns, and adapting to new information. AI systems range from simple algorithms powering recommendations to sophisticated models generating human-like text or identifying diseases in medical imaging.</p>
-
-<p>The definition of AI is fluid and evolves alongside advancements in technology and our understanding of intelligence. Historically, AI has been divided into two categories: <strong>Narrow AI</strong>, designed to excel at specific tasks (e.g., language translation, facial recognition), and the aspirational <strong>Artificial General Intelligence (AGI)</strong>, which would exhibit human-like cognitive versatility.</p>
-
-<hr>
-<h3>Bias</h3>
-
-<p>Bias in AI refers to systematic errors in the output of AI models, often resulting from unrepresentative training data or flawed algorithms, leading to unfair or unequal treatment of certain groups or individuals.</p>
-
-<hr>
-<h3>Chatbots</h3>
-
-<p>Chatbots are AI-powered programs designed to simulate human conversation, often used in customer service, information retrieval, and interactive communication online. This is the “chat” part of ChatGPT</p>
-
-<hr>
-<h3>Data Privacy</h3>
-
-<p>Data privacy encompasses the practices and policies that ensure confidential and sensitive data, including personal information, is secure, protected, and used responsibly in AI and other digital systems.</p>
-
-<hr>
-<h3>Ethics in AI</h3>
-
-<p>This refers to the moral principles guiding the design, deployment, and use of AI technologies, ensuring fairness, transparency, and respect for human rights.</p>
-
-<hr>
-<h3>Fine-Tuning</h3>
-
-<p>The process of refining a pre-trained AI model to specialize in specific tasks or domains, often using a smaller dataset relevant to the intended application</p>
-
-<hr>
-<h3>Foundational Models</h3>
-
-<p>Foundational Models are pre-trained machine learning models that serve as the base for customized applications across a diverse range of tasks and domains. These models are trained on extensive datasets to capture a broad spectrum of knowledge and skills, and they can be fine-tuned and adapted to specific tasks or industries. Foundational models are akin to generalists in the AI world, offering a versatile and robust starting point for specialized applications, including in natural language processing, computer vision, and beyond.</p>
-
-<hr>
-<h3>Frontier Models</h3>
-
-<p>Frontier Models are cutting-edge AI systems that push the boundaries of machine learning capabilities, representing the latest advancements in scale, performance, and innovation. These models are designed to tackle highly complex tasks, often exceeding the capabilities of foundational models in specialized or emergent domains. Frontier models are typically developed using state-of-the-art techniques, massive computational resources, and novel architectures. They pave the way for groundbreaking applications in areas such as advanced robotics, multi-modal AI, and scientific discovery, while also setting new benchmarks for safety, alignment, and ethical considerations in AI development</p>
-
-<hr>
-<h3>Generative AI (GenAI)</h3>
-
-<p>Generative Artificial Intelligence refers to a class of AI systems designed to create new content, such as text, images, audio, video, or code, based on patterns and knowledge learned from existing data. Unlike traditional AI systems that focus on classifying, predicting, or analyzing data, generative AI produces outputs that resemble human-created content, opening new frontiers in creativity and automation.</p>
-
-<p>Generative AI systems, such as Large Language Models (LLMs) like GPT or image generators like DALL·E, rely on sophisticated architectures, such as transformers, to learn and replicate the underlying structure of data. These models are trained on vast datasets, enabling them to generate coherent, contextually relevant, and high-quality content in response to prompts or inputs.</p>
-
-<hr>
-<h3>Hallucinations</h3>
-
-<p>In the context of AI, hallucinations refer to the instances where models generate incorrect, nonsensical, or unrealistic information. These mistakes can be very obvious or very subtle, so always review the output from a generative AI if you need it to be true and correct.</p>
-
-<hr>
-<h3>Large Language Models (LLMs)</h3>
-
-<p>Large Language Models are complex AI systems that have been trained on enormous volumes of text data to comprehend, generate, and manipulate human-like text effectively. These models, equipped with millions or even billions of parameters, excel in tasks ranging from content creation and translation to question answering and beyond. LLMs can understand context, generate coherent and contextually relevant content, and are integral in various applications including conversational AI, automated content generation, and aiding in problem-solving scenarios.</p>
-
-<hr>
-<h3>Multi-Modal AI</h3>
-
-<p>AI systems capable of processing and generating content across multiple data types (e.g., text, images, audio, video) to enable richer and more interactive educational experiences</p>
-
-<hr>
-<h3>Prompt</h3>
-
-<p>the input or query provided to the chatbot by the user. It&#x27;s the message or question given to the chatbot to elicit a response or information. The chatbot then processes the prompt and generates a relevant reply based on its programming and the data it has been trained on</p>
-</div>
-
-
-<div><img alt="AI Chip surrounded by AI processes" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx_Hexagonal_AI_core_with_flowing_data___surrounded_by_four_rings_showing_text_transformation___neural_networks___data_labeling___and_transparent_decision_processe.jpg">
-<h2><svg focusable="false" height="1em" viewbox="0 0 448 512" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M96 0C43 0 0 43 0 96V416c0 53 43 96 96 96H384h32c17.7 0 32-14.3 32-32s-14.3-32-32-32V384c17.7 0 32-14.3 32-32V32c0-17.7-14.3-32-32-32H384 96zm0 384H352v64H96c-17.7 0-32-14.3-32-32s14.3-32 32-32zm32-240c0-8.8 7.2-16 16-16H336c8.8 0 16 7.2 16 16s-7.2 16-16 16H144c-8.8 0-16-7.2-16-16zm16 48H336c8.8 0 16 7.2 16 16s-7.2 16-16 16H144c-8.8 0-16-7.2-16-16s7.2-16 16-16z" fill="currentColor"></path></svg>Moderately Technical Terms and Definitions</h2>
-
-<h3>Alignment</h3>
-
-<p>The process of ensuring that the objectives and outcomes of an AI system align with human values and intentions.</p>
-
-<hr>
-<h3>Artificial Neural Networks</h3>
-
-<p>Computational models inspired by the human brain, designed for pattern recognition and decision-making.</p>
-
-<hr>
-<h3>Data Annotation</h3>
-
-<p>The process of labeling data, such as adding descriptions to images or categories to text, to make it usable for machine learning.</p>
-
-<hr>
-<h3>Deep Learning</h3>
-
-<p>A subset of machine learning involving neural networks with multiple layers, enabling complex pattern recognition.</p>
-
-<hr>
-<h3>Explainability</h3>
-
-<p>The extent to which an AI system&#x27;s decisions or outputs can be understood and articulated by humans. This involves the system providing information about how it arrived at a result, enabling humans to interpret, explain, and trust its behavior and outcomes.</p>
-
-<hr>
-<h3>Generative Pre-Trained Transformer (GPT)</h3>
-
-<p>A machine learning model that&#x27;s pre-trained to generate coherent and contextually relevant text based on a given prompt. This is the GPT part of ChatGPT. They&#x27;re designed to understand and generate human-like text. Here&#x27;s a simplified breakdown of its name and function:<br>
-<strong>Generative</strong>: This refers to the model&#x27;s ability to create or generate new content. In the case of GPT, it can generate human-like text based on the input it receives. For instance, it can help in writing essays, answering questions, or even creating poetry.<br>
-<strong>Pre-trained</strong>: Before a model like GPT can be used, it needs to be trained on a large dataset of text. &quot;Pre-trained&quot; refers to the fact that this training occurs before the model is fine-tuned for specific tasks. The pre-training helps the model learn about grammar, facts about the world, reasoning abilities, and also some common sense.<br>
-<strong>Transformers</strong>: Transformer is the type of neural network architecture that GPT is based on. It&#x27;s particularly effective for handling sequential data like text or time series data. The Transformer architecture allows GPT to pay selective attention to different parts of the input text, which helps in understanding the context and generating coherent responses.</p>
-
-<hr>
-<h3>Inference</h3>
-
-<p>Inference is the process where a trained AI model uses its learned knowledge to make predictions or generate outputs based on new input data. In the context of an LLM (Large Language Model), inference happens when the model takes a user’s input (prompt) and processes it to produce a meaningful response.</p>
-
-<p>During inference, the model applies the parameters (like weights and biases) it learned during training to evaluate the input, recognize patterns, and generate an appropriate output. This process is what allows the model to &quot;understand&quot; and respond to prompts, answer questions, or generate creative content.</p>
-
-<p>Inference is essentially the application phase of an AI model, turning training into practical use. It’s how the model uses what it has learned to interact with the world</p>
-
-<hr>
-<h3>Interpretability</h3>
-
-<p>The degree to which the outputs and operations of a machine learning model can be understood by humans.</p>
-
-<hr>
-<h3>Machine Learning</h3>
-
-<p>Machine Learning (ML) is a subset of Artificial Intelligence (AI) that provides systems the ability to automatically learn and improve from experience without being explicitly programmed to do so.</p>
-
-<hr>
-<h3>Natural Language Processing (NLP)</h3>
-
-<p>A domain of AI enabling machines to understand, interpret, and generate human language.</p>
-
-<hr>
-<h3>Parameters</h3>
-
-<p>The rules or settings that an LLM uses to &quot;understand&quot; and generate language. There are two main types of parameters in an LLM: weights and biases. Weights are numbers that show how strong the connections are between different parts of the LLM. Biases are numbers that help adjust the output of the LLM. Together, weights and biases control how the LLM processes and produces language. Generally, the more parameters an LLM has, the more powerful it becomes.</p>
-
-<p>Parameters are the internal variables that the model learns through training. They help the model make predictions or decisions based on input data.</p>
-
-<hr>
-<h3>Training Data</h3>
-
-<p>The dataset used to train machine learning models, containing examples to learn from.</p>
-
-<hr>
-<h3>Transformer</h3>
-
-<p>A Transformer is a model architecture in machine learning that excels in handling sequential data, such as text. This is the breakthrough technology that has allowed chatbots like ChatGPT to become so powerful.</p>
-</div>
-</div>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Gen AI - Behind the Curtain</h2>
+            <div>
+
+            <div>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>How Does Generative AI Work?</h2>
+            <p>(<a aria-label="Footnote explaining ELI-12" href="#eli-12">the ELI-12 version<sup>1</sup></a>)</p>
+
+            <div>
+            <h3><i></i>Training – The Creation of a GenAI Model</h3>
+            <img alt="Abstract illustration of AI model training process" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=stylized%20illustration%20of%20AI%20model%20training%20process%20with%20data%20flowing%20into%20a%20glowing%20neural%20network%2C%20clean%20tech%20style&amp;w=700&amp;h=250&amp;style=professional">
+            <p>When you use a Generative AI tool, you are using a tool that has been created by a complex and expensive process. To help you develop an understanding of this process, I’m going to rely a bit on an analogy that isn’t perfect but will help with your understanding, at least at a high level.</p>
+
+            <p>Think about how a child learns language – through exposure to countless conversations, books, and interactions. Large Language Models (LLMs) learn in a similar way, but instead of years of real-world experience, they learn from vast amounts of text from the internet, books, and other sources. Here’s a basic overview of how these AI models are trained:</p>
+
+            <ol>
+            	<li>
+            	<div><i></i></div>
+
+            	<div><strong>Gathering and Preparing the Data:</strong>
+
+            	<p>Companies collect enormous amounts of data from sources like books, websites, and articles. This data needs to be carefully cleaned and filtered – removing inappropriate content, errors, and low-quality information. Just like you wouldn’t want a child learning from incorrect or harmful material, the AI needs good quality data to learn from.</p>
+            	</div>
+            	</li>
+            	<li>
+            	<div><i></i></div>
+
+            	<div><strong>Basic Training:</strong>
+
+            	<p>The AI begins recognizing patterns in all this text – not just learning words, but understanding how they typically appear together and relate to each other. Unlike a child who learns strict grammar rules, the AI learns by spotting patterns in millions (or even billions) of examples. It starts recognizing which words often appear together, what typically follows certain phrases, and how ideas are usually expressed.</p>
+            	</div>
+            	</li>
+            	<li>
+            	<div><i></i></div>
+
+            	<div><strong>Alignment:</strong>
+
+            	<p>The model is then trained to be helpful and safe – like teaching good manners and proper behavior. The training involves guiding the AI towards providing useful, appropriate responses while limiting harmful or biased content. This process is called <em>alignment</em>.</p>
+            	</div>
+            	</li>
+            	<li>
+            	<div><i></i></div>
+
+            	<div><strong>Testing and Release:</strong>
+
+            	<p>The AI is thoroughly tested to make sure it works well and safely. Once ready, it’s made available for people to use, but continues to be monitored and improved over time.</p>
+            	</div>
+            	</li>
+            </ol>
+
+            <p>These AI models are continuously being improved and refined. However, it’s important to remember that despite this sophisticated training process, these models are still pattern-matching tools – they don’t truly understand or think like humans do. They’re incredibly powerful assistants, but they need human guidance and oversight to be used effectively.</p>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>Inference – Using a GenAI Model</h3>
+
+            <p>When you use a GenAI chatbot, you are interacting with a user interface but behind the scenes is a GenAI model working hard to calculate a response to your prompts. This calculation process is called inference.</p>
+
+            <p>Here is what happens during inference:</p>
+
+            <ol>
+            	<li>
+            	<div><i></i></div>
+
+            	<div><strong>Processing Your Input:</strong>
+
+            	<p>The model splits your text into small chunks called tokens (imagine splitting a sentence into individual words and parts of words – like breaking “playing” into “play” and “ing”). This helps the model understand your input piece by piece.</p>
+            	</div>
+            	</li>
+            	<li>
+            	<div><i></i></div>
+
+            	<div><strong>Using Its “Knowledge”:</strong>
+
+            	<p>The model then uses all the patterns it learned during its training – kind of like how you use everything you’ve learned in school to answer a question. But instead of actively searching through books, the model uses its “memory” (the patterns stored in its system) to figure out what might come next.</p>
+            	</div>
+            	</li>
+            	<li>
+            	<div><i></i></div>
+
+            	<div><strong>Making Smart Predictions:</strong>
+
+            	<p>The model looks at your input and what it has started writing, considering everything together (like how you consider the whole question before answering). It then figures out what would make the most sense to say next, one small piece at a time.</p>
+            	</div>
+            	</li>
+            	<li>
+            	<div><i></i></div>
+
+            	<div><strong>Adding Some Variety:</strong>
+
+            	<p>The model has special settings (like a creativity dial) that control how creative or focused its response should be. A higher setting means more creative and varied responses, while a lower setting means more focused and predictable ones.</p>
+            	</div>
+            	</li>
+            	<li>
+            	<div><i></i></div>
+
+            	<div><strong>Building the Response:</strong>
+
+            	<p>Finally, the model builds its response one small piece at a time. Each new piece it adds is influenced by everything that came before it – both in your prompt and in the response it’s creating. It’s like building with blocks, where each new block needs to fit with all the others.</p>
+            	</div>
+            	</li>
+            </ol>
+
+            <p><strong>Remember:</strong> The model isn’t thinking or understanding like a human does. It’s following patterns it learned during training to create responses that make sense based on your input. It’s more like a very sophisticated pattern-matching tool than a thinking brain.</p>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>Going Deeper</h3>
+            <img alt="Detective inspecting a clue" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/DeepDive_Detective.png">
+            <h4><i></i>Must Read Articles</h4>
+
+            <ul>
+            	<li><a href="https://www.theguardian.com/technology/ng-interactive/2023/nov/01/how-ai-chatbots-like-chatgpt-or-bard-work-visual-explainer" rel="noreferrer noopener" target="_blank"><i></i><strong>If you only read one thing about how LLMs work, read this.</strong> A short explainer from the Guardian newspaper about how LLMs work</a></li>
+            	<li><a href="https://arstechnica.com/science/2023/07/a-jargon-free-explanation-of-how-ai-large-language-models-work/" rel="noreferrer noopener" target="_blank"><i></i><strong>A Jargon Free Explanation of How AI LLMs Work:</strong> If you really want to get into the weeds about how large language models work, but aren’t a machine learning expert. (10 minute read)</a></li>
+            </ul>
+
+            <h4><i></i>Videos on Generative AI and Large Language Models (LLMs)</h4>
+
+            <div>
+            <p>The web has countless resources to help you learn more about the inner workings of GenAI. Here are some of my favourites, organized by complexity and approach:</p>
+            </div>
+
+            <div>
+            <div>
+            <h5>Generative AI in a Nutshell</h5>
+
+            <p>This is one of those “drawing and talking” videos that discusses how GenAI works and how to use it. It’s a fun video that doesn’t require any technical background.</p>
+
+            <div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/2IK3DFHRFfw?si=N34eOPbeUYEEG74B" title="YouTube video player: Generative AI in a Nutshell"></iframe></div>
+            </div>
+
+            <div>
+            <h5>LLMs for Curious Beginners (3Blue1Brown)</h5>
+
+            <p>Grant Sanderson provides a brief overview of Large Language Models with his signature visual explanations. Perfect for those who want to understand the basics.</p>
+
+            <div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/LPZh9BOjkQs?si=Lez02I9HO_I3vdcf" title="YouTube video player: LLMs for Curious Beginners (3Blue1Brown)"></iframe></div>
+            </div>
+            </div>
+
+            <div>
+
+            <div id="expandableVideos">
+            <div>
+            <div>
+            <h5>Transformers and Attention (3Blue1Brown)</h5>
+
+            <p>A deeper dive into the transformer architecture and attention mechanism that powers modern LLMs. Requires some mathematical background.</p>
+
+            <div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/KJtZARuO3JY?si=IUA9UMf-_QfVpTzM" title="YouTube video player: Talk on Transformers and Attention"></iframe></div>
+            </div>
+
+            <div>
+            <h5>What is a Neural Network? (3Blue1Brown)</h5>
+
+            <p>First video in a comprehensive series on Deep Learning. This 2017 series was well ahead of the ChatGPT explosion and provides foundational knowledge.</p>
+
+            <div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/aircAruvnKk?si=WuigjZWEAoSpmkxl" title="YouTube video player: What is a neural network (3Blue1Brown)"></iframe></div>
+            </div>
+
+            <div>
+            <h5>The Busy Person’s Intro to LLMs</h5>
+
+            <p>Andrej Karpathy, OpenAI founder and former Tesla AI Director, provides a general-audience tutorial on LLMs with technical depth.</p>
+
+            <div><iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="" frameborder="0" loading="lazy" sandbox="allow-scripts allow-same-origin" src="https://www.youtube.com/embed/zjkBMFhNj_g?si=sHiSPUsBguxMy672" title="YouTube video player: Intro to LLMs (Andrej Karpathy)"></iframe></div>
+            </div>
+            </div>
+            </div>
+            </div>
+
+            <h4><i></i>More Articles and Activities to Explore</h4>
+
+            <ul>
+            	<li><a href="https://platform.openai.com/tokenizer" rel="noopener" target="_blank"><i></i><strong>Text-to-Tokens Visualization:</strong> Want to see what a token is compared to a word? This interactive website, the OpenAI Tokenizer Tool, allows you to input text and see how it’s broken down into tokens.</a></li>
+            	<li><a href="https://perplexity.vercel.app/" rel="noopener" target="_blank"><i></i><strong>Visualize Text Probability:</strong> This one is fun! It provides an editable text block which initially is a description of how the tool works. When you click “Run visualization” it gives you the probability of each word appearing in the text along with all of the other likely words that might have appeared instead.</a></li>
+            	<li><a href="https://bbycroft.net/llm" rel="noopener" target="_blank"><i></i><strong>LLM Visualization tool:</strong> This is an animation of a large language model processing some text. To be honest, I thought it was a little hard to follow and you probably need some background knowledge to follow, but it <strong>looks really cool</strong>.</a></li>
+            	<li><a href="https://poloclub.github.io/dodrio/" rel="noopener" target="_blank"><i></i><strong>See the attention mechanism at work:</strong> When processing text, the model looks at how each word relates to other words…this process is the attention mechanism. This visualizer shows the inter-relatedness of words in a sentence but is another one that I don’t completely follow…but also <strong>looks cool</strong>.</a></li>
+            </ul>
+            </div>
+
+            <div>
+            <p id="eli-12"><sup>1</sup> ELI-12: Explain it to me Like I’m 12</p>
+            </div>
+            </div>
+            </div>
+
+
+
+                </div><div>
+                <p><img alt="" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/157304/images/AI_Timeline.png"></p>
+
+                </div><div>
+
+            <div>
+            <div>
+            <h1><svg focusable="false" height="1em" viewbox="0 0 576 512" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M249.6 471.5c10.8 3.8 22.4-4.1 22.4-15.5V78.6c0-4.2-1.6-8.4-5-11C247.4 52 202.4 32 144 32C93.5 32 46.3 45.3 18.1 56.1C6.8 60.5 0 71.7 0 83.8V454.1c0 11.9 12.8 20.2 24.1 16.5C55.6 460.1 105.5 448 144 448c33.9 0 79 14 105.6 23.5zm76.8 0C353 462 398.1 448 432 448c38.5 0 88.4 12.1 119.9 22.6c11.3 3.8 24.1-4.6 24.1-16.5V83.8c0-12.1-6.8-23.3-18.1-27.6C529.7 45.3 482.5 32 432 32c-58.4 0-103.4 20-123 35.6c-3.3 2.6-5 6.8-5 11V456c0 11.4 11.7 19.3 22.4 15.5z" fill="currentColor"></path></svg>AI Literacy Glossary: An Introduction</h1>
+
+            <p>This glossary is designed to provide clear, concise definitions of key concepts, models, and techniques in Artificial Intelligence (AI) and Generative AI. It serves as a reference for educators, learners, and anyone seeking to build a foundational understanding of this rapidly evolving field.</p>
+
+            <p>AI is transforming industries and reshaping how we learn, work, and create. From understanding the basics of machine learning to exploring the cutting-edge capabilities of generative models, this glossary covers essential terms that demystify AI and its applications.</p>
+
+            <p>These definitions are intended to support your understanding of AI at a broad level and provide clarity on important terms and ideas. While they are not exhaustive or technical explanations, they aim to give you a solid starting point for engaging with AI concepts and exploring their relevance to real-world applications. Whether you&#x27;re navigating AI for the first time or deepening your knowledge, this glossary is here to make these complex ideas more accessible.</p>
+
+            <p>The Glossary is broken into 2 sections:</p>
+
+            <ol>
+            	<li>Commonly used AI terms - these are the terms that we encounter in everyday usage of generative AI</li>
+            	<li>(Moderately) Technical Terms - these are terms that you will encounter as a layperson if you are going for a deeper understanding of how generative AI works</li>
+            </ol>
+            <img alt="Infographic of AI terms" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx_Tech_infographic_showing_AI_brain_center__connecting_to_5_icons_robot_teacher__human-digital_face__creative_workshop___chat_bubble___and_ethical_compass_._Minim.jpg">
+        </section>
+        <section class="gai-box">
+            <h2><svg focusable="false" height="1em" viewbox="0 0 640 512" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M208 352c114.9 0 208-78.8 208-176S322.9 0 208 0S0 78.8 0 176c0 38.6 14.7 74.3 39.6 103.4c-3.5 9.4-8.7 17.7-14.2 24.7c-4.8 6.2-9.7 11-13.3 14.3c-1.8 1.6-3.3 2.9-4.3 3.7c-.5 .4-.9 .7-1.1 .8l-.2 .2 0 0 0 0C1 327.2-1.4 334.4 .8 340.9S9.1 352 16 352c21.8 0 43.8-5.6 62.1-12.5c9.2-3.5 17.8-7.4 25.3-11.4C134.1 343.3 169.8 352 208 352zM448 176c0 112.3-99.1 196.9-216.5 207C255.8 457.4 336.4 512 432 512c38.2 0 73.9-8.7 104.7-23.9c7.5 4 16 7.9 25.2 11.4c18.3 6.9 40.3 12.5 62.1 12.5c6.9 0 13.1-4.5 15.2-11.1c2.1-6.6-.2-13.8-5.8-17.9l0 0 0 0-.2-.2c-.2-.2-.6-.4-1.1-.8c-1-.8-2.5-2-4.3-3.7c-3.6-3.3-8.5-8.1-13.3-14.3c-5.5-7-10.7-15.4-14.2-24.7c24.9-29 39.6-64.7 39.6-103.4c0-92.8-84.9-168.9-192.6-175.5c.4 5.1 .6 10.3 .6 15.5z" fill="currentColor"></path></svg>Commonly Used AI Terms</h2>
+            <h3>AI Agent</h3>
+
+            <p>Computer programs or systems that are capable of performing autonomous actions, making decisions, and interacting with their environment to achieve specific goals or tasks. They can adapt, learn, and optimize their performance over time.</p>
+
+            <hr>
+            <h3>AI Literacy</h3>
+
+            <p>The knowledge and skills required to understand, interact with, and critically evaluate AI tools and technologies in various contexts, including education.</p>
+
+            <hr>
+            <h3>Alignment</h3>
+
+            <p>The process of ensuring AI systems align with human values, ethical considerations, and intended goals, particularly in educational contexts.</p>
+
+            <hr>
+            <h3>Artificial General Intelligence (AGI)</h3>
+
+            <p>AGI refers to a (so far) hypothetical class of AI systems capable of understanding, learning, and applying knowledge across a broad range of tasks and domains, comparable to human cognitive abilities. Unlike Narrow AI, which excels at specific tasks, AGI would exhibit the versatility and adaptability needed to solve unfamiliar problems, reason abstractly, and transfer knowledge between domains.</p>
+
+            <p>The concept of AGI remains difficult to define precisely due to the complexity and breadth of human intelligence itself. AGI systems would not only need to achieve human-level performance in diverse areas but also demonstrate attributes such as common sense, self-awareness, and the ability to set and pursue goals autonomously.</p>
+
+            <p>Achieving AGI is widely regarded as the ultimate challenge in AI research. It would require breakthroughs in understanding cognition, developing highly scalable and flexible learning architectures, and addressing foundational issues such as alignment with human values and safety. While AGI remains a theoretical construct, its pursuit drives significant debate and innovation, with implications spanning scientific discovery, ethics, and the future of human-AI collaboration.</p>
+
+            <hr>
+            <h3>Artificial Intelligence</h3>
+
+            <p>Artificial Intelligence (AI) encompasses a broad field of computer science focused on creating systems capable of performing tasks that typically require human intelligence. These tasks include problem-solving, decision-making, understanding natural language, recognizing patterns, and adapting to new information. AI systems range from simple algorithms powering recommendations to sophisticated models generating human-like text or identifying diseases in medical imaging.</p>
+
+            <p>The definition of AI is fluid and evolves alongside advancements in technology and our understanding of intelligence. Historically, AI has been divided into two categories: <strong>Narrow AI</strong>, designed to excel at specific tasks (e.g., language translation, facial recognition), and the aspirational <strong>Artificial General Intelligence (AGI)</strong>, which would exhibit human-like cognitive versatility.</p>
+
+            <hr>
+            <h3>Bias</h3>
+
+            <p>Bias in AI refers to systematic errors in the output of AI models, often resulting from unrepresentative training data or flawed algorithms, leading to unfair or unequal treatment of certain groups or individuals.</p>
+
+            <hr>
+            <h3>Chatbots</h3>
+
+            <p>Chatbots are AI-powered programs designed to simulate human conversation, often used in customer service, information retrieval, and interactive communication online. This is the “chat” part of ChatGPT</p>
+
+            <hr>
+            <h3>Data Privacy</h3>
+
+            <p>Data privacy encompasses the practices and policies that ensure confidential and sensitive data, including personal information, is secure, protected, and used responsibly in AI and other digital systems.</p>
+
+            <hr>
+            <h3>Ethics in AI</h3>
+
+            <p>This refers to the moral principles guiding the design, deployment, and use of AI technologies, ensuring fairness, transparency, and respect for human rights.</p>
+
+            <hr>
+            <h3>Fine-Tuning</h3>
+
+            <p>The process of refining a pre-trained AI model to specialize in specific tasks or domains, often using a smaller dataset relevant to the intended application</p>
+
+            <hr>
+            <h3>Foundational Models</h3>
+
+            <p>Foundational Models are pre-trained machine learning models that serve as the base for customized applications across a diverse range of tasks and domains. These models are trained on extensive datasets to capture a broad spectrum of knowledge and skills, and they can be fine-tuned and adapted to specific tasks or industries. Foundational models are akin to generalists in the AI world, offering a versatile and robust starting point for specialized applications, including in natural language processing, computer vision, and beyond.</p>
+
+            <hr>
+            <h3>Frontier Models</h3>
+
+            <p>Frontier Models are cutting-edge AI systems that push the boundaries of machine learning capabilities, representing the latest advancements in scale, performance, and innovation. These models are designed to tackle highly complex tasks, often exceeding the capabilities of foundational models in specialized or emergent domains. Frontier models are typically developed using state-of-the-art techniques, massive computational resources, and novel architectures. They pave the way for groundbreaking applications in areas such as advanced robotics, multi-modal AI, and scientific discovery, while also setting new benchmarks for safety, alignment, and ethical considerations in AI development</p>
+
+            <hr>
+            <h3>Generative AI (GenAI)</h3>
+
+            <p>Generative Artificial Intelligence refers to a class of AI systems designed to create new content, such as text, images, audio, video, or code, based on patterns and knowledge learned from existing data. Unlike traditional AI systems that focus on classifying, predicting, or analyzing data, generative AI produces outputs that resemble human-created content, opening new frontiers in creativity and automation.</p>
+
+            <p>Generative AI systems, such as Large Language Models (LLMs) like GPT or image generators like DALL·E, rely on sophisticated architectures, such as transformers, to learn and replicate the underlying structure of data. These models are trained on vast datasets, enabling them to generate coherent, contextually relevant, and high-quality content in response to prompts or inputs.</p>
+
+            <hr>
+            <h3>Hallucinations</h3>
+
+            <p>In the context of AI, hallucinations refer to the instances where models generate incorrect, nonsensical, or unrealistic information. These mistakes can be very obvious or very subtle, so always review the output from a generative AI if you need it to be true and correct.</p>
+
+            <hr>
+            <h3>Large Language Models (LLMs)</h3>
+
+            <p>Large Language Models are complex AI systems that have been trained on enormous volumes of text data to comprehend, generate, and manipulate human-like text effectively. These models, equipped with millions or even billions of parameters, excel in tasks ranging from content creation and translation to question answering and beyond. LLMs can understand context, generate coherent and contextually relevant content, and are integral in various applications including conversational AI, automated content generation, and aiding in problem-solving scenarios.</p>
+
+            <hr>
+            <h3>Multi-Modal AI</h3>
+
+            <p>AI systems capable of processing and generating content across multiple data types (e.g., text, images, audio, video) to enable richer and more interactive educational experiences</p>
+
+            <hr>
+            <h3>Prompt</h3>
+
+            <p>the input or query provided to the chatbot by the user. It&#x27;s the message or question given to the chatbot to elicit a response or information. The chatbot then processes the prompt and generates a relevant reply based on its programming and the data it has been trained on</p>
+            </div>
+
+
+            <div><img alt="AI Chip surrounded by AI processes" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx_Hexagonal_AI_core_with_flowing_data___surrounded_by_four_rings_showing_text_transformation___neural_networks___data_labeling___and_transparent_decision_processe.jpg">
+        </section>
+        <section class="gai-box">
+            <h2><svg focusable="false" height="1em" viewbox="0 0 448 512" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M96 0C43 0 0 43 0 96V416c0 53 43 96 96 96H384h32c17.7 0 32-14.3 32-32s-14.3-32-32-32V384c17.7 0 32-14.3 32-32V32c0-17.7-14.3-32-32-32H384 96zm0 384H352v64H96c-17.7 0-32-14.3-32-32s14.3-32 32-32zm32-240c0-8.8 7.2-16 16-16H336c8.8 0 16 7.2 16 16s-7.2 16-16 16H144c-8.8 0-16-7.2-16-16zm16 48H336c8.8 0 16 7.2 16 16s-7.2 16-16 16H144c-8.8 0-16-7.2-16-16s7.2-16 16-16z" fill="currentColor"></path></svg>Moderately Technical Terms and Definitions</h2>
+            <h3>Alignment</h3>
+
+            <p>The process of ensuring that the objectives and outcomes of an AI system align with human values and intentions.</p>
+
+            <hr>
+            <h3>Artificial Neural Networks</h3>
+
+            <p>Computational models inspired by the human brain, designed for pattern recognition and decision-making.</p>
+
+            <hr>
+            <h3>Data Annotation</h3>
+
+            <p>The process of labeling data, such as adding descriptions to images or categories to text, to make it usable for machine learning.</p>
+
+            <hr>
+            <h3>Deep Learning</h3>
+
+            <p>A subset of machine learning involving neural networks with multiple layers, enabling complex pattern recognition.</p>
+
+            <hr>
+            <h3>Explainability</h3>
+
+            <p>The extent to which an AI system&#x27;s decisions or outputs can be understood and articulated by humans. This involves the system providing information about how it arrived at a result, enabling humans to interpret, explain, and trust its behavior and outcomes.</p>
+
+            <hr>
+            <h3>Generative Pre-Trained Transformer (GPT)</h3>
+
+            <p>A machine learning model that&#x27;s pre-trained to generate coherent and contextually relevant text based on a given prompt. This is the GPT part of ChatGPT. They&#x27;re designed to understand and generate human-like text. Here&#x27;s a simplified breakdown of its name and function:<br>
+            <strong>Generative</strong>: This refers to the model&#x27;s ability to create or generate new content. In the case of GPT, it can generate human-like text based on the input it receives. For instance, it can help in writing essays, answering questions, or even creating poetry.<br>
+            <strong>Pre-trained</strong>: Before a model like GPT can be used, it needs to be trained on a large dataset of text. &quot;Pre-trained&quot; refers to the fact that this training occurs before the model is fine-tuned for specific tasks. The pre-training helps the model learn about grammar, facts about the world, reasoning abilities, and also some common sense.<br>
+            <strong>Transformers</strong>: Transformer is the type of neural network architecture that GPT is based on. It&#x27;s particularly effective for handling sequential data like text or time series data. The Transformer architecture allows GPT to pay selective attention to different parts of the input text, which helps in understanding the context and generating coherent responses.</p>
+
+            <hr>
+            <h3>Inference</h3>
+
+            <p>Inference is the process where a trained AI model uses its learned knowledge to make predictions or generate outputs based on new input data. In the context of an LLM (Large Language Model), inference happens when the model takes a user’s input (prompt) and processes it to produce a meaningful response.</p>
+
+            <p>During inference, the model applies the parameters (like weights and biases) it learned during training to evaluate the input, recognize patterns, and generate an appropriate output. This process is what allows the model to &quot;understand&quot; and respond to prompts, answer questions, or generate creative content.</p>
+
+            <p>Inference is essentially the application phase of an AI model, turning training into practical use. It’s how the model uses what it has learned to interact with the world</p>
+
+            <hr>
+            <h3>Interpretability</h3>
+
+            <p>The degree to which the outputs and operations of a machine learning model can be understood by humans.</p>
+
+            <hr>
+            <h3>Machine Learning</h3>
+
+            <p>Machine Learning (ML) is a subset of Artificial Intelligence (AI) that provides systems the ability to automatically learn and improve from experience without being explicitly programmed to do so.</p>
+
+            <hr>
+            <h3>Natural Language Processing (NLP)</h3>
+
+            <p>A domain of AI enabling machines to understand, interpret, and generate human language.</p>
+
+            <hr>
+            <h3>Parameters</h3>
+
+            <p>The rules or settings that an LLM uses to &quot;understand&quot; and generate language. There are two main types of parameters in an LLM: weights and biases. Weights are numbers that show how strong the connections are between different parts of the LLM. Biases are numbers that help adjust the output of the LLM. Together, weights and biases control how the LLM processes and produces language. Generally, the more parameters an LLM has, the more powerful it becomes.</p>
+
+            <p>Parameters are the internal variables that the model learns through training. They help the model make predictions or decisions based on input data.</p>
+
+            <hr>
+            <h3>Training Data</h3>
+
+            <p>The dataset used to train machine learning models, containing examples to learn from.</p>
+
+            <hr>
+            <h3>Transformer</h3>
+
+            <p>A Transformer is a model architecture in machine learning that excels in handling sequential data, such as text. This is the breakthrough technology that has allowed chatbots like ChatGPT to become so powerful.</p>
+            </div>
+            </div>
+
+
+                </div>
+        </section>
+                <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/gen-ai-fundamentals.html
+++ b/site/gen-ai-fundamentals.html
@@ -4,289 +4,326 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Gen AI Fundamentals - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="active has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li class="active"><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Gen AI Fundamentals</h2>
-        <div>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div id="gai-wrap">
-<div>
-<div>
-<div>
-<div><img alt="Glowing brain illustration representing generative AI" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/GenAIFund_GlowingBrain_Intro.png"></div>
-
-<div>
-<h1>Understanding Generative AI (GenAI)</h1>
-
-<p><strong>Generative AI (GenAI)</strong> is a subfield of artificial intelligence focused on creating new content that often resembles human-generated work. It uses models to generate realistic and coherent outputs across modalities, not limited to a single medium.</p>
-</div>
-</div>
-</div>
-
-<h2>What Can GenAI Create?</h2>
-
-<p>Examples of GenAI include:</p>
-
-<div>
-<div><i></i>
-
-<p>Creating realistic images or artworks</p>
-</div>
-
-<div><i></i>
-
-<p>Writing cohesive text</p>
-</div>
-
-<div><i></i>
-
-<p>Generating music</p>
-</div>
-
-<div><i></i>
-
-<p>Creating realistic voices</p>
-</div>
-
-<div><i></i>
-
-<p>Designing 3D models</p>
-</div>
-
-<div><i></i>
-
-<p>Describing pictures or videos</p>
-</div>
-</div>
-
-<div>
-<h5><i></i>In this section on Generative AI Fundamentals, you will discover:</h5>
-
-<ul>
-	<li>What Generative AI is and what it isn’t</li>
-	<li>Scenarios where GenAI tools can help</li>
-	<li>Key limitations of GenAI</li>
-	<li>The basics of how generative AI works</li>
-</ul>
-</div>
-
-<div>
-<div>
-<h5><i></i> What Generative AI Is</h5>
-
-<ul>
-	<li>A tool to assist and enhance your work</li>
-	<li>A pattern-matching system trained on human-created content</li>
-	<li>A creative collaborator that can help generate ideas and content</li>
-	<li>A productivity aid that can help streamline tasks</li>
-	<li>A learning companion that can explain concepts in different ways</li>
-	<li>A starting point for projects and creative work</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i> What Generative AI Isn’t</h5>
-
-<ul>
-	<li>Magic</li>
-	<li>Perfect or error-free</li>
-	<li>Capable of true understanding or reasoning</li>
-	<li>Always up to date with current events</li>
-	<li>Able to fact-check itself reliably</li>
-	<li>A substitute for human expertise or judgment</li>
-	<li>A source of consistent or reproducible outputs</li>
-	<li>Capable of forming genuine opinions or beliefs</li>
-</ul>
-</div>
-</div>
-
-<p>GenAI is most effective as a collaborative tool that enhances your ability. Think of it as a sophisticated assistant or thought partner rather than an autonomous expert.</p>
-
-<hr>
-<h2>Generative AI: Your Versatile Partner</h2>
-
-<p>At its best, GenAI augments human creativity, communication, productivity, planning, and problem-solving.</p>
-<img alt="Man and robot collaborating illustration" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/GenAIFund_RobotAndMan_YourVersatilePartner.png">
-<div>
-<div>
-<h5><i></i> As a Creative Partner</h5>
-
-<p>It can help you by:</p>
-
-<ul>
-	<li>Brainstorming new ideas and concepts</li>
-	<li>Helping overcome creative blocks</li>
-	<li>Visualizing concepts through image generation</li>
-	<li>Experimenting with different creative directions</li>
-	<li>Providing inspiration through variations</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i> As a Learning Partner</h5>
-
-<p>It can help you by:</p>
-
-<ul>
-	<li>Breaking down complex topics</li>
-	<li>Creating practice questions</li>
-	<li>Offering multiple perspectives</li>
-	<li>Helping review and summarize material</li>
-	<li>Helping organize research findings</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i> As a Communication Partner</h5>
-
-<p>It can help you by:</p>
-
-<ul>
-	<li>Helping draft and refine messages</li>
-	<li>Suggesting different tones and styles</li>
-	<li>Adapting content for audiences</li>
-	<li>Improving clarity and conciseness</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i> As a Problem-Solving Partner</h5>
-
-<p>It can help you by:</p>
-
-<ul>
-	<li>Breaking down complex problems</li>
-	<li>Suggesting different approaches</li>
-	<li>Checking logic and reasoning</li>
-	<li>Offering alternative perspectives</li>
-	<li>Helping analyze pros and cons</li>
-</ul>
-</div>
-</div>
-
-<p>The list doesn’t end here. Whatever way you use GenAI, remember: <strong>you are responsible for the output you co-create.</strong></p>
-
-<hr>
-<div>
-<h2><i></i> But…Be Wary and Understand the Limitations</h2>
-
-<p>Like any tool, generative AI has limitations you need to understand. Here are the major ones:</p>
-
-<div>
-<div>
-<h5><i></i> Everything It Outputs is “Made Up”</h5>
-
-<p>GenAI creates responses by predicting. This means:</p>
-
-<ul>
-	<li>It can confidently present incorrect information</li>
-	<li>It makes up facts and citations</li>
-	<li>It can’t verify its own accuracy</li>
-	<li>It doesn’t truly understand</li>
-	<li>It generally doesn&#x27;t learn from conversations</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i> Bias is Built Into the System</h5>
-
-<p>GenAI learns from human content, inheriting biases:</p>
-
-<ul>
-	<li>May favor certain perspectives</li>
-	<li>Can perpetuate stereotypes</li>
-	<li>Might give different treatment to groups</li>
-	<li>Often reflects Western biases</li>
-	<li>Consider environmental impact</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i> Privacy Concerns are Real</h5>
-
-<p>When you use GenAI tools, remember:</p>
-
-<ul>
-	<li>Conversations may be stored/analyzed</li>
-	<li>Inputs might be used for training</li>
-	<li>Sensitive info could be exposed</li>
-	<li>Privacy policies can change</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i> Copyright &amp; Ownership are Complicated</h5>
-
-<p>Using GenAI raises IP questions:</p>
-
-<ul>
-	<li>Trained on potentially copyrighted material</li>
-	<li>Ownership of AI content isn’t always clear</li>
-	<li>Different tools have different terms</li>
-	<li>Commercial use may have restrictions</li>
-	<li>Disclose AI use as appropriate</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i> Output May Not be Reliable or Consistent</h5>
-
-<ul>
-	<li>The same prompt can give different results</li>
-	<li>Quality can vary significantly</li>
-	<li>Results depend heavily on prompt phrasing</li>
-	<li>The AI can go off track or change tone</li>
-	<li>May not maintain consistency</li>
-</ul>
-</div>
-</div>
-</div>
-
-<div>
-<p>While GenAI is a powerful tool, it’s essential to <strong>verify outputs, use critical thinking, and maintain appropriate skepticism.</strong> You are responsible for fact-checking, ensuring ethical use, and making final decisions.</p>
-</div>
-
-<hr>
-<div>
-<h2><i></i> The Special Case of Generative AI in Education</h2>
-<img alt="Group of students illustration" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/GenAIFund_GroupOfStudents.png">
-<p>In education, GenAI presents both opportunities and challenges. It can help tailor educational content, assist in creating authentic assessments, and support student creativity. However, it also introduces academic integrity concerns, new privacy considerations, and can exacerbate inequalities in technology access.</p>
-
-<p>The role of GenAI in education is evolving. It’s marked by its promise to revolutionize learning and the challenges it presents. As educators, students, and innovators, our task is to harness GenAI’s potential while safeguarding fair, effective, and ethical educational principles, always keeping a <strong>human-centric approach</strong> at the forefront.</p>
-
-<div>
-<h5><i></i> Innovation and Ethics</h5>
-
-<p>Striving for a balance between innovation and ethical, equitable implementation in education.</p>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Gen AI Fundamentals</h2>
+            <div>
+
+            <div>
+            <div>
+            <div>
+            <div><img alt="Glowing brain illustration representing generative AI" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/GenAIFund_GlowingBrain_Intro.png"></div>
+
+            <div>
+            <h1>Understanding Generative AI (GenAI)</h1>
+
+            <p><strong>Generative AI (GenAI)</strong> is a subfield of artificial intelligence focused on creating new content that often resembles human-generated work. It uses models to generate realistic and coherent outputs across modalities, not limited to a single medium.</p>
+            </div>
+            </div>
+            </div>
+        </section>
+        <section class="gai-box">
+            <h2>What Can GenAI Create?</h2>
+            <p>Examples of GenAI include:</p>
+
+            <div>
+            <div><i></i>
+
+            <p>Creating realistic images or artworks</p>
+            </div>
+
+            <div><i></i>
+
+            <p>Writing cohesive text</p>
+            </div>
+
+            <div><i></i>
+
+            <p>Generating music</p>
+            </div>
+
+            <div><i></i>
+
+            <p>Creating realistic voices</p>
+            </div>
+
+            <div><i></i>
+
+            <p>Designing 3D models</p>
+            </div>
+
+            <div><i></i>
+
+            <p>Describing pictures or videos</p>
+            </div>
+            </div>
+
+            <div>
+            <h5><i></i>In this section on Generative AI Fundamentals, you will discover:</h5>
+
+            <ul>
+            	<li>What Generative AI is and what it isn’t</li>
+            	<li>Scenarios where GenAI tools can help</li>
+            	<li>Key limitations of GenAI</li>
+            	<li>The basics of how generative AI works</li>
+            </ul>
+            </div>
+
+            <div>
+            <div>
+            <h5><i></i> What Generative AI Is</h5>
+
+            <ul>
+            	<li>A tool to assist and enhance your work</li>
+            	<li>A pattern-matching system trained on human-created content</li>
+            	<li>A creative collaborator that can help generate ideas and content</li>
+            	<li>A productivity aid that can help streamline tasks</li>
+            	<li>A learning companion that can explain concepts in different ways</li>
+            	<li>A starting point for projects and creative work</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i> What Generative AI Isn’t</h5>
+
+            <ul>
+            	<li>Magic</li>
+            	<li>Perfect or error-free</li>
+            	<li>Capable of true understanding or reasoning</li>
+            	<li>Always up to date with current events</li>
+            	<li>Able to fact-check itself reliably</li>
+            	<li>A substitute for human expertise or judgment</li>
+            	<li>A source of consistent or reproducible outputs</li>
+            	<li>Capable of forming genuine opinions or beliefs</li>
+            </ul>
+            </div>
+            </div>
+
+            <p>GenAI is most effective as a collaborative tool that enhances your ability. Think of it as a sophisticated assistant or thought partner rather than an autonomous expert.</p>
+
+            <hr>
+        </section>
+        <section class="gai-box">
+            <h2>Generative AI: Your Versatile Partner</h2>
+            <p>At its best, GenAI augments human creativity, communication, productivity, planning, and problem-solving.</p>
+            <img alt="Man and robot collaborating illustration" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/GenAIFund_RobotAndMan_YourVersatilePartner.png">
+            <div>
+            <div>
+            <h5><i></i> As a Creative Partner</h5>
+
+            <p>It can help you by:</p>
+
+            <ul>
+            	<li>Brainstorming new ideas and concepts</li>
+            	<li>Helping overcome creative blocks</li>
+            	<li>Visualizing concepts through image generation</li>
+            	<li>Experimenting with different creative directions</li>
+            	<li>Providing inspiration through variations</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i> As a Learning Partner</h5>
+
+            <p>It can help you by:</p>
+
+            <ul>
+            	<li>Breaking down complex topics</li>
+            	<li>Creating practice questions</li>
+            	<li>Offering multiple perspectives</li>
+            	<li>Helping review and summarize material</li>
+            	<li>Helping organize research findings</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i> As a Communication Partner</h5>
+
+            <p>It can help you by:</p>
+
+            <ul>
+            	<li>Helping draft and refine messages</li>
+            	<li>Suggesting different tones and styles</li>
+            	<li>Adapting content for audiences</li>
+            	<li>Improving clarity and conciseness</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i> As a Problem-Solving Partner</h5>
+
+            <p>It can help you by:</p>
+
+            <ul>
+            	<li>Breaking down complex problems</li>
+            	<li>Suggesting different approaches</li>
+            	<li>Checking logic and reasoning</li>
+            	<li>Offering alternative perspectives</li>
+            	<li>Helping analyze pros and cons</li>
+            </ul>
+            </div>
+            </div>
+
+            <p>The list doesn’t end here. Whatever way you use GenAI, remember: <strong>you are responsible for the output you co-create.</strong></p>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i> But…Be Wary and Understand the Limitations</h2>
+            <p>Like any tool, generative AI has limitations you need to understand. Here are the major ones:</p>
+
+            <div>
+            <div>
+            <h5><i></i> Everything It Outputs is “Made Up”</h5>
+
+            <p>GenAI creates responses by predicting. This means:</p>
+
+            <ul>
+            	<li>It can confidently present incorrect information</li>
+            	<li>It makes up facts and citations</li>
+            	<li>It can’t verify its own accuracy</li>
+            	<li>It doesn’t truly understand</li>
+            	<li>It generally doesn&#x27;t learn from conversations</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i> Bias is Built Into the System</h5>
+
+            <p>GenAI learns from human content, inheriting biases:</p>
+
+            <ul>
+            	<li>May favor certain perspectives</li>
+            	<li>Can perpetuate stereotypes</li>
+            	<li>Might give different treatment to groups</li>
+            	<li>Often reflects Western biases</li>
+            	<li>Consider environmental impact</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i> Privacy Concerns are Real</h5>
+
+            <p>When you use GenAI tools, remember:</p>
+
+            <ul>
+            	<li>Conversations may be stored/analyzed</li>
+            	<li>Inputs might be used for training</li>
+            	<li>Sensitive info could be exposed</li>
+            	<li>Privacy policies can change</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i> Copyright &amp; Ownership are Complicated</h5>
+
+            <p>Using GenAI raises IP questions:</p>
+
+            <ul>
+            	<li>Trained on potentially copyrighted material</li>
+            	<li>Ownership of AI content isn’t always clear</li>
+            	<li>Different tools have different terms</li>
+            	<li>Commercial use may have restrictions</li>
+            	<li>Disclose AI use as appropriate</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i> Output May Not be Reliable or Consistent</h5>
+
+            <ul>
+            	<li>The same prompt can give different results</li>
+            	<li>Quality can vary significantly</li>
+            	<li>Results depend heavily on prompt phrasing</li>
+            	<li>The AI can go off track or change tone</li>
+            	<li>May not maintain consistency</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+            <div>
+            <p>While GenAI is a powerful tool, it’s essential to <strong>verify outputs, use critical thinking, and maintain appropriate skepticism.</strong> You are responsible for fact-checking, ensuring ethical use, and making final decisions.</p>
+            </div>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i> The Special Case of Generative AI in Education</h2>
+            <img alt="Group of students illustration" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/GenAIFund_GroupOfStudents.png">
+            <p>In education, GenAI presents both opportunities and challenges. It can help tailor educational content, assist in creating authentic assessments, and support student creativity. However, it also introduces academic integrity concerns, new privacy considerations, and can exacerbate inequalities in technology access.</p>
+
+            <p>The role of GenAI in education is evolving. It’s marked by its promise to revolutionize learning and the challenges it presents. As educators, students, and innovators, our task is to harness GenAI’s potential while safeguarding fair, effective, and ethical educational principles, always keeping a <strong>human-centric approach</strong> at the forefront.</p>
+
+            <div>
+            <h5><i></i> Innovation and Ethics</h5>
+
+            <p>Striving for a balance between innovation and ethical, equitable implementation in education.</p>
+            </div>
+            </div>
+            </div>
+
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/gen-ai-tools-platforms-and-interfaces.html
+++ b/site/gen-ai-tools-platforms-and-interfaces.html
@@ -4,1025 +4,1059 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Gen AI Tools, Platforms, and Interfaces - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="active has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li class="active"><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Gen AI Tools, Platforms, and Interfaces</h2>
-        <div>
-    
-<link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div>
-<div>
-<div><img alt="Abstract network of interconnected AI tools" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract%20network%20of%20interconnected%20AI%20tools%20and%20platforms%2C%20glowing%20nodes%2C%20circular&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
-<div>
-<h1>Generative AI Tools</h1>
-
-<p>The availability and range of generative AI tools, platforms, and interfaces has exploded in the last couple of years. We have a range of easily accessible tools for generating text, images, music, and videos. We have platforms like ChatGPT and Google Gemini that bundle these capabilities together and provide other useful tools for us. And, we have different ways of interfacing; through desktop and mobile devices, through typing and talking, through chatbots and API.</p>
-</div>
-</div>
-
-<h2>Chatbots - They Do More Than Just &quot;Chat&quot;</h2>
-<img alt="Chatbot with diverse capabilities" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=stylized%20illustration%20of%20a%20friendly%20chatbot%20icon%20with%20multiple%20speech%20bubbles%20showing%20icons%20for%20text%2C%20image%20generation%2C%20code%2C%20document%20creation&amp;w=600&amp;h=200&amp;style=professional">
-<p>Let&#x27;s start with the most popular form of interface: a chatbot, which in the past year have become much more than just chatbots. ChatGPT is the prime example of a chatbot and when it was first released all it could do was chat. Now we have easy access to many different chatbots which can not only chat, but can also produce documents, write code, execute code, help you manage projects, create images, and more.</p>
-
-<div>
-<h3>Prominent Chatbot Platforms</h3>
-
-<p>Here is an illustrative list of chatbots, each typically leveraging their own Large Language Models (LLMs). This list doesn&#x27;t include chatbots that solely use another company&#x27;s LLM:</p>
-
-<ul>
-	<li><a href="https://chatgpt.com/" rel="noopener noreferrer" target="_blank">ChatGPT (OpenAI)</a></li>
-	<li><a href="https://gemini.google.com/app" rel="noopener noreferrer" target="_blank">Google Gemini</a></li>
-	<li><a href="https://claude.ai/" rel="noopener noreferrer" target="_blank">Claude (Anthropic)</a></li>
-	<li><a href="https://www.meta.ai/" rel="noopener noreferrer" target="_blank">Llama (Meta)</a></li>
-	<li><a href="https://mistral.ai/" rel="noopener noreferrer" target="_blank">Mistral</a></li>
-	<li><a href="https://www.deepseek.com/" rel="noopener noreferrer" target="_blank">Deepseek</a></li>
-	<li><a href="https://x.ai/grok" rel="noopener noreferrer" target="_blank">Grok (xAI)</a></li>
-	<li><a href="https://github.com/QwenLM" rel="noopener noreferrer" target="_blank">Qwen (Alibaba)</a></li>
-	<li><a href="https://www.01.ai/" rel="noopener noreferrer" target="_blank">Yi (01.AI)</a></li>
-	<li><a href="https://aws.amazon.com/q/" rel="noopener noreferrer" target="_blank">Amazon Q (AWS)</a></li>
-</ul>
-
-<p>Many other models and platforms exist, and the landscape is constantly evolving!</p>
-</div>
-
-<div>
-<p><i></i>Rankings of these models are maintained on many different websites. A popular site for human-evaluated comparisons is the <a href="https://lmarena.ai/?leaderboard" rel="noopener noreferrer" target="_blank">Chatbot Arena LLM Leaderboard</a>, which focuses on blind ratings of text responses.</p>
-</div>
-
-<p>The rankings in the LLM Leaderboard are based solely on text responses, but there are many other dimensions on which to compare these chatbots. Let&#x27;s look at a comparison between three of the most popular: ChatGPT, Google Gemini, and Claude.</p>
-
-<p>This comparison is strictly a comparison of features, not a judgment of how good the LLM is at generating the text you want (see the Chatbot Arena for that). In my opinion, you can&#x27;t go wrong with any of these three as far as the quality of responses go, so this comparison can help you decide which chatbot to use based on the extra features they have.</p>
-
-<hr>
-<div>
-<h3><i></i>Quick Comparison: Key Takeaways</h3>
-
-<p>Don&#x27;t have time for the full tables? Here&#x27;s a 20-second summary:</p>
-
-<div>
-<div>
-<h4><i></i>Paid Versions</h4>
-
-<ul>
-	<li><i></i><strong>ChatGPT:</strong> Has the most features (image/video generation, Python interpreter, Custom GPTs, web search, Canvas).</li>
-	<li><i></i><strong>Claude:</strong> Best for content creation (Projects and Artifacts), strong for long documents.</li>
-	<li><i></i><strong>Gemini:</strong> Massive context window and strong Google ecosystem integration.</li>
-</ul>
-</div>
-
-<div>
-<h4><i></i>Free Versions</h4>
-
-<ul>
-	<li><i></i><strong>ChatGPT:</strong> Accessible without login. Access to shared Custom GPTs.</li>
-	<li><i></i><strong>Claude:</strong> Often generous with features available in its free tier compared to others.</li>
-	<li><i></i><strong>Gemini:</strong> Typically less restricted in terms of number of messages/day.</li>
-</ul>
-</div>
-</div>
-</div>
-
-<hr>
-<div>
-<h2><i></i>Detailed Feature Comparison</h2>
-
-<p>Below is a detailed look at the features of the paid and free versions of ChatGPT, Claude, and Google Gemini. Note that features and availability can change rapidly.<br>
-Last update: May 8, 2025.</p>
-
-<h4>Comparison of Paid Versions</h4>
-
-<table>
-	<thead>
-		<tr>
-			<th>Feature Category</th>
-			<th>Feature</th>
-			<th>ChatGPT (Plus/Team)</th>
-			<th>Google Gemini (Advanced)</th>
-			<th>Claude (Pro/Team)</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><strong>Core Capabilities</strong></td>
-			<td><strong>LLMs Available</strong></td>
-			<td>GPT-4o, GPT-4o mini, GPT4.5, o3, o4-mini</td>
-			<td>Gemini 1.5 Pro, Gemini 1.5 Flash, (Ultra via API)</td>
-			<td>Claude 3.7 Sonnet, Claude 3.5 Sonnet, Claude 3 Opus, Claude 3.5 Haiku</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Context Window</strong></td>
-			<td>~128K tokens (GPT-4o)</td>
-			<td>~1M tokens (Gemini 1.5 Pro)</td>
-			<td>~200K tokens</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Web Search</strong></td>
-			<td>Yes (Browse with Bing)</td>
-			<td>Yes (Google Search integration)</td>
-			<td>Yes </td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Voice Mode</strong></td>
-			<td>Voice input &amp; voice-voice conversations</td>
-			<td>Voice input &amp; voice-voice (via app)</td>
-			<td>Voice input (via app)</td>
-		</tr>
-		<tr>
-			<td><strong>Code</strong></td>
-			<td><strong>Code Writing</strong></td>
-			<td>Yes</td>
-			<td>Yes</td>
-			<td>Yes</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Code Execution</strong></td>
-			<td>Yes (Python interpreter in Code Interpreter)</td>
-			<td>Yes (Python interpreter)</td>
-			<td>Yes (Front-end code via Artifacts)</td>
-		</tr>
-		<tr>
-			<td><strong>Files</strong></td>
-			<td><strong>File Upload</strong></td>
-			<td>Yes (various formats)</td>
-			<td>Yes (various formats, Google Drive)</td>
-			<td>Yes (various formats)</td>
-		</tr>
-		<tr>
-			<td><strong>Creative &amp; Visual</strong></td>
-			<td><strong>Image Generation</strong></td>
-			<td>Yes</td>
-			<td>Yes (Imagen 3)</td>
-			<td>No (but can analyze images)</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Video Generation</strong></td>
-			<td>Yes (Sora, limited access)</td>
-			<td>Yes (Veo2)</td>
-			<td>No</td>
-		</tr>
-		<tr>
-			<td><strong>Customization</strong></td>
-			<td><strong>Custom Instructions/Memory</strong></td>
-			<td>Yes (Custom Instructions, Memory)</td>
-			<td>Yes (Custom Instructions)</td>
-			<td>Yes (Custom Instructions, Pre-prompts)</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Reusable Prompts/Assistants</strong></td>
-			<td>Yes (Custom GPTs)</td>
-			<td>Yes (Gems )</td>
-			<td>Yes (Projects, Prompt Library)</td>
-		</tr>
-		<tr>
-			<td><strong>Access &amp; Platforms</strong></td>
-			<td><strong>Mobile App</strong></td>
-			<td>Yes (iOS, Android)</td>
-			<td>Yes (Gemini app for Android, via Google App on iOS)</td>
-			<td>Yes (iOS, Android - rolling out)</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Browser Extension</strong></td>
-			<td>Yes (Official &amp; third-party)</td>
-			<td>Yes (Official &amp; third-party)</td>
-			<td>Fewer official options, some third-party</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Message Limits</strong></td>
-			<td>GPT-4o: Higher limits; GPT-4: ~40 msgs/3 hrs</td>
-			<td>Generally high, unspecified</td>
-			<td>Higher limits, varies by model &amp; load</td>
-		</tr>
-		<tr>
-			<td><strong>Practical Considerations</strong></td>
-			<td><strong>Privacy Features</strong></td>
-			<td>Option to disable chat history/training</td>
-			<td>Activity controls, option to disable saving</td>
-			<td>Data not used for training by default for paid</td>
-		</tr>
-		<tr>
-			<td><strong>Other Unique Features</strong></td>
-			<td> </td>
-			<td>Canvas, Data Analysis, Apple Intelligence integration (upcoming)</td>
-			<td>Google Workspace/Ecosystem integration (Maps, Flights, Hotels, YouTube)</td>
-			<td>Artifacts for interactive content, strong long-context summarization</td>
-		</tr>
-		<tr>
-			<td><strong>Cost (approx.)</strong></td>
-			<td> </td>
-			<td>$20 USD/month</td>
-			<td>~$20 USD/month (or regional equivalent)</td>
-			<td>$20 USD/month</td>
-		</tr>
-	</tbody>
-</table>
-
-<h4>Comparison of Free Versions</h4>
-
-<table>
-	<thead>
-		<tr>
-			<th>Feature Category</th>
-			<th>Feature</th>
-			<th>ChatGPT</th>
-			<th>Google Gemini</th>
-			<th>Claude</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><strong>Core Capabilities</strong></td>
-			<td><strong>LLMs Available</strong></td>
-			<td>GPT-4o (rate-limited)</td>
-			<td>Gemini 2.5 Flash and Pro (rate-limited), Gemini 2.0 Flash</td>
-			<td>Claude 3.7 Sonnet (rate-limited)</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Context Window</strong></td>
-			<td>~128K (GPT-4o), ~16K (GPT-3.5)</td>
-			<td>~1M (Gemini 1.5 Flash, limited), ~32K (Gemini 1.0 Pro)</td>
-			<td>~200K tokens (generous for free tier)</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Web Search</strong></td>
-			<td>Yes (GPT-4o, limited)</td>
-			<td>Yes</td>
-			<td>Limited/No</td>
-		</tr>
-		<tr>
-			<td><strong>Code</strong></td>
-			<td><strong>Code Writing</strong></td>
-			<td>Yes</td>
-			<td>Yes</td>
-			<td>Yes</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Code Execution</strong></td>
-			<td>Limited (via GPT-4o if available)</td>
-			<td>No</td>
-			<td>Limited (Artifacts, if available)</td>
-		</tr>
-		<tr>
-			<td><strong>Files</strong></td>
-			<td><strong>File Upload</strong></td>
-			<td>Yes (GPT-4o, limited)</td>
-			<td>Yes (limited types/size)</td>
-			<td>Yes (limited)</td>
-		</tr>
-		<tr>
-			<td><strong>Creative &amp; Visual</strong></td>
-			<td><strong>Image Generation</strong></td>
-			<td>Yes (GPT-4o, DALL·E, limited)</td>
-			<td>Yes (limited)</td>
-			<td>No</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Video Generation</strong></td>
-			<td>Yes (Sora)</td>
-			<td>No</td>
-			<td>No</td>
-		</tr>
-		<tr>
-			<td><strong>Customization</strong></td>
-			<td><strong>Custom Instructions/Memory</strong></td>
-			<td>Yes (Custom Instructions, Memory)</td>
-			<td>Yes (Custom Instructions)</td>
-			<td>Limited/No</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Reusable Prompts/Assistants</strong></td>
-			<td>Access to some shared Custom GPTs</td>
-			<td>No</td>
-			<td>No</td>
-		</tr>
-		<tr>
-			<td><strong>Access &amp; Platforms</strong></td>
-			<td><strong>Mobile App</strong></td>
-			<td>Yes</td>
-			<td>Yes</td>
-			<td>Yes (rolling out)</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Login Required</strong></td>
-			<td>Optional for basic use, required for history/GPTs</td>
-			<td>Required</td>
-			<td>Required</td>
-		</tr>
-		<tr>
-			<td> </td>
-			<td><strong>Message Limits</strong></td>
-			<td>Rate limits, especially on GPT-4o</td>
-			<td>Generally more generous daily limits</td>
-			<td>Daily limits, resets periodically</td>
-		</tr>
-		<tr>
-			<td><strong>Practical Considerations</strong></td>
-			<td><strong>Privacy Features</strong></td>
-			<td>Option to disable chat history/training</td>
-			<td>Activity controls</td>
-			<td>Data may be used for training unless opted out (check policy)</td>
-		</tr>
-	</tbody>
-</table>
-</div>
-
-<hr>
-<div>
-<p>Regardless of which chatbot you choose, each offers powerful AI capabilities that can enhance your productivity and creativity. The free versions provide a great starting point for exploring AI assistance, while the paid versions unlock additional features that may be worth the investment depending on your specific needs. The key is to <strong>experiment with different options</strong> and find the one that best matches your workflow. Remember that these platforms are rapidly evolving, with new features and capabilities being added regularly, so it&#x27;s worth staying informed about updates and changes to make the most of these powerful AI assistants.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    
-<link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div>
-<div>
-<h1><i></i>Harnessing Specialty AI Tools</h1>
-
-<div><img alt="Abstract representation of various specialized AI tools interacting" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract%20network%20of%20interconnected%20AI%20tools%20for%20education%2C%20glowing%20nodes%2C%20clean%20design&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
-<div>
-<p>Specialty tools harness <span>generative AI</span> for specific purposes beyond basic text, image, or audio generation. These tools build upon LLMs and other <span>AI</span> models, adding specialized functionality to serve particular needs. For example, some <span>AI</span>-powered search engines not only find information but also synthesize and summarize results. While specialty tools exist for various industries—from legal services (<a href="https://www.harvey.ai/" rel="noopener noreferrer" target="_blank">Harvey</a>) to fitness planning (Fitbod) to software development (<a href="https://github.com/features/copilot" rel="noopener noreferrer" target="_blank">Github Copilot</a>) —the following tools are particularly valuable for enhancing learning and education.</p>
-</div>
-</div>
-
-<hr>
-<div>
-<h3><i></i>NotebookLM</h3>
-
-<p>After falling behind OpenAI, Anthropic, and others, Google finally has an <span>AI</span> product worthy of discussion and at least some of your attention. <a href="https://notebooklm.google.com/" rel="noreferrer noopener" target="_blank">NotebookLM</a> is an experimental tool that is billed to “help users read, take notes, ask questions, and organise ideas”, but that doesn’t really capture the use cases that are blowing up on Twitter. One of the primary use cases is as a multimodal summarizer/tutor. With multimodal meaning that you can provide input in different modes (text, images, slides etc.) and you can get output in a couple of different modes too. You will get a summary of everything you upload plus you can ask questions about the content. But what everyone on the socials is excited about is the “podcast” button…NotebookLM will turn the content that you created into a podcast that is actually not bad. The podcast is a conversation between two fairly realistic and expressive <span>AI</span> voices about whatever you uploaded.</p>
-
-<p>Of course, things aren’t perfect – the “podcasters” really like to use analogies which don’t always land, they often miss nuance, and some users have identified potential gender <span>bias</span> in the conversation (there are two podcaster voices, one male and one female, and one user identified that “the female character had indicated agreement with the male six times before the male voice indicated agreement with her even once”). On top of that, there are only two voices, so currently, every “podcast” created by NotebookLM has the same two hosts and I can imagine getting tired of them after a bit.</p>
-
-<p>Summarizing content and even creating a podcast are both doable in ChatGPT, Claude etc. But the focus of NotebookLM on summarizing and question answering makes the user experience of NotebookLM easier and more enjoyable. Plus it is currently completely free and each notebook supports document upload of about 750,000 words.</p>
-
-<figure><img alt="NotebookLM Screenshot" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/NotebookLMScreens.png">
-<figcaption>The NotebookLM interface showing a notebook created from Dario Amodei&#x27;s essay &quot;Machines of Loving Grace.</figcaption>
-</figure>
-
-<ol>
-	<li>Go to <a href="https://notebooklm.google.com" rel="noreferrer noopener" target="_blank">https://notebooklm.google.com</a></li>
-	<li>Click on “New notebook”</li>
-	<li>Upload a document (PDF, .txt, or markdown only), link to a website or copy in some text and wait until it loads.</li>
-	<li>You will get a summary, suggested questions, and an interface to ask questions and create notes about the content. Answers will be footnoted to point to where in the uploaded document the answers came from.</li>
-	<li>Click on “* Notebook guide” at the bottom right to bring up the option to create an Audio Overview – the podcast. This will take a few minutes.</li>
-</ol>
-
-<p><em>I created a Notebook for a lab from one of my electronics courses and the audio overview that it created was actually good and made the lab seem kinda interesting. Even if you never use NotebookLM again, it’s worth trying out this “podcast” feature at least once.</em></p>
-
-<div>
-<h5>tl;dr</h5>
-
-<p>Google’s first compelling <span>AI</span> entry is a free tool that summarizes uploads, answers questions and creates audio chats.</p>
-<strong>How it works:</strong>
-
-<ul>
-	<li>Upload content</li>
-	<li>Get summaries, ask questions</li>
-	<li>Generate <span>AI</span> conversations (podcasts)</li>
-</ul>
-</div>
-</div>
-
-<hr>
-<div>
-<h3><i></i>Learn About: Google&#x27;s AI-Powered Learning Companion</h3>
-
-<p><a href="https://learning.google.com/experiments/learn-about" rel="noopener noreferrer" target="_blank">Google&#x27;s <em>Learn About</em></a> is an experimental <span>AI</span> tool designed to enhance education through personalized, interactive experiences. Built on the LearnLM model, it aims to transform learning with features tailored to curiosity and exploration.</p>
-
-<div>
-<h5>Why it matters:</h5>
-
-<ul>
-	<li>It uses visual aids, context boxes, and interactive tools to deepen understanding.</li>
-	<li>It&#x27;s designed for learners, it adapts to individual goals with personalized responses.</li>
-</ul>
-</div>
-
-<figure><img alt="Google Learn About interface showing learning topics" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/LearnAbout.png">
-<figcaption>The Google Learn About interface allows users to explore various topics with AI-powered explanations and interactive elements.</figcaption>
-</figure>
-
-<p> </p>
-
-<h5>Key Features:</h5>
-
-<ol>
-	<li><strong>Interactive Learning:</strong> Detailed explanations paired with images, videos, and hands-on guides.</li>
-	<li><strong>Educational Aids:</strong> Tools like &quot;common misconceptions&quot; and &quot;test your knowledge&quot; make it engaging.</li>
-	<li><strong>Personalized Exploration:</strong> Supports questions, uploaded materials, and curated topics for tailored learning paths.</li>
-	<li><strong>Visual Context:</strong> Responses come with textbook-style definitions and examples.</li>
-</ol>
-
-<h5>Who Can Use It:</h5>
-
-<p><em>Learn About</em> is officially available in English for users 18+ in the U.S., and you’ll need a Google account to access it.</p>
-
-<p><strong>Not in the US? Here’s a tip:</strong> Use a VPN to set your location to the States—the <a href="https://www.opera.com/download" rel="noopener noreferrer" target="_blank"><em>Opera browser</em></a> makes it super easy with its built-in VPN. 😉 Happy learning!</p>
-
-<h5>Getting Started:</h5>
-
-<ol>
-	<li>Open the Opera browser with VPN enabled (or connect to another VPN in the US).</li>
-	<li>Visit the <a href="https://learning.google.com/experiments/learn-about" rel="noopener noreferrer" target="_blank"><em>Learn About</em></a> website.</li>
-	<li>Enter a query or upload documents/images.</li>
-	<li>Dive into summaries, visuals, and quizzes.</li>
-</ol>
-
-<div>
-<h5>tl;dr</h5>
-
-<p>A free, <span>AI</span>-powered tool for interactive learning with visuals, quizzes, and personalized responses.</p>
-<strong>How it works:</strong>
-
-<ul>
-	<li>Ask questions or upload materials.</li>
-	<li>Get tailored explanations with videos, images, and definitions.</li>
-	<li>Test your knowledge with engaging tools.</li>
-</ul>
-
-<p><strong>Pro tip:</strong> Use a VPN (like Opera’s) if you&#x27;re outside the U.S.</p>
-</div>
-</div>
-
-<hr>
-<div>
-<h3><i></i>Perplexity: An Answer Engine</h3>
-
-<p><a href="https://www.perplexity.ai" rel="noopener" target="_blank">Perplexity AI</a> uses a combination of search and conversational <span>AI</span> to give the user direct answers with cited sources, rather than just links.</p>
-
-<figure><img alt="Perplexity search results showing sources and opening paragraph" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/PerplexityScreenshot.png">
-<figcaption>Perplexity search results showing sources and opening paragraph.</figcaption>
-</figure>
-
-<h5>How it works:</h5>
-
-<ul>
-	<li>Combines <span>AI</span> language models with real-time web search</li>
-	<li>Provides up-to-date information for current events</li>
-	<li>Creates custom research pages from simple prompts</li>
-	<li>Cites sources for fact-checking</li>
-</ul>
-
-<h5>Plans:</h5>
-
-<ul>
-	<li><strong>Free plan:</strong> Uses GPT-4o mini with web browsing</li>
-	<li><strong>Pro plan:</strong> Adds access to advanced <span>AI</span> models (GPT-4, Claude 3.5, Grok-2) plus internal file search, image analysis, and image generation</li>
-</ul>
-
-<h5>Latest features:</h5>
-
-<ul>
-	<li>Shopping hub for product recommendations</li>
-	<li>Internal knowledge search across documents</li>
-	<li>Spaces: <span>AI</span>-powered collaboration hub</li>
-</ul>
-
-<div>
-<h5>The bottom line:</h5>
-
-<p>Perplexity <span>AI</span> streamlines research and information gathering for students, researchers, and content creators who need quick answers with links to the information source.</p>
-</div>
-</div>
-
-<hr>
-<div>
-<h3><i></i>AI Writing Assistants: Grammarly and Quillbot</h3>
-
-<p><a href="https://www.grammarly.com/" rel="noopener" target="_blank">Grammarly</a> and <a href="https://quillbot.com/" rel="noopener" target="_blank">Quillbot</a> are both <span>AI</span> writing assistants that check grammar, enhance style, generate content, and improve writing quality.</p>
-
-<h5>By the numbers:</h5>
-
-<ul>
-	<li>Both tools have free and paid versions (Grammarly $12 US/month and Quillbot $8.33 US/month - annual billing).</li>
-	<li>Core functions: Paraphrase, summarize.</li>
-	<li>Available on: Browser, MS Word, Outlook, mobile.</li>
-</ul>
-
-<h5>What they do:</h5>
-
-<ul>
-	<li>Check grammar, spelling, and tone in real-time</li>
-	<li>Paraphrase and summarize</li>
-	<li>Suggest vocabulary improvements</li>
-	<li>Detect plagiarism (Premium)</li>
-	<li>Rewrite full sentences for clarity</li>
-	<li>Adjust writing style by genre</li>
-</ul>
-
-<div>
-<div>
-<h5><i></i>Grammarly</h5>
-
-<p>Focuses on perfecting English writing. Best for polishing grammar, tone, clarity, and inclusiveness. Integrates well with many apps and has excellent team features.</p>
-</div>
-
-<div>
-<h5><i></i>Quillbot</h5>
-
-<p>Excels at paraphrasing and supports multiple languages. Ideal for research, quick rewrites, and translation. Offers a robust summarization tool and citation generator.</p>
-</div>
-</div>
-
-<div>
-<h5><i></i>Reminder &amp; Trade-offs:</h5>
-
-<p>These tools are meant to <em>support</em> your writing, not replace it. Over-reliance on <span>AI</span> can hinder your learning and may violate class policies regarding <span>AI</span> use. Use these tools responsibly!</p>
-<strong>Consider these trade-offs:</strong>
-
-<ul>
-	<li><strong>Cost:</strong> Premium features are costly for individuals.</li>
-	<li><strong>Context:</strong> <span>AI</span> suggestions aren’t always context-aware.</li>
-	<li><strong>Annoying:</strong> Some find upgrade prompts intrusive.</li>
-	<li><strong>Accuracy:</strong> Tools may occasionally make mistakes.</li>
-</ul>
-
-<p>The free versions handle basic needs well. Premium versions unlock powerful features for serious writers, but success still depends on your judgment and skill.</p>
-</div>
-</div>
-
-<hr>
-<div>
-<h3><i></i>AI Supported Research Tools</h3>
-
-<details open=""><summary>About These Tools (Source: Georgetown University Library)</summary>
-
-<div>
-<p>This section comes from Georgetown University Library (<a href="https://guides.library.georgetown.edu/ai/tools" rel="noopener noreferrer" target="_blank">original</a>) and is licensed under a <a href="https://creativecommons.org/licenses/by-nc/4.0/" rel="noopener noreferrer" target="_blank">Creative Commons Attribution NonCommercial 4.0 International License</a>.</p>
-
-<p><span>AI</span> tools for research can help you to discover new sources for your literature review or research assignment. These tools will synthesize information from large databases of scholarly output with the aim of finding the most relevant articles and saving researchers’ time. As with our research databases or any other search tool, however, it’s important not to rely on one tool for all of your research, as you will risk missing important information on your topic of interest.Placeholder: Abstract graphic representing a network of research papers or data analysis, or a collage of logos for Elicit, Consensus, etc. </p>
-</div>
-</details>
-
-<figure><img alt="Abstract graphic representing research tools" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ResearchToolsGraphic.png">
-<figcaption>AI research tools provide access to databases that are not directly accessible via websearch.</figcaption>
-</figure>
-
-<div>
-<table>
-	<thead>
-		<tr>
-			<th>NAME</th>
-			<th>WHAT IT DOES</th>
-			<th>UNDERLYING DATA</th>
-			<th>IS IT FREE?</th>
-			<th>MORE INFORMATION</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><a href="https://elicit.com/" rel="noopener" target="_blank">Elicit</a></td>
-			<td>Using large language models (LLMs), Elicit finds papers relevant to your topic by searching through papers and citations and extracting and synthesizing key information.</td>
-			<td>Semantic Scholar Database</td>
-			<td>Free with paid subscriptions available.</td>
-			<td><a href="https://elicit.com/#FAQ" rel="noopener" target="_blank">Elicit FAQs</a></td>
-		</tr>
-		<tr>
-			<td><a href="https://consensus.app/search/" rel="noopener" target="_blank">Consensus</a></td>
-			<td>Similar to Elicit, Consensus uses LLMs to help researchers find and synthesize answers to research questions, focusing on the scholarly authors’ findings and claims in each paper.</td>
-			<td>Semantic Scholar Database</td>
-			<td>Free (20 searches/month); Paid version allows unlimited searching.</td>
-			<td><a href="https://consensus.app/home/blog/welcome-to-consensus/" rel="noopener" target="_blank">Consensus FAQs</a></td>
-		</tr>
-		<tr>
-			<td><a href="https://www.semanticscholar.org/" rel="noopener" target="_blank">Semantic Scholar</a></td>
-			<td>Semantic Scholar (which supplies underlying data for many of the other tools on this list) provides brief summaries (‘TLDR’s) of the main objectives and results of papers.</td>
-			<td>Semantic Scholar Database</td>
-			<td>Semantic Scholar is currently free.</td>
-			<td><a href="https://www.semanticscholar.org/faq" rel="noopener" target="_blank">Semantic Scholar FAQs</a></td>
-		</tr>
-		<tr>
-			<td><a href="https://www.researchrabbit.ai/" rel="noopener" target="_blank">Research Rabbit</a></td>
-			<td>Research Rabbit is a citation-based mapping tool that focuses on the relationships between research works. It uses visualizations to help researchers find similar papers and other researchers in their field.</td>
-			<td>Research Rabbit uses multiple databases, but does not name them (more information can be found on the <a href="https://researchrabbit.notion.site/Welcome-to-the-FAQ-c33b4a61e453431482015e27e8af40d5#c1b5f1fe3f844c12ae32b453ff295964" rel="noopener" target="_blank">FAQ page</a>).</td>
-			<td>Research Rabbit is currently free.</td>
-			<td><a href="https://researchrabbit.notion.site/Welcome-to-the-FAQ-c33b4a61e453431482015e27e8af40d5#c1b5f1fe3f844c12ae32b453ff295964" rel="noopener" target="_blank">Research Rabbit FAQs</a></td>
-		</tr>
-		<tr>
-			<td><a href="https://www.connectedpapers.com/" rel="noopener" target="_blank">Connected Papers</a></td>
-			<td>Like Research Rabbit, Connected Papers focuses on the relationships between research papers to find similar research. You can also use Connected Papers to get a visual overview of an academic field.</td>
-			<td>Semantic Scholar Database</td>
-			<td>Free (5 graphs/month); paid version allows unlimited graphing.</td>
-			<td><a href="https://www.connectedpapers.com/about" rel="noopener" target="_blank">Connected Papers – About</a></td>
-		</tr>
-		<tr>
-			<td><a href="https://scite.ai/home" rel="noopener" target="_blank">scite</a></td>
-			<td>scite has a suite of products that help researchers develop their topics, find papers, and search citations in context (describing whether the article provides supporting or contrasting evidence)</td>
-			<td>Many different sources (an incomplete list can be found <a href="https://help.scite.ai/en-us/article/where-do-you-get-your-articles-from-1vglydm/" rel="noopener" target="_blank">on this page</a>)</td>
-			<td>No. (<a href="https://scite.ai/pricing" rel="noopener" target="_blank">Pricing information</a>)</td>
-			<td><a href="https://help.scite.ai/en-us/" rel="noopener" target="_blank">scite FAQs</a>; <a href="https://direct.mit.edu/qss/article/2/3/882/102990/scite-A-smart-citation-index-that-displays-the" rel="noopener" target="_blank">how scite works</a></td>
-		</tr>
-		<tr>
-			<td><a href="https://www.scholarcy.com/" rel="noopener" target="_blank">Scholarcy</a></td>
-			<td>Scholarcy summarizes key points and claims of articles into ‘summary cards’ that researchers can read, share, and annotate when compiling research on a given topic.</td>
-			<td>Scholarcy only uses <a href="https://www.scholarcy.com/scholarcy-features/" rel="noopener" target="_blank">research papers uploaded or linked by the researcher themselves</a>. It works as a way to help you read and summarize your research, but is not a search engine.</td>
-			<td>Free (short articles only); Paid version allows articles of any length.</td>
-			<td><a href="https://www.scholarcy.com/faq/" rel="noopener" target="_blank">Scholarcy FAQs</a></td>
-		</tr>
-		<tr>
-			<td><a href="https://chat.openai.com/auth/login" rel="noopener" target="_blank">ChatGPT</a></td>
-			<td>While the <span>AI</span> chatbot ChatGPT is typically thought of as a writing tool, it can be used in the initial idea development phase of research, and can also be of use in finding further sources. (Remember to always look up sources to verify their credibility.)</td>
-			<td>The <a href="https://help.openai.com/en/articles/8077698-how-do-i-use-chatgpt-browse-with-bing-to-search-the-web" rel="noopener" target="_blank">paid versions of ChatGPT are currently connected to the internet through Bing</a>. The free version was trained on data last updated in September 2021, but that might change in the future.</td>
-			<td>There is a free version available.</td>
-			<td><a href="https://help.openai.com/en/collections/3742473-chatgpt" rel="noopener" target="_blank">OpenAI Help Center – ChatGPT</a></td>
-		</tr>
-	</tbody>
-</table>
-</div>
-</div>
-
-<hr>
-<div>
-<h3><i></i>Gamma and Other AI Presentation Tools</h3>
-
-<p><a href="https://gamma.app" rel="noopener noreferrer" target="_blank">Gamma</a> is an <span>AI</span> presentation tool that may be worth the switch from ChatGPT or Claude, especially if you&#x27;re design-challenged. Unlike general <span>AI</span> tools, Gamma excels at design-focused tasks, creating polished presentations from simple prompts or content.</p>
-
-<h5>How it works:</h5>
-
-<ul>
-	<li>Input your content or idea</li>
-	<li><span>AI</span> handles both design and layout</li>
-	<li>Creates presentations, docs, or websites</li>
-	<li>Suggests color schemes and themes automatically</li>
-</ul>
-
-<h5>Pricing:</h5>
-
-<ul>
-	<li><strong>Free:</strong> Basic features with Gamma branding</li>
-	<li><strong>$10/month:</strong> More design credits, no branding</li>
-</ul>
-
-<div>
-<h5>The bottom line:</h5>
-
-<p>If Canva and ChatGPT had a baby, it would be Gamma. It&#x27;s particularly valuable for those who want professional-looking presentations without design expertise.</p>
-</div>
-
-<h5>Other Options:</h5>
-
-<p>These are apps with similar capabilities as Gamma that may be worth checking out:</p>
-
-<ul>
-	<li><strong>Beautiful.ai:</strong> 14 day trial then $144 US/year</li>
-	<li><strong>Microsoft Copilot in Powerpoint:</strong> requires Microsoft 365 account plus Copilot subscription</li>
-	<li><strong>Google Gemini in Google Slides:</strong> requires Gemini Advanced Account</li>
-</ul>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Image generators turn your description into a picture—often in seconds. They’re fun to explore and incredibly useful for drafts, lesson visuals, diagrams, and design experiments. Quality has improved rapidly, but getting the exact image you want still takes iteration: broad scenes (e.g., “students studying at a table”) are easy; precise details (e.g., “three students at one table—one with a laptop, two on phones”) usually require prompt refinement.</p>
-
-<p>A quick note on impact: generating images uses substantial compute—meaning energy and water. Before spinning up dozens of variations “just to see,” consider whether a smaller batch or a stock photo would do. For perspective, the What Uses More? calculator compares the footprint of AI image generation with everyday digital activities: <a href="https://what-uses-more.com/" rel="noopener" target="_blank">what-uses-more.com</a>.</p>
-
-<p> </p>
-<hr>
-
-<h4><img alt="Cute robot doing art" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/electronaxe_happy_robot_artist_drawing_a_picture_view_is_over_i_a17296d1-939e-4db8-9d78-23c323d7e32d.png">Midjourney</h4>
-
-
-<p><strong>Company</strong>: Midjourney<br>
-<strong>Available through:</strong> <a href="https://www.midjourney.com/">https://www.midjourney.com/</a> and Midjourney bot on Discord<br>
-<strong>Cost</strong>: Varies: free, $10-$120 US/month. I would recommend the $10/month subscription<br>
-<strong>Summary</strong>: Midjourney produces some of the most striking pictures, but it is challenging to get the exact details you want. Originally only available through Discord, you can now generate images on the Midjourney website. Midjourney has several models to choose from including one that is specifically trained on anime. There is no free subscription.<br>
-<strong>Pros</strong>: Excellent image quality. Several different models. Can edit pictures.<br>
-<strong>Cons</strong>: No free access. Can only edit pictures on yearly subscription.</p>
-
-<hr>
-<h4>DALL-E<img alt="Dali style picture with melting computer in desert" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/DALL·E_2023-10-14_11.34.51_-_A_melting_laptop_is_showcased_on_a_desk__its_keys_dripping_like_liquid_metal._Beside_the_laptop__a_peculiar__warped_clock_casts_elongated__dream-like_.png"></h4>
-
-<p><strong>Company</strong>: OpenAI<br>
-<strong>Available through:</strong> Microsoft Copilot and ChatGPT<br>
-<strong>Cost</strong>: Varies. Free. More images with ChatGPT Plus<br>
-<strong>Summary</strong>: Named as a play on Salvador Dali and WALL-E. In my opinion, DALL-E images are not as good as the other generators listed here, but it does a good job handling text within the image. To support users, both the Copilot version and the ChatGPT version will enhance your prompts and show you the updated prompt for each picture that you create.<br>
-<strong>Pros</strong>: Good text rendering. Free on Microsoft and ChatGPT. Automatically enhances/improves your prompts<br>
-<strong>Cons</strong>: Free access on ChatGPT is very limited. Image quality is okay</p>
-
-<hr>
-<h4><img alt="Mascot holding sign saying &quot;Ideogram&quot;" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ideogram_mascot.png">Ideogram</h4>
-
-<p> </p>
-
-<p><strong>Company</strong>: Ideogram<br>
-<strong>Available through:</strong> https://ideogram.ai<br>
-<strong>Cost</strong>: Varies: free (up to 40 images/day), $8-$60 US/month (up to 14,000 images/month)<br>
-<strong>Summary</strong>: Ideogram is a new company, even in the world of AI. It was founded in August 2023 and is competitive with leading image generators like Midjourney and Dall-E (arguably better than Dall-E but worse than Midjourney). It does a great job. Can edit pictures.<br>
-<strong>Pros</strong>: Excellent image quality. Renders text accurately.<br>
-<strong>Cons</strong>: Free access is very slow</p>
-
-<p> </p>
-
-<hr>
-<h4>FLUX<img alt="Up close picture of single tiger eye with &quot;Flux&quot; splashed across it" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/flux_tiger_eye_plus_text.png"></h4>
-
-<p> </p>
-
-<p><strong>Company</strong>: Black Forest Labs<br>
-<strong>Available through:</strong> API or third party apps (e.g. <a href="https://chat.mistral.ai/chat">Le Chat from Mistral</a>)<br>
-<strong>Cost</strong>: Varies. Free to ???<br>
-<strong>Summary</strong>: Flux is another new image generator that is particularly adept at following the user instructions and generating text. Since it isn&#x27;t available directly from the provider except through an API, it can be hard to find.<br>
-<strong>Pros</strong>: Good text rendering. Free access through multiple providers increases your daily limit. My favourite for quality after Midjourney. Some third party apps provide image editing tools<br>
-<strong>Cons</strong>: Can be hard to find</p>
-
-<hr>
-<h4> </h4>
-
-<h4><img alt="the word &quot;imagen&quot; written in trees" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/Gemini_Imagen_in_trees.jpg">Imagen</h4>
-
-<p> </p>
-
-<p><strong>Company</strong>: Google<br>
-<strong>Available through:</strong> https://gemini.google.com<br>
-<strong>Cost</strong>: Varies: free (up to ?? images/day). More images with $26/month Gemini Advanced subscription<br>
-<strong>Summary</strong>: Imagen 3 is the latest version of Google&#x27;s image generator. It is now built into Gemini, so free users can create images. There is a generation limit, but I can&#x27;t find it listed, haven&#x27;t hit it yet after 20 images.<br>
-<strong>Pros</strong>: Excellent image quality, lots of images with free version<br>
-<strong>Cons</strong>: Many of the features of Imagen (e.g., customization, image editing) are not generally available. Can&#x27;t create pictures of people on free version</p>
-
-<hr>
-<h4 id="adobe-firefly"><img alt="Placeholder for Adobe Firefly image" loading="lazy" src="https://via.placeholder.com/200"> Adobe Firefly</h4>
-
-<p><strong>Company</strong>: Adobe<br>
-<strong>Available through:</strong> <a href="https://firefly.adobe.com" rel="noopener" target="_blank">firefly.adobe.com</a> and Creative Cloud apps (Photoshop, Illustrator, Express)<br>
-<strong>Cost</strong>: Generative credits included with Creative Cloud plans (allowances vary by plan; see Adobe’s Generative Credits table). Firefly on the web also offers a free tier with limited credits. Example plan prices (US): Photoshop $22.99/month; Creative Cloud All Apps $59.99/month. See Adobe’s pricing pages for current regional pricing and credit allotments<br>
-<strong>Summary</strong>: Firefly’s Image 3 model powers Generative Fill and related tools across Adobe apps. Emphasis on commercially safer outputs (trained on Adobe Stock and licensed data) and Content Credentials for provenance. Excellent for inpainting/outpainting and design‑ready assets within familiar workflows.<br>
-<strong>Pros</strong>: Rights-conscious training; tight Photoshop/Illustrator integration; strong inpainting; Content Credentials; enterprise options<br>
-<strong>Cons</strong>: Credit limits can throttle heavy use; some styles/text rendering trail tools focused on typography/logos; requires Adobe account</p>
-
-<div> </div>
-
-<hr>
-<h4 id="stable-diffusion"><img alt="Placeholder for Stable Diffusion image" loading="lazy" src="https://via.placeholder.com/200"> Stable Diffusion (SDXL / SD3)</h4>
-
-<p><strong>Company</strong>: Stability AI and the open‑source community<br>
-<strong>Available through:</strong> Hosted UIs/APIs (e.g., DreamStudio, Playground AI). Can also be run on local hardware<br>
-<strong>Cost</strong>: Local use can be free (you provide hardware). Hosted services use credits/subscriptions with their own free tiers/limits. Pricing varies by provider (e.g., pay‑as‑you‑go on DreamStudio; free + paid tiers on Playground). Check the chosen host for current rates and daily limits<br>
-<strong>Summary</strong>: The Stable Diffusion family offers maximum control and extensibility—run locally and fine‑tune for domain styles. <br>
-<strong>Pros</strong>: Full control/customization; offline/local options; vast model ecosystem; cost‑efficient at scale<br>
-<strong>Cons</strong>: Setup complexity; output quality depends on model/config; licensing/compliance varies across community models; text rendering inconsistent without specialized checkpoints</p>
-
-<div> </div>
-
-<hr>
-<h4 id="leonardo"><img alt="Placeholder for Leonardo image" loading="lazy" src="https://via.placeholder.com/200"> Leonardo</h4>
-
-<p><strong>Company</strong>: Leonardo AI<br>
-<strong>Available through:</strong> <a href="https://leonardo.ai" rel="noopener" target="_blank">https://leonardo.ai</a><br>
-<strong>Cost</strong>: Free tier (daily tokens). Paid plans (US monthly) starting at $12.<br>
-<strong>Summary</strong>: A creator‑focused platform for concept art, game assets, and stylized illustrations. Robust canvas editor, inpainting/outpainting, upscaling, background removal, and workflow tools. Supports training/customization for brand or project styles.<br>
-<strong>Pros</strong>: Strong editor and upscaling; asset‑oriented workflows; style libraries; custom training; active community<br>
-<strong>Cons</strong>: Free tier can be queued/slow; review licensing/training policy for commercial use; more iteration needed for photorealism vs. top photoreal models</p>
-
-<div> </div>
-
-<hr>
-<h4 id="canva"><img alt="Placeholder for Canva image" loading="lazy" src="https://via.placeholder.com/200"> Canva (Magic Media — Text to Image)</h4>
-
-<p><strong>Company</strong>: Canva<br>
-<strong>Available through:</strong> <a href="https://www.canva.com" rel="noopener" target="_blank">https://www.canva.com</a> (Magic Media &gt; Text to Image; integrated in the Canva editor)<br>
-<strong>Cost</strong>: Credit‑based generation. Published monthly AI credit allowances (US): Free plan ~50 credits/month; Pro $12.99/month with ~500 credits/month; Teams pricing varies with ~500 credits per seat/month. Education/Nonprofit plans have distinct allowances—see Canva’s help/pricing pages for current figures<br>
-<strong>Summary</strong>: Canva is a full featured graphic design platform with integrated image generator for quick compositions, class materials, and social/marketing visuals. <br>
-<strong>Pros</strong>: Easy to use; template‑rich; collaborative; fast to production‑ready layouts; no context switching<br>
-<strong>Cons</strong>: Less fine‑grained control/ultimate quality than specialist tools; text rendering can be hit‑or‑miss; credit limits apply</p>
-
-<div> </div>
-
-
-    </div><div>
-    
-<div id="gai-wrap">
-<div>
-<div>
-<h1 id="top"><i></i> Generative AI Videos</h1>
-
-<div>
-<p>Generative AI video systems create moving images from prompts, reference images, or existing footage—synthesizing scenes, camera moves, and effects that once required large crews or complex pipelines. In minutes, you can draft storyboards, visualize concepts, or prototype explainer clips that would have taken days.</p>
-
-<p>The technology is improving rapidly: models are getting better at temporal consistency, object permanence, realistic physics, lip‑sync, and multi‑shot continuity. Controls are expanding too—keyframe conditioning, image‑to‑video, depth maps, masks, and “edit by prompt” workflows give creators more precise handles on motion, look, and pacing.</p>
-</div>
-
-<div id="downsides">
-<h2><i></i>Downsides, Costs, and Risks</h2>
-
-<div>
-<p><i></i> <strong>Environmental cost:</strong> Training and large‑scale generation can consume significant energy and water. Before using video generators keep the environmental cost in mind and find ways to minimize impact (e.g., settings, shorter drafts, batched renders, and provider options that disclose sustainability practices)</p>
-</div>
-
-<div>
-<p><i></i> <strong>Copyright and training data:</strong> Many providers face scrutiny over whether training data included copyrighted works without permission. </p>
-</div>
-
-<div>
-<p><i></i> <strong>Deepfakes and deception:</strong> AI can fabricate convincing people and events. Always obtain consent, avoid impersonation, and label AI‑generated or AI‑edited content. Also, always be aware that media you consume may be a deepfake</p>
-</div>
-
-<ul>
-	<li><strong>Bias and representation:</strong> Models may reproduce stereotypes unless you guide outputs and review critically.</li>
-	<li><strong>Privacy:</strong> Avoid uploading sensitive footage; follow your organization’s data policies.</li>
-	<li><strong>Overreliance:</strong> Treat AI as a creative partner—not a replacement for domain expertise, verification, and ethics.</li>
-</ul>
-
-<div>
-<h5><i></i>Responsible Use—Quick Checklist</h5>
-
-<p>Label AI involvement, get consent from identifiable people, use assets you have rights to, keep a record of prompts and sources, and verify factual claims if your video informs or instructs.</p>
-</div>
-</div>
-
-<div id="tools-table">
-<h2><i></i>Generative AI Video Tools</h2>
-
-<p>Here is a a concise comparison of some popular AI video generators, with access details, strengths, trade‑offs, and common use cases.</p>
-
-<div aria-label="Generative AI video tools comparison">
-<table>
-	<caption>AI Video Tools Comparison</caption>
-	<thead>
-		<tr>
-			<th scope="col">AI Video Tool</th>
-			<th scope="col">Access &amp; Pricing</th>
-			<th scope="col">Key Pros</th>
-			<th scope="col">Key Cons</th>
-			<th scope="col">Typical Use Cases</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><strong>Google Veo 3</strong></td>
-			<td>Access via Vertex AI (Veo 3 Fast available). Also integrated into Canva’s “Create a Video Clip.” Pricing and quotas vary by Google Cloud usage; Google AI Pro plan</td>
-			<td>State-of-the-art realism; native audio (music/FX/dialogue).</td>
-			<td>Short clips; expensive; </td>
-			<td>Fun creative shorts, storyboarding, filmmaker prototyping.</td>
-		</tr>
-		<tr>
-			<td><strong>Runway (Gen-3 current)</strong></td>
-			<td>Web platform with free trial and paid plans (≈$15+/mo). API available.</td>
-			<td>Generates short 1080p clips; strong editing suite (inpainting, keyframes, masking, timeline tools).</td>
-			<td>No native audio; short durations; multiple attempts often needed for best results.</td>
-			<td>Artistic shorts, music video visuals, indie pre‑viz.</td>
-		</tr>
-		<tr>
-			<td><strong>OpenAI Sora</strong></td>
-			<td>Available with ChatGPT Plus and Pro via sora.com. </td>
-			<td>Can create longer clips (up to ~20s) and supports workflows like storyboard, looping, and remixing.</td>
-			<td>No free tier.</td>
-			<td>Experimental creative exploration, imaginative short scenes.</td>
-		</tr>
-		<tr>
-			<td><strong>Kling AI (Kuaishou)</strong></td>
-			<td>Web tool (app.klingai.com). Free credits available; paid plans around ~$10/mo reported; exact credits/tiers vary by region and time.</td>
-			<td>Cinematic‑style clips; supports dynamic camera movement; generally affordable.</td>
-			<td>No audio; short clips; free tier limits.</td>
-			<td>Budget‑friendly cinematic videos, music visuals, storyboards.</td>
-		</tr>
-		<tr>
-			<td><strong>Alibaba Qwen (Tongyi Video)</strong></td>
-			<td>Free access on the Qwen web interface observed; clip length short; watermark/unlimited status not officially specified on public docs.</td>
-			<td>Fast to test ideas; accessible.</td>
-			<td>Very short outputs; quality below leaders; limited controls/features.</td>
-			<td>Learning, ideation, quick concept testing.</td>
-		</tr>
-		<tr>
-			<td><strong>Adobe Firefly (Video)</strong></td>
-			<td>Generate Video (beta) in Firefly web app; included in Firefly/Creative Cloud plans (starting at ~$9.99+/mo).</td>
-			<td>Trained on licensed/Adobe Stock (commercially safer usage); smooth export to Premiere Pro/After Effects.</td>
-			<td>Very short clips in beta (no official published number); beta quality; requires Adobe subscription.</td>
-			<td>Professional b‑roll, marketing visuals, scene fillers.</td>
-		</tr>
-		<tr>
-			<td><strong>Pika Labs</strong></td>
-			<td>Web app (originally a Discord bot). Free trial credits (~300 common), paid plans ~$10–$60/mo.</td>
-			<td>Simple to use; strong community sharing and re‑prompting.</td>
-			<td>Outputs are animation‑style; no native audio.</td>
-			<td>Casual fun, memes, educational demos.</td>
-		</tr>
-		<tr>
-			<td><strong>Higgsfield</strong></td>
-			<td>Web platform (higgsfield.ai). Free trial; Basic plan around $9/mo (e.g., 150 credits); higher tiers available.</td>
-			<td>Sharp visual quality; useful preset effects/camera moves.</td>
-			<td>Short clips; no native audio; stitching needed for longer content.</td>
-			<td>Creative VFX shots, experimental b‑roll.</td>
-		</tr>
-	</tbody>
-</table>
-</div>
-
-<p>Note: Capabilities, availability, and watermarking/provenance practices change quickly. Verify details if important.</p>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p> </p>
-
-<p>This Bingo Challenge is inspired by the <a href="https://opentextbc.ca/teachingandlearningwithai/" target="_blank">Gen AI in Teaching and Learning Toolkit </a>by Gwen Nguyen and this brief introduction is directly from that book (<a href="https://creativecommons.org/licenses/by-nc/4.0/deed.en" target="_blank"><span><span>CC BY-NC 4.0</span></span></a>). It encourages you to explore various generative AI tools, experimenting with both text-based and image generation platforms. By engaging with these tools, you can hopefully better understand their functionalities, applications, and limitations in educational settings.</p>
-
-<p>Instructions:</p>
-
-<ol>
-	<li>Print or download the BINGO worksheet.</li>
-	<li>Once you complete five challenges in a row (horizontally, vertically, or diagonally), you’ve achieved BINGO!</li>
-	<li>For each tool you try, reflect on how it might be used or integrated into your teaching practice.</li>
-</ol>
-
-<table bgcolor="#FFFFFF" border="2" cellpadding="10" cellspacing="0" width="100%">
-	<caption>
-	<h2>Student GenAI BINGO Challenge</h2>
-	</caption>
-	<tbody>
-		<tr bgcolor="#2c3e50">
-			<th width="20%"><font color="white" size="5">B</font></th>
-			<th width="20%"><font color="white" size="5">I</font></th>
-			<th width="20%"><font color="white" size="5">N</font></th>
-			<th width="20%"><font color="white" size="5">G</font></th>
-			<th width="20%"><font color="white" size="5">O</font></th>
-		</tr>
-		<tr align="center">
-			<td height="100">Use ChatGPT to explain a difficult concept</td>
-			<td>Create study flashcards with an AI tool</td>
-			<td>Use Claude to analyze a research paper</td>
-			<td>Generate a mind map about a class topic using AI</td>
-			<td>Write a poem about your field of study with AI</td>
-		</tr>
-		<tr align="center">
-			<td height="100">Use Perplexity to fact-check information from ChatGPT</td>
-			<td>Ask Gemini to help brainstorm essay topics</td>
-			<td>Compare answers from 2 different AI tools on the same question</td>
-			<td>Create an image that represents your major using DALL-E</td>
-			<td>Break down a complex project into steps using Claude</td>
-		</tr>
-		<tr align="center">
-			<td height="100">Use Claude to proofread your writing</td>
-			<td>Create a presentation outline with Gamma</td>
-			<td bgcolor="#3498db"><font color="white"><b>FREE SPACE<br>
-			Try a new AI tool!</b></font></td>
-			<td>Use AI to improve the clarity of your writing</td>
-			<td>Use DeepL to translate your work into another language</td>
-		</tr>
-		<tr align="center">
-			<td height="100">Ask AI to explain where it got its information</td>
-			<td>Use AI to find relevant sources for your research</td>
-			<td>Create a study schedule using an AI assistant</td>
-			<td>Use AI to find counterarguments to your essay position</td>
-			<td>Use NotebookLM to summarize your class notes</td>
-		</tr>
-		<tr align="center">
-			<td height="100"><span block-id="element-2-14-content"><span block-id="element-element-0"><span block-id="element-element-0-inline-0">Ask multiple Gen AI tools to predict the future of your field in 5 years and compare responses</span></span></span></td>
-			<td><span block-id="element-2-16-content"><span block-id="element-element-0"><span block-id="element-element-0-inline-0">Use AI to generate a &quot;survival guide&quot; for your most challenging course</span></span></span></td>
-			<td>Create a visual summary of a chapter using Gen AI</td>
-			<td>Use Gen AI to identify gaps in your research</td>
-			<td>Ask AI to explain its limitations</td>
-		</tr>
-	</tbody>
-</table>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Gen AI Tools, Platforms, and Interfaces</h2>
+            <div>
+
+            <div>
+            <div>
+            <div><img alt="Abstract network of interconnected AI tools" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract%20network%20of%20interconnected%20AI%20tools%20and%20platforms%2C%20glowing%20nodes%2C%20circular&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
+            <div>
+            <h1>Generative AI Tools</h1>
+
+            <p>The availability and range of generative AI tools, platforms, and interfaces has exploded in the last couple of years. We have a range of easily accessible tools for generating text, images, music, and videos. We have platforms like ChatGPT and Google Gemini that bundle these capabilities together and provide other useful tools for us. And, we have different ways of interfacing; through desktop and mobile devices, through typing and talking, through chatbots and API.</p>
+            </div>
+            </div>
+        </section>
+        <section class="gai-box">
+            <h2>Chatbots - They Do More Than Just &quot;Chat&quot;</h2>
+            <img alt="Chatbot with diverse capabilities" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=stylized%20illustration%20of%20a%20friendly%20chatbot%20icon%20with%20multiple%20speech%20bubbles%20showing%20icons%20for%20text%2C%20image%20generation%2C%20code%2C%20document%20creation&amp;w=600&amp;h=200&amp;style=professional">
+            <p>Let&#x27;s start with the most popular form of interface: a chatbot, which in the past year have become much more than just chatbots. ChatGPT is the prime example of a chatbot and when it was first released all it could do was chat. Now we have easy access to many different chatbots which can not only chat, but can also produce documents, write code, execute code, help you manage projects, create images, and more.</p>
+
+            <div>
+            <h3>Prominent Chatbot Platforms</h3>
+
+            <p>Here is an illustrative list of chatbots, each typically leveraging their own Large Language Models (LLMs). This list doesn&#x27;t include chatbots that solely use another company&#x27;s LLM:</p>
+
+            <ul>
+            	<li><a href="https://chatgpt.com/" rel="noopener noreferrer" target="_blank">ChatGPT (OpenAI)</a></li>
+            	<li><a href="https://gemini.google.com/app" rel="noopener noreferrer" target="_blank">Google Gemini</a></li>
+            	<li><a href="https://claude.ai/" rel="noopener noreferrer" target="_blank">Claude (Anthropic)</a></li>
+            	<li><a href="https://www.meta.ai/" rel="noopener noreferrer" target="_blank">Llama (Meta)</a></li>
+            	<li><a href="https://mistral.ai/" rel="noopener noreferrer" target="_blank">Mistral</a></li>
+            	<li><a href="https://www.deepseek.com/" rel="noopener noreferrer" target="_blank">Deepseek</a></li>
+            	<li><a href="https://x.ai/grok" rel="noopener noreferrer" target="_blank">Grok (xAI)</a></li>
+            	<li><a href="https://github.com/QwenLM" rel="noopener noreferrer" target="_blank">Qwen (Alibaba)</a></li>
+            	<li><a href="https://www.01.ai/" rel="noopener noreferrer" target="_blank">Yi (01.AI)</a></li>
+            	<li><a href="https://aws.amazon.com/q/" rel="noopener noreferrer" target="_blank">Amazon Q (AWS)</a></li>
+            </ul>
+
+            <p>Many other models and platforms exist, and the landscape is constantly evolving!</p>
+            </div>
+
+            <div>
+            <p><i></i>Rankings of these models are maintained on many different websites. A popular site for human-evaluated comparisons is the <a href="https://lmarena.ai/?leaderboard" rel="noopener noreferrer" target="_blank">Chatbot Arena LLM Leaderboard</a>, which focuses on blind ratings of text responses.</p>
+            </div>
+
+            <p>The rankings in the LLM Leaderboard are based solely on text responses, but there are many other dimensions on which to compare these chatbots. Let&#x27;s look at a comparison between three of the most popular: ChatGPT, Google Gemini, and Claude.</p>
+
+            <p>This comparison is strictly a comparison of features, not a judgment of how good the LLM is at generating the text you want (see the Chatbot Arena for that). In my opinion, you can&#x27;t go wrong with any of these three as far as the quality of responses go, so this comparison can help you decide which chatbot to use based on the extra features they have.</p>
+
+            <hr>
+            <div>
+            <h3><i></i>Quick Comparison: Key Takeaways</h3>
+
+            <p>Don&#x27;t have time for the full tables? Here&#x27;s a 20-second summary:</p>
+
+            <div>
+            <div>
+            <h4><i></i>Paid Versions</h4>
+
+            <ul>
+            	<li><i></i><strong>ChatGPT:</strong> Has the most features (image/video generation, Python interpreter, Custom GPTs, web search, Canvas).</li>
+            	<li><i></i><strong>Claude:</strong> Best for content creation (Projects and Artifacts), strong for long documents.</li>
+            	<li><i></i><strong>Gemini:</strong> Massive context window and strong Google ecosystem integration.</li>
+            </ul>
+            </div>
+
+            <div>
+            <h4><i></i>Free Versions</h4>
+
+            <ul>
+            	<li><i></i><strong>ChatGPT:</strong> Accessible without login. Access to shared Custom GPTs.</li>
+            	<li><i></i><strong>Claude:</strong> Often generous with features available in its free tier compared to others.</li>
+            	<li><i></i><strong>Gemini:</strong> Typically less restricted in terms of number of messages/day.</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Detailed Feature Comparison</h2>
+            <p>Below is a detailed look at the features of the paid and free versions of ChatGPT, Claude, and Google Gemini. Note that features and availability can change rapidly.<br>
+            Last update: May 8, 2025.</p>
+
+            <h4>Comparison of Paid Versions</h4>
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Feature Category</th>
+            			<th>Feature</th>
+            			<th>ChatGPT (Plus/Team)</th>
+            			<th>Google Gemini (Advanced)</th>
+            			<th>Claude (Pro/Team)</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><strong>Core Capabilities</strong></td>
+            			<td><strong>LLMs Available</strong></td>
+            			<td>GPT-4o, GPT-4o mini, GPT4.5, o3, o4-mini</td>
+            			<td>Gemini 1.5 Pro, Gemini 1.5 Flash, (Ultra via API)</td>
+            			<td>Claude 3.7 Sonnet, Claude 3.5 Sonnet, Claude 3 Opus, Claude 3.5 Haiku</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Context Window</strong></td>
+            			<td>~128K tokens (GPT-4o)</td>
+            			<td>~1M tokens (Gemini 1.5 Pro)</td>
+            			<td>~200K tokens</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Web Search</strong></td>
+            			<td>Yes (Browse with Bing)</td>
+            			<td>Yes (Google Search integration)</td>
+            			<td>Yes </td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Voice Mode</strong></td>
+            			<td>Voice input &amp; voice-voice conversations</td>
+            			<td>Voice input &amp; voice-voice (via app)</td>
+            			<td>Voice input (via app)</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Code</strong></td>
+            			<td><strong>Code Writing</strong></td>
+            			<td>Yes</td>
+            			<td>Yes</td>
+            			<td>Yes</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Code Execution</strong></td>
+            			<td>Yes (Python interpreter in Code Interpreter)</td>
+            			<td>Yes (Python interpreter)</td>
+            			<td>Yes (Front-end code via Artifacts)</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Files</strong></td>
+            			<td><strong>File Upload</strong></td>
+            			<td>Yes (various formats)</td>
+            			<td>Yes (various formats, Google Drive)</td>
+            			<td>Yes (various formats)</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Creative &amp; Visual</strong></td>
+            			<td><strong>Image Generation</strong></td>
+            			<td>Yes</td>
+            			<td>Yes (Imagen 3)</td>
+            			<td>No (but can analyze images)</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Video Generation</strong></td>
+            			<td>Yes (Sora, limited access)</td>
+            			<td>Yes (Veo2)</td>
+            			<td>No</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Customization</strong></td>
+            			<td><strong>Custom Instructions/Memory</strong></td>
+            			<td>Yes (Custom Instructions, Memory)</td>
+            			<td>Yes (Custom Instructions)</td>
+            			<td>Yes (Custom Instructions, Pre-prompts)</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Reusable Prompts/Assistants</strong></td>
+            			<td>Yes (Custom GPTs)</td>
+            			<td>Yes (Gems )</td>
+            			<td>Yes (Projects, Prompt Library)</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Access &amp; Platforms</strong></td>
+            			<td><strong>Mobile App</strong></td>
+            			<td>Yes (iOS, Android)</td>
+            			<td>Yes (Gemini app for Android, via Google App on iOS)</td>
+            			<td>Yes (iOS, Android - rolling out)</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Browser Extension</strong></td>
+            			<td>Yes (Official &amp; third-party)</td>
+            			<td>Yes (Official &amp; third-party)</td>
+            			<td>Fewer official options, some third-party</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Message Limits</strong></td>
+            			<td>GPT-4o: Higher limits; GPT-4: ~40 msgs/3 hrs</td>
+            			<td>Generally high, unspecified</td>
+            			<td>Higher limits, varies by model &amp; load</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Practical Considerations</strong></td>
+            			<td><strong>Privacy Features</strong></td>
+            			<td>Option to disable chat history/training</td>
+            			<td>Activity controls, option to disable saving</td>
+            			<td>Data not used for training by default for paid</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Other Unique Features</strong></td>
+            			<td> </td>
+            			<td>Canvas, Data Analysis, Apple Intelligence integration (upcoming)</td>
+            			<td>Google Workspace/Ecosystem integration (Maps, Flights, Hotels, YouTube)</td>
+            			<td>Artifacts for interactive content, strong long-context summarization</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Cost (approx.)</strong></td>
+            			<td> </td>
+            			<td>$20 USD/month</td>
+            			<td>~$20 USD/month (or regional equivalent)</td>
+            			<td>$20 USD/month</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <h4>Comparison of Free Versions</h4>
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Feature Category</th>
+            			<th>Feature</th>
+            			<th>ChatGPT</th>
+            			<th>Google Gemini</th>
+            			<th>Claude</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><strong>Core Capabilities</strong></td>
+            			<td><strong>LLMs Available</strong></td>
+            			<td>GPT-4o (rate-limited)</td>
+            			<td>Gemini 2.5 Flash and Pro (rate-limited), Gemini 2.0 Flash</td>
+            			<td>Claude 3.7 Sonnet (rate-limited)</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Context Window</strong></td>
+            			<td>~128K (GPT-4o), ~16K (GPT-3.5)</td>
+            			<td>~1M (Gemini 1.5 Flash, limited), ~32K (Gemini 1.0 Pro)</td>
+            			<td>~200K tokens (generous for free tier)</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Web Search</strong></td>
+            			<td>Yes (GPT-4o, limited)</td>
+            			<td>Yes</td>
+            			<td>Limited/No</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Code</strong></td>
+            			<td><strong>Code Writing</strong></td>
+            			<td>Yes</td>
+            			<td>Yes</td>
+            			<td>Yes</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Code Execution</strong></td>
+            			<td>Limited (via GPT-4o if available)</td>
+            			<td>No</td>
+            			<td>Limited (Artifacts, if available)</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Files</strong></td>
+            			<td><strong>File Upload</strong></td>
+            			<td>Yes (GPT-4o, limited)</td>
+            			<td>Yes (limited types/size)</td>
+            			<td>Yes (limited)</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Creative &amp; Visual</strong></td>
+            			<td><strong>Image Generation</strong></td>
+            			<td>Yes (GPT-4o, DALL·E, limited)</td>
+            			<td>Yes (limited)</td>
+            			<td>No</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Video Generation</strong></td>
+            			<td>Yes (Sora)</td>
+            			<td>No</td>
+            			<td>No</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Customization</strong></td>
+            			<td><strong>Custom Instructions/Memory</strong></td>
+            			<td>Yes (Custom Instructions, Memory)</td>
+            			<td>Yes (Custom Instructions)</td>
+            			<td>Limited/No</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Reusable Prompts/Assistants</strong></td>
+            			<td>Access to some shared Custom GPTs</td>
+            			<td>No</td>
+            			<td>No</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Access &amp; Platforms</strong></td>
+            			<td><strong>Mobile App</strong></td>
+            			<td>Yes</td>
+            			<td>Yes</td>
+            			<td>Yes (rolling out)</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Login Required</strong></td>
+            			<td>Optional for basic use, required for history/GPTs</td>
+            			<td>Required</td>
+            			<td>Required</td>
+            		</tr>
+            		<tr>
+            			<td> </td>
+            			<td><strong>Message Limits</strong></td>
+            			<td>Rate limits, especially on GPT-4o</td>
+            			<td>Generally more generous daily limits</td>
+            			<td>Daily limits, resets periodically</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Practical Considerations</strong></td>
+            			<td><strong>Privacy Features</strong></td>
+            			<td>Option to disable chat history/training</td>
+            			<td>Activity controls</td>
+            			<td>Data may be used for training unless opted out (check policy)</td>
+            		</tr>
+            	</tbody>
+            </table>
+            </div>
+
+            <hr>
+            <div>
+            <p>Regardless of which chatbot you choose, each offers powerful AI capabilities that can enhance your productivity and creativity. The free versions provide a great starting point for exploring AI assistance, while the paid versions unlock additional features that may be worth the investment depending on your specific needs. The key is to <strong>experiment with different options</strong> and find the one that best matches your workflow. Remember that these platforms are rapidly evolving, with new features and capabilities being added regularly, so it&#x27;s worth staying informed about updates and changes to make the most of these powerful AI assistants.</p>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+
+            <div>
+            <div>
+            <h1><i></i>Harnessing Specialty AI Tools</h1>
+
+            <div><img alt="Abstract representation of various specialized AI tools interacting" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract%20network%20of%20interconnected%20AI%20tools%20for%20education%2C%20glowing%20nodes%2C%20clean%20design&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
+            <div>
+            <p>Specialty tools harness <span>generative AI</span> for specific purposes beyond basic text, image, or audio generation. These tools build upon LLMs and other <span>AI</span> models, adding specialized functionality to serve particular needs. For example, some <span>AI</span>-powered search engines not only find information but also synthesize and summarize results. While specialty tools exist for various industries—from legal services (<a href="https://www.harvey.ai/" rel="noopener noreferrer" target="_blank">Harvey</a>) to fitness planning (Fitbod) to software development (<a href="https://github.com/features/copilot" rel="noopener noreferrer" target="_blank">Github Copilot</a>) —the following tools are particularly valuable for enhancing learning and education.</p>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>NotebookLM</h3>
+
+            <p>After falling behind OpenAI, Anthropic, and others, Google finally has an <span>AI</span> product worthy of discussion and at least some of your attention. <a href="https://notebooklm.google.com/" rel="noreferrer noopener" target="_blank">NotebookLM</a> is an experimental tool that is billed to “help users read, take notes, ask questions, and organise ideas”, but that doesn’t really capture the use cases that are blowing up on Twitter. One of the primary use cases is as a multimodal summarizer/tutor. With multimodal meaning that you can provide input in different modes (text, images, slides etc.) and you can get output in a couple of different modes too. You will get a summary of everything you upload plus you can ask questions about the content. But what everyone on the socials is excited about is the “podcast” button…NotebookLM will turn the content that you created into a podcast that is actually not bad. The podcast is a conversation between two fairly realistic and expressive <span>AI</span> voices about whatever you uploaded.</p>
+
+            <p>Of course, things aren’t perfect – the “podcasters” really like to use analogies which don’t always land, they often miss nuance, and some users have identified potential gender <span>bias</span> in the conversation (there are two podcaster voices, one male and one female, and one user identified that “the female character had indicated agreement with the male six times before the male voice indicated agreement with her even once”). On top of that, there are only two voices, so currently, every “podcast” created by NotebookLM has the same two hosts and I can imagine getting tired of them after a bit.</p>
+
+            <p>Summarizing content and even creating a podcast are both doable in ChatGPT, Claude etc. But the focus of NotebookLM on summarizing and question answering makes the user experience of NotebookLM easier and more enjoyable. Plus it is currently completely free and each notebook supports document upload of about 750,000 words.</p>
+
+            <figure><img alt="NotebookLM Screenshot" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/NotebookLMScreens.png">
+            <figcaption>The NotebookLM interface showing a notebook created from Dario Amodei&#x27;s essay &quot;Machines of Loving Grace.</figcaption>
+            </figure>
+
+            <ol>
+            	<li>Go to <a href="https://notebooklm.google.com" rel="noreferrer noopener" target="_blank">https://notebooklm.google.com</a></li>
+            	<li>Click on “New notebook”</li>
+            	<li>Upload a document (PDF, .txt, or markdown only), link to a website or copy in some text and wait until it loads.</li>
+            	<li>You will get a summary, suggested questions, and an interface to ask questions and create notes about the content. Answers will be footnoted to point to where in the uploaded document the answers came from.</li>
+            	<li>Click on “* Notebook guide” at the bottom right to bring up the option to create an Audio Overview – the podcast. This will take a few minutes.</li>
+            </ol>
+
+            <p><em>I created a Notebook for a lab from one of my electronics courses and the audio overview that it created was actually good and made the lab seem kinda interesting. Even if you never use NotebookLM again, it’s worth trying out this “podcast” feature at least once.</em></p>
+
+            <div>
+            <h5>tl;dr</h5>
+
+            <p>Google’s first compelling <span>AI</span> entry is a free tool that summarizes uploads, answers questions and creates audio chats.</p>
+            <strong>How it works:</strong>
+
+            <ul>
+            	<li>Upload content</li>
+            	<li>Get summaries, ask questions</li>
+            	<li>Generate <span>AI</span> conversations (podcasts)</li>
+            </ul>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>Learn About: Google&#x27;s AI-Powered Learning Companion</h3>
+
+            <p><a href="https://learning.google.com/experiments/learn-about" rel="noopener noreferrer" target="_blank">Google&#x27;s <em>Learn About</em></a> is an experimental <span>AI</span> tool designed to enhance education through personalized, interactive experiences. Built on the LearnLM model, it aims to transform learning with features tailored to curiosity and exploration.</p>
+
+            <div>
+            <h5>Why it matters:</h5>
+
+            <ul>
+            	<li>It uses visual aids, context boxes, and interactive tools to deepen understanding.</li>
+            	<li>It&#x27;s designed for learners, it adapts to individual goals with personalized responses.</li>
+            </ul>
+            </div>
+
+            <figure><img alt="Google Learn About interface showing learning topics" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/LearnAbout.png">
+            <figcaption>The Google Learn About interface allows users to explore various topics with AI-powered explanations and interactive elements.</figcaption>
+            </figure>
+
+            <p> </p>
+
+            <h5>Key Features:</h5>
+
+            <ol>
+            	<li><strong>Interactive Learning:</strong> Detailed explanations paired with images, videos, and hands-on guides.</li>
+            	<li><strong>Educational Aids:</strong> Tools like &quot;common misconceptions&quot; and &quot;test your knowledge&quot; make it engaging.</li>
+            	<li><strong>Personalized Exploration:</strong> Supports questions, uploaded materials, and curated topics for tailored learning paths.</li>
+            	<li><strong>Visual Context:</strong> Responses come with textbook-style definitions and examples.</li>
+            </ol>
+
+            <h5>Who Can Use It:</h5>
+
+            <p><em>Learn About</em> is officially available in English for users 18+ in the U.S., and you’ll need a Google account to access it.</p>
+
+            <p><strong>Not in the US? Here’s a tip:</strong> Use a VPN to set your location to the States—the <a href="https://www.opera.com/download" rel="noopener noreferrer" target="_blank"><em>Opera browser</em></a> makes it super easy with its built-in VPN. 😉 Happy learning!</p>
+
+            <h5>Getting Started:</h5>
+
+            <ol>
+            	<li>Open the Opera browser with VPN enabled (or connect to another VPN in the US).</li>
+            	<li>Visit the <a href="https://learning.google.com/experiments/learn-about" rel="noopener noreferrer" target="_blank"><em>Learn About</em></a> website.</li>
+            	<li>Enter a query or upload documents/images.</li>
+            	<li>Dive into summaries, visuals, and quizzes.</li>
+            </ol>
+
+            <div>
+            <h5>tl;dr</h5>
+
+            <p>A free, <span>AI</span>-powered tool for interactive learning with visuals, quizzes, and personalized responses.</p>
+            <strong>How it works:</strong>
+
+            <ul>
+            	<li>Ask questions or upload materials.</li>
+            	<li>Get tailored explanations with videos, images, and definitions.</li>
+            	<li>Test your knowledge with engaging tools.</li>
+            </ul>
+
+            <p><strong>Pro tip:</strong> Use a VPN (like Opera’s) if you&#x27;re outside the U.S.</p>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>Perplexity: An Answer Engine</h3>
+
+            <p><a href="https://www.perplexity.ai" rel="noopener" target="_blank">Perplexity AI</a> uses a combination of search and conversational <span>AI</span> to give the user direct answers with cited sources, rather than just links.</p>
+
+            <figure><img alt="Perplexity search results showing sources and opening paragraph" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/PerplexityScreenshot.png">
+            <figcaption>Perplexity search results showing sources and opening paragraph.</figcaption>
+            </figure>
+
+            <h5>How it works:</h5>
+
+            <ul>
+            	<li>Combines <span>AI</span> language models with real-time web search</li>
+            	<li>Provides up-to-date information for current events</li>
+            	<li>Creates custom research pages from simple prompts</li>
+            	<li>Cites sources for fact-checking</li>
+            </ul>
+
+            <h5>Plans:</h5>
+
+            <ul>
+            	<li><strong>Free plan:</strong> Uses GPT-4o mini with web browsing</li>
+            	<li><strong>Pro plan:</strong> Adds access to advanced <span>AI</span> models (GPT-4, Claude 3.5, Grok-2) plus internal file search, image analysis, and image generation</li>
+            </ul>
+
+            <h5>Latest features:</h5>
+
+            <ul>
+            	<li>Shopping hub for product recommendations</li>
+            	<li>Internal knowledge search across documents</li>
+            	<li>Spaces: <span>AI</span>-powered collaboration hub</li>
+            </ul>
+
+            <div>
+            <h5>The bottom line:</h5>
+
+            <p>Perplexity <span>AI</span> streamlines research and information gathering for students, researchers, and content creators who need quick answers with links to the information source.</p>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>AI Writing Assistants: Grammarly and Quillbot</h3>
+
+            <p><a href="https://www.grammarly.com/" rel="noopener" target="_blank">Grammarly</a> and <a href="https://quillbot.com/" rel="noopener" target="_blank">Quillbot</a> are both <span>AI</span> writing assistants that check grammar, enhance style, generate content, and improve writing quality.</p>
+
+            <h5>By the numbers:</h5>
+
+            <ul>
+            	<li>Both tools have free and paid versions (Grammarly $12 US/month and Quillbot $8.33 US/month - annual billing).</li>
+            	<li>Core functions: Paraphrase, summarize.</li>
+            	<li>Available on: Browser, MS Word, Outlook, mobile.</li>
+            </ul>
+
+            <h5>What they do:</h5>
+
+            <ul>
+            	<li>Check grammar, spelling, and tone in real-time</li>
+            	<li>Paraphrase and summarize</li>
+            	<li>Suggest vocabulary improvements</li>
+            	<li>Detect plagiarism (Premium)</li>
+            	<li>Rewrite full sentences for clarity</li>
+            	<li>Adjust writing style by genre</li>
+            </ul>
+
+            <div>
+            <div>
+            <h5><i></i>Grammarly</h5>
+
+            <p>Focuses on perfecting English writing. Best for polishing grammar, tone, clarity, and inclusiveness. Integrates well with many apps and has excellent team features.</p>
+            </div>
+
+            <div>
+            <h5><i></i>Quillbot</h5>
+
+            <p>Excels at paraphrasing and supports multiple languages. Ideal for research, quick rewrites, and translation. Offers a robust summarization tool and citation generator.</p>
+            </div>
+            </div>
+
+            <div>
+            <h5><i></i>Reminder &amp; Trade-offs:</h5>
+
+            <p>These tools are meant to <em>support</em> your writing, not replace it. Over-reliance on <span>AI</span> can hinder your learning and may violate class policies regarding <span>AI</span> use. Use these tools responsibly!</p>
+            <strong>Consider these trade-offs:</strong>
+
+            <ul>
+            	<li><strong>Cost:</strong> Premium features are costly for individuals.</li>
+            	<li><strong>Context:</strong> <span>AI</span> suggestions aren’t always context-aware.</li>
+            	<li><strong>Annoying:</strong> Some find upgrade prompts intrusive.</li>
+            	<li><strong>Accuracy:</strong> Tools may occasionally make mistakes.</li>
+            </ul>
+
+            <p>The free versions handle basic needs well. Premium versions unlock powerful features for serious writers, but success still depends on your judgment and skill.</p>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>AI Supported Research Tools</h3>
+
+            <details open=""><summary>About These Tools (Source: Georgetown University Library)</summary>
+
+            <div>
+            <p>This section comes from Georgetown University Library (<a href="https://guides.library.georgetown.edu/ai/tools" rel="noopener noreferrer" target="_blank">original</a>) and is licensed under a <a href="https://creativecommons.org/licenses/by-nc/4.0/" rel="noopener noreferrer" target="_blank">Creative Commons Attribution NonCommercial 4.0 International License</a>.</p>
+
+            <p><span>AI</span> tools for research can help you to discover new sources for your literature review or research assignment. These tools will synthesize information from large databases of scholarly output with the aim of finding the most relevant articles and saving researchers’ time. As with our research databases or any other search tool, however, it’s important not to rely on one tool for all of your research, as you will risk missing important information on your topic of interest.Placeholder: Abstract graphic representing a network of research papers or data analysis, or a collage of logos for Elicit, Consensus, etc. </p>
+            </div>
+            </details>
+
+            <figure><img alt="Abstract graphic representing research tools" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ResearchToolsGraphic.png">
+            <figcaption>AI research tools provide access to databases that are not directly accessible via websearch.</figcaption>
+            </figure>
+
+            <div>
+            <table>
+            	<thead>
+            		<tr>
+            			<th>NAME</th>
+            			<th>WHAT IT DOES</th>
+            			<th>UNDERLYING DATA</th>
+            			<th>IS IT FREE?</th>
+            			<th>MORE INFORMATION</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><a href="https://elicit.com/" rel="noopener" target="_blank">Elicit</a></td>
+            			<td>Using large language models (LLMs), Elicit finds papers relevant to your topic by searching through papers and citations and extracting and synthesizing key information.</td>
+            			<td>Semantic Scholar Database</td>
+            			<td>Free with paid subscriptions available.</td>
+            			<td><a href="https://elicit.com/#FAQ" rel="noopener" target="_blank">Elicit FAQs</a></td>
+            		</tr>
+            		<tr>
+            			<td><a href="https://consensus.app/search/" rel="noopener" target="_blank">Consensus</a></td>
+            			<td>Similar to Elicit, Consensus uses LLMs to help researchers find and synthesize answers to research questions, focusing on the scholarly authors’ findings and claims in each paper.</td>
+            			<td>Semantic Scholar Database</td>
+            			<td>Free (20 searches/month); Paid version allows unlimited searching.</td>
+            			<td><a href="https://consensus.app/home/blog/welcome-to-consensus/" rel="noopener" target="_blank">Consensus FAQs</a></td>
+            		</tr>
+            		<tr>
+            			<td><a href="https://www.semanticscholar.org/" rel="noopener" target="_blank">Semantic Scholar</a></td>
+            			<td>Semantic Scholar (which supplies underlying data for many of the other tools on this list) provides brief summaries (‘TLDR’s) of the main objectives and results of papers.</td>
+            			<td>Semantic Scholar Database</td>
+            			<td>Semantic Scholar is currently free.</td>
+            			<td><a href="https://www.semanticscholar.org/faq" rel="noopener" target="_blank">Semantic Scholar FAQs</a></td>
+            		</tr>
+            		<tr>
+            			<td><a href="https://www.researchrabbit.ai/" rel="noopener" target="_blank">Research Rabbit</a></td>
+            			<td>Research Rabbit is a citation-based mapping tool that focuses on the relationships between research works. It uses visualizations to help researchers find similar papers and other researchers in their field.</td>
+            			<td>Research Rabbit uses multiple databases, but does not name them (more information can be found on the <a href="https://researchrabbit.notion.site/Welcome-to-the-FAQ-c33b4a61e453431482015e27e8af40d5#c1b5f1fe3f844c12ae32b453ff295964" rel="noopener" target="_blank">FAQ page</a>).</td>
+            			<td>Research Rabbit is currently free.</td>
+            			<td><a href="https://researchrabbit.notion.site/Welcome-to-the-FAQ-c33b4a61e453431482015e27e8af40d5#c1b5f1fe3f844c12ae32b453ff295964" rel="noopener" target="_blank">Research Rabbit FAQs</a></td>
+            		</tr>
+            		<tr>
+            			<td><a href="https://www.connectedpapers.com/" rel="noopener" target="_blank">Connected Papers</a></td>
+            			<td>Like Research Rabbit, Connected Papers focuses on the relationships between research papers to find similar research. You can also use Connected Papers to get a visual overview of an academic field.</td>
+            			<td>Semantic Scholar Database</td>
+            			<td>Free (5 graphs/month); paid version allows unlimited graphing.</td>
+            			<td><a href="https://www.connectedpapers.com/about" rel="noopener" target="_blank">Connected Papers – About</a></td>
+            		</tr>
+            		<tr>
+            			<td><a href="https://scite.ai/home" rel="noopener" target="_blank">scite</a></td>
+            			<td>scite has a suite of products that help researchers develop their topics, find papers, and search citations in context (describing whether the article provides supporting or contrasting evidence)</td>
+            			<td>Many different sources (an incomplete list can be found <a href="https://help.scite.ai/en-us/article/where-do-you-get-your-articles-from-1vglydm/" rel="noopener" target="_blank">on this page</a>)</td>
+            			<td>No. (<a href="https://scite.ai/pricing" rel="noopener" target="_blank">Pricing information</a>)</td>
+            			<td><a href="https://help.scite.ai/en-us/" rel="noopener" target="_blank">scite FAQs</a>; <a href="https://direct.mit.edu/qss/article/2/3/882/102990/scite-A-smart-citation-index-that-displays-the" rel="noopener" target="_blank">how scite works</a></td>
+            		</tr>
+            		<tr>
+            			<td><a href="https://www.scholarcy.com/" rel="noopener" target="_blank">Scholarcy</a></td>
+            			<td>Scholarcy summarizes key points and claims of articles into ‘summary cards’ that researchers can read, share, and annotate when compiling research on a given topic.</td>
+            			<td>Scholarcy only uses <a href="https://www.scholarcy.com/scholarcy-features/" rel="noopener" target="_blank">research papers uploaded or linked by the researcher themselves</a>. It works as a way to help you read and summarize your research, but is not a search engine.</td>
+            			<td>Free (short articles only); Paid version allows articles of any length.</td>
+            			<td><a href="https://www.scholarcy.com/faq/" rel="noopener" target="_blank">Scholarcy FAQs</a></td>
+            		</tr>
+            		<tr>
+            			<td><a href="https://chat.openai.com/auth/login" rel="noopener" target="_blank">ChatGPT</a></td>
+            			<td>While the <span>AI</span> chatbot ChatGPT is typically thought of as a writing tool, it can be used in the initial idea development phase of research, and can also be of use in finding further sources. (Remember to always look up sources to verify their credibility.)</td>
+            			<td>The <a href="https://help.openai.com/en/articles/8077698-how-do-i-use-chatgpt-browse-with-bing-to-search-the-web" rel="noopener" target="_blank">paid versions of ChatGPT are currently connected to the internet through Bing</a>. The free version was trained on data last updated in September 2021, but that might change in the future.</td>
+            			<td>There is a free version available.</td>
+            			<td><a href="https://help.openai.com/en/collections/3742473-chatgpt" rel="noopener" target="_blank">OpenAI Help Center – ChatGPT</a></td>
+            		</tr>
+            	</tbody>
+            </table>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>Gamma and Other AI Presentation Tools</h3>
+
+            <p><a href="https://gamma.app" rel="noopener noreferrer" target="_blank">Gamma</a> is an <span>AI</span> presentation tool that may be worth the switch from ChatGPT or Claude, especially if you&#x27;re design-challenged. Unlike general <span>AI</span> tools, Gamma excels at design-focused tasks, creating polished presentations from simple prompts or content.</p>
+
+            <h5>How it works:</h5>
+
+            <ul>
+            	<li>Input your content or idea</li>
+            	<li><span>AI</span> handles both design and layout</li>
+            	<li>Creates presentations, docs, or websites</li>
+            	<li>Suggests color schemes and themes automatically</li>
+            </ul>
+
+            <h5>Pricing:</h5>
+
+            <ul>
+            	<li><strong>Free:</strong> Basic features with Gamma branding</li>
+            	<li><strong>$10/month:</strong> More design credits, no branding</li>
+            </ul>
+
+            <div>
+            <h5>The bottom line:</h5>
+
+            <p>If Canva and ChatGPT had a baby, it would be Gamma. It&#x27;s particularly valuable for those who want professional-looking presentations without design expertise.</p>
+            </div>
+
+            <h5>Other Options:</h5>
+
+            <p>These are apps with similar capabilities as Gamma that may be worth checking out:</p>
+
+            <ul>
+            	<li><strong>Beautiful.ai:</strong> 14 day trial then $144 US/year</li>
+            	<li><strong>Microsoft Copilot in Powerpoint:</strong> requires Microsoft 365 account plus Copilot subscription</li>
+            	<li><strong>Google Gemini in Google Slides:</strong> requires Gemini Advanced Account</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+                <p>Image generators turn your description into a picture—often in seconds. They’re fun to explore and incredibly useful for drafts, lesson visuals, diagrams, and design experiments. Quality has improved rapidly, but getting the exact image you want still takes iteration: broad scenes (e.g., “students studying at a table”) are easy; precise details (e.g., “three students at one table—one with a laptop, two on phones”) usually require prompt refinement.</p>
+
+            <p>A quick note on impact: generating images uses substantial compute—meaning energy and water. Before spinning up dozens of variations “just to see,” consider whether a smaller batch or a stock photo would do. For perspective, the What Uses More? calculator compares the footprint of AI image generation with everyday digital activities: <a href="https://what-uses-more.com/" rel="noopener" target="_blank">what-uses-more.com</a>.</p>
+
+            <p> </p>
+            <hr>
+
+            <h4><img alt="Cute robot doing art" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/electronaxe_happy_robot_artist_drawing_a_picture_view_is_over_i_a17296d1-939e-4db8-9d78-23c323d7e32d.png">Midjourney</h4>
+
+
+            <p><strong>Company</strong>: Midjourney<br>
+            <strong>Available through:</strong> <a href="https://www.midjourney.com/">https://www.midjourney.com/</a> and Midjourney bot on Discord<br>
+            <strong>Cost</strong>: Varies: free, $10-$120 US/month. I would recommend the $10/month subscription<br>
+            <strong>Summary</strong>: Midjourney produces some of the most striking pictures, but it is challenging to get the exact details you want. Originally only available through Discord, you can now generate images on the Midjourney website. Midjourney has several models to choose from including one that is specifically trained on anime. There is no free subscription.<br>
+            <strong>Pros</strong>: Excellent image quality. Several different models. Can edit pictures.<br>
+            <strong>Cons</strong>: No free access. Can only edit pictures on yearly subscription.</p>
+
+            <hr>
+            <h4>DALL-E<img alt="Dali style picture with melting computer in desert" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/DALL·E_2023-10-14_11.34.51_-_A_melting_laptop_is_showcased_on_a_desk__its_keys_dripping_like_liquid_metal._Beside_the_laptop__a_peculiar__warped_clock_casts_elongated__dream-like_.png"></h4>
+
+            <p><strong>Company</strong>: OpenAI<br>
+            <strong>Available through:</strong> Microsoft Copilot and ChatGPT<br>
+            <strong>Cost</strong>: Varies. Free. More images with ChatGPT Plus<br>
+            <strong>Summary</strong>: Named as a play on Salvador Dali and WALL-E. In my opinion, DALL-E images are not as good as the other generators listed here, but it does a good job handling text within the image. To support users, both the Copilot version and the ChatGPT version will enhance your prompts and show you the updated prompt for each picture that you create.<br>
+            <strong>Pros</strong>: Good text rendering. Free on Microsoft and ChatGPT. Automatically enhances/improves your prompts<br>
+            <strong>Cons</strong>: Free access on ChatGPT is very limited. Image quality is okay</p>
+
+            <hr>
+            <h4><img alt="Mascot holding sign saying &quot;Ideogram&quot;" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ideogram_mascot.png">Ideogram</h4>
+
+            <p> </p>
+
+            <p><strong>Company</strong>: Ideogram<br>
+            <strong>Available through:</strong> https://ideogram.ai<br>
+            <strong>Cost</strong>: Varies: free (up to 40 images/day), $8-$60 US/month (up to 14,000 images/month)<br>
+            <strong>Summary</strong>: Ideogram is a new company, even in the world of AI. It was founded in August 2023 and is competitive with leading image generators like Midjourney and Dall-E (arguably better than Dall-E but worse than Midjourney). It does a great job. Can edit pictures.<br>
+            <strong>Pros</strong>: Excellent image quality. Renders text accurately.<br>
+            <strong>Cons</strong>: Free access is very slow</p>
+
+            <p> </p>
+
+            <hr>
+            <h4>FLUX<img alt="Up close picture of single tiger eye with &quot;Flux&quot; splashed across it" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/flux_tiger_eye_plus_text.png"></h4>
+
+            <p> </p>
+
+            <p><strong>Company</strong>: Black Forest Labs<br>
+            <strong>Available through:</strong> API or third party apps (e.g. <a href="https://chat.mistral.ai/chat">Le Chat from Mistral</a>)<br>
+            <strong>Cost</strong>: Varies. Free to ???<br>
+            <strong>Summary</strong>: Flux is another new image generator that is particularly adept at following the user instructions and generating text. Since it isn&#x27;t available directly from the provider except through an API, it can be hard to find.<br>
+            <strong>Pros</strong>: Good text rendering. Free access through multiple providers increases your daily limit. My favourite for quality after Midjourney. Some third party apps provide image editing tools<br>
+            <strong>Cons</strong>: Can be hard to find</p>
+
+            <hr>
+            <h4> </h4>
+
+            <h4><img alt="the word &quot;imagen&quot; written in trees" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/Gemini_Imagen_in_trees.jpg">Imagen</h4>
+
+            <p> </p>
+
+            <p><strong>Company</strong>: Google<br>
+            <strong>Available through:</strong> https://gemini.google.com<br>
+            <strong>Cost</strong>: Varies: free (up to ?? images/day). More images with $26/month Gemini Advanced subscription<br>
+            <strong>Summary</strong>: Imagen 3 is the latest version of Google&#x27;s image generator. It is now built into Gemini, so free users can create images. There is a generation limit, but I can&#x27;t find it listed, haven&#x27;t hit it yet after 20 images.<br>
+            <strong>Pros</strong>: Excellent image quality, lots of images with free version<br>
+            <strong>Cons</strong>: Many of the features of Imagen (e.g., customization, image editing) are not generally available. Can&#x27;t create pictures of people on free version</p>
+
+            <hr>
+            <h4 id="adobe-firefly"><img alt="Placeholder for Adobe Firefly image" loading="lazy" src="https://via.placeholder.com/200"> Adobe Firefly</h4>
+
+            <p><strong>Company</strong>: Adobe<br>
+            <strong>Available through:</strong> <a href="https://firefly.adobe.com" rel="noopener" target="_blank">firefly.adobe.com</a> and Creative Cloud apps (Photoshop, Illustrator, Express)<br>
+            <strong>Cost</strong>: Generative credits included with Creative Cloud plans (allowances vary by plan; see Adobe’s Generative Credits table). Firefly on the web also offers a free tier with limited credits. Example plan prices (US): Photoshop $22.99/month; Creative Cloud All Apps $59.99/month. See Adobe’s pricing pages for current regional pricing and credit allotments<br>
+            <strong>Summary</strong>: Firefly’s Image 3 model powers Generative Fill and related tools across Adobe apps. Emphasis on commercially safer outputs (trained on Adobe Stock and licensed data) and Content Credentials for provenance. Excellent for inpainting/outpainting and design‑ready assets within familiar workflows.<br>
+            <strong>Pros</strong>: Rights-conscious training; tight Photoshop/Illustrator integration; strong inpainting; Content Credentials; enterprise options<br>
+            <strong>Cons</strong>: Credit limits can throttle heavy use; some styles/text rendering trail tools focused on typography/logos; requires Adobe account</p>
+
+            
+
+            <hr>
+            <h4 id="stable-diffusion"><img alt="Placeholder for Stable Diffusion image" loading="lazy" src="https://via.placeholder.com/200"> Stable Diffusion (SDXL / SD3)</h4>
+
+            <p><strong>Company</strong>: Stability AI and the open‑source community<br>
+            <strong>Available through:</strong> Hosted UIs/APIs (e.g., DreamStudio, Playground AI). Can also be run on local hardware<br>
+            <strong>Cost</strong>: Local use can be free (you provide hardware). Hosted services use credits/subscriptions with their own free tiers/limits. Pricing varies by provider (e.g., pay‑as‑you‑go on DreamStudio; free + paid tiers on Playground). Check the chosen host for current rates and daily limits<br>
+            <strong>Summary</strong>: The Stable Diffusion family offers maximum control and extensibility—run locally and fine‑tune for domain styles. <br>
+            <strong>Pros</strong>: Full control/customization; offline/local options; vast model ecosystem; cost‑efficient at scale<br>
+            <strong>Cons</strong>: Setup complexity; output quality depends on model/config; licensing/compliance varies across community models; text rendering inconsistent without specialized checkpoints</p>
+
+            
+
+            <hr>
+            <h4 id="leonardo"><img alt="Placeholder for Leonardo image" loading="lazy" src="https://via.placeholder.com/200"> Leonardo</h4>
+
+            <p><strong>Company</strong>: Leonardo AI<br>
+            <strong>Available through:</strong> <a href="https://leonardo.ai" rel="noopener" target="_blank">https://leonardo.ai</a><br>
+            <strong>Cost</strong>: Free tier (daily tokens). Paid plans (US monthly) starting at $12.<br>
+            <strong>Summary</strong>: A creator‑focused platform for concept art, game assets, and stylized illustrations. Robust canvas editor, inpainting/outpainting, upscaling, background removal, and workflow tools. Supports training/customization for brand or project styles.<br>
+            <strong>Pros</strong>: Strong editor and upscaling; asset‑oriented workflows; style libraries; custom training; active community<br>
+            <strong>Cons</strong>: Free tier can be queued/slow; review licensing/training policy for commercial use; more iteration needed for photorealism vs. top photoreal models</p>
+
+            
+
+            <hr>
+            <h4 id="canva"><img alt="Placeholder for Canva image" loading="lazy" src="https://via.placeholder.com/200"> Canva (Magic Media — Text to Image)</h4>
+
+            <p><strong>Company</strong>: Canva<br>
+            <strong>Available through:</strong> <a href="https://www.canva.com" rel="noopener" target="_blank">https://www.canva.com</a> (Magic Media &gt; Text to Image; integrated in the Canva editor)<br>
+            <strong>Cost</strong>: Credit‑based generation. Published monthly AI credit allowances (US): Free plan ~50 credits/month; Pro $12.99/month with ~500 credits/month; Teams pricing varies with ~500 credits per seat/month. Education/Nonprofit plans have distinct allowances—see Canva’s help/pricing pages for current figures<br>
+            <strong>Summary</strong>: Canva is a full featured graphic design platform with integrated image generator for quick compositions, class materials, and social/marketing visuals. <br>
+            <strong>Pros</strong>: Easy to use; template‑rich; collaborative; fast to production‑ready layouts; no context switching<br>
+            <strong>Cons</strong>: Less fine‑grained control/ultimate quality than specialist tools; text rendering can be hit‑or‑miss; credit limits apply</p>
+
+            
+
+
+                </div><div>
+
+
+            <div>
+            <div>
+            <h1 id="top"><i></i> Generative AI Videos</h1>
+
+            <div>
+            <p>Generative AI video systems create moving images from prompts, reference images, or existing footage—synthesizing scenes, camera moves, and effects that once required large crews or complex pipelines. In minutes, you can draft storyboards, visualize concepts, or prototype explainer clips that would have taken days.</p>
+
+            <p>The technology is improving rapidly: models are getting better at temporal consistency, object permanence, realistic physics, lip‑sync, and multi‑shot continuity. Controls are expanding too—keyframe conditioning, image‑to‑video, depth maps, masks, and “edit by prompt” workflows give creators more precise handles on motion, look, and pacing.</p>
+            </div>
+
+            <div id="downsides">
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Downsides, Costs, and Risks</h2>
+            <div>
+            <p><i></i> <strong>Environmental cost:</strong> Training and large‑scale generation can consume significant energy and water. Before using video generators keep the environmental cost in mind and find ways to minimize impact (e.g., settings, shorter drafts, batched renders, and provider options that disclose sustainability practices)</p>
+            </div>
+
+            <div>
+            <p><i></i> <strong>Copyright and training data:</strong> Many providers face scrutiny over whether training data included copyrighted works without permission. </p>
+            </div>
+
+            <div>
+            <p><i></i> <strong>Deepfakes and deception:</strong> AI can fabricate convincing people and events. Always obtain consent, avoid impersonation, and label AI‑generated or AI‑edited content. Also, always be aware that media you consume may be a deepfake</p>
+            </div>
+
+            <ul>
+            	<li><strong>Bias and representation:</strong> Models may reproduce stereotypes unless you guide outputs and review critically.</li>
+            	<li><strong>Privacy:</strong> Avoid uploading sensitive footage; follow your organization’s data policies.</li>
+            	<li><strong>Overreliance:</strong> Treat AI as a creative partner—not a replacement for domain expertise, verification, and ethics.</li>
+            </ul>
+
+            <div>
+            <h5><i></i>Responsible Use—Quick Checklist</h5>
+
+            <p>Label AI involvement, get consent from identifiable people, use assets you have rights to, keep a record of prompts and sources, and verify factual claims if your video informs or instructs.</p>
+            </div>
+            </div>
+
+            <div id="tools-table">
+        </section>
+        <section class="gai-box">
+            <h2><i></i>Generative AI Video Tools</h2>
+            <p>Here is a a concise comparison of some popular AI video generators, with access details, strengths, trade‑offs, and common use cases.</p>
+
+            <div aria-label="Generative AI video tools comparison">
+            <table>
+            	<caption>AI Video Tools Comparison</caption>
+            	<thead>
+            		<tr>
+            			<th scope="col">AI Video Tool</th>
+            			<th scope="col">Access &amp; Pricing</th>
+            			<th scope="col">Key Pros</th>
+            			<th scope="col">Key Cons</th>
+            			<th scope="col">Typical Use Cases</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><strong>Google Veo 3</strong></td>
+            			<td>Access via Vertex AI (Veo 3 Fast available). Also integrated into Canva’s “Create a Video Clip.” Pricing and quotas vary by Google Cloud usage; Google AI Pro plan</td>
+            			<td>State-of-the-art realism; native audio (music/FX/dialogue).</td>
+            			<td>Short clips; expensive; </td>
+            			<td>Fun creative shorts, storyboarding, filmmaker prototyping.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Runway (Gen-3 current)</strong></td>
+            			<td>Web platform with free trial and paid plans (≈$15+/mo). API available.</td>
+            			<td>Generates short 1080p clips; strong editing suite (inpainting, keyframes, masking, timeline tools).</td>
+            			<td>No native audio; short durations; multiple attempts often needed for best results.</td>
+            			<td>Artistic shorts, music video visuals, indie pre‑viz.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>OpenAI Sora</strong></td>
+            			<td>Available with ChatGPT Plus and Pro via sora.com. </td>
+            			<td>Can create longer clips (up to ~20s) and supports workflows like storyboard, looping, and remixing.</td>
+            			<td>No free tier.</td>
+            			<td>Experimental creative exploration, imaginative short scenes.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Kling AI (Kuaishou)</strong></td>
+            			<td>Web tool (app.klingai.com). Free credits available; paid plans around ~$10/mo reported; exact credits/tiers vary by region and time.</td>
+            			<td>Cinematic‑style clips; supports dynamic camera movement; generally affordable.</td>
+            			<td>No audio; short clips; free tier limits.</td>
+            			<td>Budget‑friendly cinematic videos, music visuals, storyboards.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Alibaba Qwen (Tongyi Video)</strong></td>
+            			<td>Free access on the Qwen web interface observed; clip length short; watermark/unlimited status not officially specified on public docs.</td>
+            			<td>Fast to test ideas; accessible.</td>
+            			<td>Very short outputs; quality below leaders; limited controls/features.</td>
+            			<td>Learning, ideation, quick concept testing.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Adobe Firefly (Video)</strong></td>
+            			<td>Generate Video (beta) in Firefly web app; included in Firefly/Creative Cloud plans (starting at ~$9.99+/mo).</td>
+            			<td>Trained on licensed/Adobe Stock (commercially safer usage); smooth export to Premiere Pro/After Effects.</td>
+            			<td>Very short clips in beta (no official published number); beta quality; requires Adobe subscription.</td>
+            			<td>Professional b‑roll, marketing visuals, scene fillers.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Pika Labs</strong></td>
+            			<td>Web app (originally a Discord bot). Free trial credits (~300 common), paid plans ~$10–$60/mo.</td>
+            			<td>Simple to use; strong community sharing and re‑prompting.</td>
+            			<td>Outputs are animation‑style; no native audio.</td>
+            			<td>Casual fun, memes, educational demos.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Higgsfield</strong></td>
+            			<td>Web platform (higgsfield.ai). Free trial; Basic plan around $9/mo (e.g., 150 credits); higher tiers available.</td>
+            			<td>Sharp visual quality; useful preset effects/camera moves.</td>
+            			<td>Short clips; no native audio; stitching needed for longer content.</td>
+            			<td>Creative VFX shots, experimental b‑roll.</td>
+            		</tr>
+            	</tbody>
+            </table>
+            </div>
+
+            <p>Note: Capabilities, availability, and watermarking/provenance practices change quickly. Verify details if important.</p>
+            </div>
+            </div>
+            </div>
+
+
+
+                </div><div>
+                <p> </p>
+
+            <p>This Bingo Challenge is inspired by the <a href="https://opentextbc.ca/teachingandlearningwithai/" target="_blank">Gen AI in Teaching and Learning Toolkit </a>by Gwen Nguyen and this brief introduction is directly from that book (<a href="https://creativecommons.org/licenses/by-nc/4.0/deed.en" target="_blank"><span><span>CC BY-NC 4.0</span></span></a>). It encourages you to explore various generative AI tools, experimenting with both text-based and image generation platforms. By engaging with these tools, you can hopefully better understand their functionalities, applications, and limitations in educational settings.</p>
+
+            <p>Instructions:</p>
+
+            <ol>
+            	<li>Print or download the BINGO worksheet.</li>
+            	<li>Once you complete five challenges in a row (horizontally, vertically, or diagonally), you’ve achieved BINGO!</li>
+            	<li>For each tool you try, reflect on how it might be used or integrated into your teaching practice.</li>
+            </ol>
+
+            <table bgcolor="#FFFFFF" border="2" cellpadding="10" cellspacing="0" width="100%">
+            	<caption>
+        </section>
+        <section class="gai-box">
+            <h2>Student GenAI BINGO Challenge</h2>
+            </caption>
+            	<tbody>
+            		<tr bgcolor="#2c3e50">
+            			<th width="20%"><font color="white" size="5">B</font></th>
+            			<th width="20%"><font color="white" size="5">I</font></th>
+            			<th width="20%"><font color="white" size="5">N</font></th>
+            			<th width="20%"><font color="white" size="5">G</font></th>
+            			<th width="20%"><font color="white" size="5">O</font></th>
+            		</tr>
+            		<tr align="center">
+            			<td height="100">Use ChatGPT to explain a difficult concept</td>
+            			<td>Create study flashcards with an AI tool</td>
+            			<td>Use Claude to analyze a research paper</td>
+            			<td>Generate a mind map about a class topic using AI</td>
+            			<td>Write a poem about your field of study with AI</td>
+            		</tr>
+            		<tr align="center">
+            			<td height="100">Use Perplexity to fact-check information from ChatGPT</td>
+            			<td>Ask Gemini to help brainstorm essay topics</td>
+            			<td>Compare answers from 2 different AI tools on the same question</td>
+            			<td>Create an image that represents your major using DALL-E</td>
+            			<td>Break down a complex project into steps using Claude</td>
+            		</tr>
+            		<tr align="center">
+            			<td height="100">Use Claude to proofread your writing</td>
+            			<td>Create a presentation outline with Gamma</td>
+            			<td bgcolor="#3498db"><font color="white"><b>FREE SPACE<br>
+            			Try a new AI tool!</b></font></td>
+            			<td>Use AI to improve the clarity of your writing</td>
+            			<td>Use DeepL to translate your work into another language</td>
+            		</tr>
+            		<tr align="center">
+            			<td height="100">Ask AI to explain where it got its information</td>
+            			<td>Use AI to find relevant sources for your research</td>
+            			<td>Create a study schedule using an AI assistant</td>
+            			<td>Use AI to find counterarguments to your essay position</td>
+            			<td>Use NotebookLM to summarize your class notes</td>
+            		</tr>
+            		<tr align="center">
+            			<td height="100"><span block-id="element-2-14-content"><span block-id="element-element-0"><span block-id="element-element-0-inline-0">Ask multiple Gen AI tools to predict the future of your field in 5 years and compare responses</span></span></span></td>
+            			<td><span block-id="element-2-16-content"><span block-id="element-element-0"><span block-id="element-element-0-inline-0">Use AI to generate a &quot;survival guide&quot; for your most challenging course</span></span></span></td>
+            			<td>Create a visual summary of a chapter using Gen AI</td>
+            			<td>Use Gen AI to identify gaps in your research</td>
+            			<td>Ask AI to explain its limitations</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/learning-is-hard-and-its-supposed-to-be.html
+++ b/site/learning-is-hard-and-its-supposed-to-be.html
@@ -4,217 +4,254 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Learning is Hard - and it&#x27;s supposed to be - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="active has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li class="active"><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Learning is Hard - and it&#x27;s supposed to be</h2>
-        <div>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div id="gai-wrap">
-<div>
-<h1> </h1>
-
-<div>
-<p>Wouldn&#x27;t it be fantastic if we could achieve mastery of our subject without effort - like Neo in the Matrix plugging the computer into his brain to instantly learn kung fu. The truth is, the science of learning shows that struggle is the engine of growth. Lasting learning requires an effortful, cognitive process to build the neural pathways in your brain to build deep understanding. Generative AI is a powerful tool that can support that process, but if you use it to bypass the &quot;heavy lifting&quot;, you are undermining actual skill acquisition and knowledge retention.</p>
-
-<div id="worth-watching">
-<h5><i></i> Worth Watching</h5>
-
-<p>The inspiration for this page: <a href="https://www.youtube.com/watch?v=0xS68sl2D70" rel="noopener noreferrer" target="_blank"> What Everyone Gets Wrong About AI and Learning </a></p>
-
-<details><summary> <i></i> Chapters </summary>
-
-<div>
-<ul>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=6" rel="noopener noreferrer" target="_blank"><strong>Introduction</strong> — 00:06</a></li>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=33" rel="noopener noreferrer" target="_blank"><strong>The AI Tutor</strong> — 00:33</a></li>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=126" rel="noopener noreferrer" target="_blank"><strong>Failures of Education</strong> — 02:06</a></li>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=264" rel="noopener noreferrer" target="_blank"><strong>Previous &quot;Revolutions&quot; in Education</strong> — 04:24</a></li>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=558" rel="noopener noreferrer" target="_blank"><strong>Why Revolutions Haven&#x27;t Materialized</strong> — 09:18</a></li>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=665" rel="noopener noreferrer" target="_blank"><strong>Thinking, Fast and Slow</strong> — 11:05</a></li>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=1100" rel="noopener noreferrer" target="_blank"><strong>Cognitive Load</strong> — 18:20</a></li>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=1198" rel="noopener noreferrer" target="_blank"><strong>The Chess Master&#x27;s Secret</strong> — 19:58</a></li>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=1581" rel="noopener noreferrer" target="_blank"><strong>Implications for Education</strong> — 26:21</a></li>
-	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=1831" rel="noopener noreferrer" target="_blank"><strong>The Dangers of Discovery Learning</strong> — 30:31</a></li>
-</ul>
-</div>
-</details>
-</div>
-
-<h4>What&#x27;s Next?</h4>
-
-<p>Science of effort ➔ forklifting vs weight-lifting ➔ guidelines for productive AI use.</p>
-</div>
-
-<hr>
-<div>
-<h2>The Science of &quot;Hard&quot;</h2>
-
-<p><em>Why Your Brain Needs the Strain to Get the Gain</em></p>
-
-<p><em>You know how a workout hurts before it helps? Learning runs on the same principle.</em> Each jolt of mental strain (remembering a fact, untangling a proof, re-testing yourself) signals your brain to lay fresh neural wiring. Skip the “burn” and no new circuits stick. Cognitive science shows that the very effort we try to avoid is the price we pay for automatic skill.</p>
-
-<div><img alt="" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/effortful_vs_effortless_work.png"> </div>
-
-<p>Think of your brain as a living switchboard. When one neuron keeps stimulating another, the connection between them strengthens in a process that can be summed up as <em>“neurons that fire together, wire together.”</em> (aka, <a href="https://www.ncbi.nlm.nih.gov/books/NBK557811/" rel="noopener noreferrer" target="_blank">neural plasticity</a>). When learning, that wiring happens best under strain which psychologists call <strong><em><a href="https://bjorklab.psych.ucla.edu/wp-content/uploads/sites/13/2016/04/EBjork_RBjork_2011.pdf" rel="noopener noreferrer" target="_blank">desirable difficulty</a></em></strong>. The strongest trio of desirable difficulties is:</p>
-
-<ul>
-	<li><strong>Retrieval Practice (Testing Effect)</strong> - This is the heavyweight champion of the three. Each time you try to pull up a fact from your memory, solve a chemistry equation, or explain a theorem in your own words, you’re deepening the connections. <a href="https://en.wikipedia.org/wiki/Testing_effect" rel="noopener noreferrer" target="_blank">Learn More</a></li>
-	<li><strong>Spaced Repetition</strong> - Reviewing material at widening time-gaps trains the brain to hold onto it for the long haul. <a href="https://en.wikipedia.org/wiki/Spaced_repetition" rel="noopener noreferrer" target="_blank">Learn More</a></li>
-	<li><strong>Levels-of-Processing Principle</strong>: The deeper you think about meaning and connections, the stronger and longer-lasting the memory trace. <a href="https://en.wikipedia.org/wiki/Levels_of_Processing_model" rel="noopener noreferrer" target="_blank">Learn More</a></li>
-</ul>
-</div>
-
-<div>
-<h2>Forklifting vs Weightlifting</h2>
-
-<p><em>Would you let a forklift do your bench presses for you?</em></p>
-
-<p>It would be absurd to drive a forklift up to the squat rack so that it can lift the weight for you. You&#x27;d leave the gym exactly as weak as you arrived. Now flip the scene: picture a worker carrying a pallet on his/her back across the loading bay instead of using a forklift. Both images are ridiculous. Similarly, it is ridiculous letting AI handle all your thinking (when the whole point of learning is to build your thinking muscle) it&#x27;s also silly forcing yourself to grunt through thoughtless drudgery that a bot could do better.</p>
-
-<div><img alt="Illustration contrasting forklifting for heavy lifting tasks vs. weightlifting for building strength." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/forklifting_vs_weightlifting.png"> </div>
-
-<h3><i></i>Key Tips</h3>
-
-<ul>
-	<li><strong>Match the tool to the goal</strong>. If the task would build strength (analysis, drafting, problem-solving), grab the bar yourself.</li>
-	<li><strong>Off-load grunt work</strong>. If the task is requires time, but no thought or effort (formatting citations, tidying a table, re-writing messy notes) let the AI forklift roll in.</li>
-	<li><strong>Lift first, then automate</strong>: Even when AI use is permitted, put your own brain power to the task <em>before</em> you turn to the AI.</li>
-	<li><strong>Documentation</strong>: Note every time AI assists with the lift so you and our instructor can see the dividing line.</li>
-</ul>
-
-<p>On your next assignment, before you get down to work, identify every &quot;weight-lift&quot; step and every &quot;forklift step&quot; while making sure you follow the AI use policies for your class. If you catch a forklift in the squat rack, or catch yourself hauling pallets on your back, rethink your approach.</p>
-</div>
-
-<div>
-<h2>Human-Led, AI-Boosted</h2>
-
-<p><em>A Playbook for Productive Struggle</em></p>
-
-<p>The table below outlines a general playbook for combining your own thinking with responsible AI assistance. Adapt the steps to suit your specific task - essay, lab report, slide deck, or problem set. Make sure you keep one principle constant: handle the core reasoning and final decision making yourself; let AI handle only the routine support that is permitted...and record where that boundary is.</p>
-
-<h3>Best-in-Class Approach to Balance Forklifting and Weightlifting</h3>
-
-<table>
-	<thead>
-		<tr>
-			<th>Stage</th>
-			<th>What you do</th>
-			<th>Why it matters</th>
-			<th>Where AI fits (never leads)</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td><strong>Figure out what to do</strong></td>
-			<td>
-			<ul>
-				<li><strong>Read and understand assignment and (if supplied) the rubric</strong></li>
-			</ul>
-			</td>
-			<td>A clear target = less wandering &amp; fewer restarts</td>
-			<td><i></i> After you&#x27;ve read and understood the assignment, ask AI to summarise the assignment; compare for gaps.</td>
-		</tr>
-		<tr>
-			<td><strong>Understand the Policies</strong></td>
-			<td>
-			<ul>
-				<li><strong>Read and understand</strong> course, department, and assignment AI policies.</li>
-				<li>Write down the “no-go” items so you don&#x27;t forget</li>
-			</ul>
-			</td>
-			<td>Prevents accidental integrity violations.</td>
-			<td><i></i> None—policy comprehension is a human lift.</td>
-		</tr>
-		<tr>
-			<td><strong>Weight-Lift / Fork-Lift Split</strong></td>
-			<td>
-			<ul>
-				<li>Make a two-column list.</li>
-				<li><strong>Weight-lifting (required learning)</strong> = idea generation, calculations, outlining, reasoning, debugging, drafting.</li>
-				<li><strong>Fork-lifting (support/enhance)</strong> = formatting, citation styling, converting raw data, quick background facts.</li>
-				<li>Cross-check your list against the AI Policy; move anything forbidden back to the weightlift column.</li>
-			</ul>
-			</td>
-			<td>Forces you to spot where true learning lives and keeps AI in the right lane.</td>
-			<td><i></i> After you create your initial list, upload the assignment and policy and prompt AI: “Suggest 3 routine support tasks for this assignment that would not violate policy.”</td>
-		</tr>
-		<tr>
-			<td><strong>Do the Work (Iterate)</strong></td>
-			<td><strong>A. Start with a lift task</strong> you identified.<br>
-			<strong>B. When you hit a routine support step, pause and deploy AI</strong> (e.g., format citations, tidy a table).<br>
-			<strong>C. Return immediately to the next lift task.</strong><br>
-			<strong>D. You&#x27;ll generally want to rewrite or tweak AI output. At the very least read and check it.</strong></td>
-			<td>Interleaving keeps momentum and shows where AI genuinely saves time without stealing reps.</td>
-			<td><i></i> Limited to “support” tasks you flagged, plus quick clarifying Q&amp;A (“What’s the APA rule for…?”).</td>
-		</tr>
-		<tr>
-			<td><strong>Accuracy &amp; Voice Check</strong></td>
-			<td>
-			<ul>
-				<li>Verify every AI-touched sentence, number, or graphic against high-quality sources (course texts, peer-reviewed articles, instructor slides).</li>
-				<li>Read aloud for tone drift; your voice should still sound like you.</li>
-			</ul>
-			</td>
-			<td>Catches hallucinations and keeps things in your voice.</td>
-			<td><i></i> Optional: “Highlight any claim without a citation”; you confirm or delete.</td>
-		</tr>
-		<tr>
-			<td><strong>Reflect &amp; Log</strong></td>
-			<td>
-			<ul>
-				<li>At minimimum (your assignment may require more) log two quick bullets:
-				<ol>
-					<li>Biggest lift insight (“I finally connected X to Y”).</li>
-					<li>Most useful AI assist (“It reformatted 25 citations”).</li>
-				</ol>
-				</li>
-			</ul>
-			</td>
-			<td>Reflection converts experience into transferable skill.</td>
-			<td><i></i> Can format your log, but the insights come from you.</td>
-		</tr>
-	</tbody>
-</table>
-
-<p>This might all seem really formulaic and probably doesn&#x27;t fit every scenario. Use it as a guide to maximize your learning and minimize your chance of an academic integrity violation. It is helpful to be really deliberate about your approach at first and then as you get more comfortable balancing your own work with AI support you will be able to use your intuition more and more (oohhh, this is its own kind of learning).</p>
-
-<p>You can find more subject specific examples <span>HERE - (add link when section is complete)</span></p>
-</div>
-
-<div>
-<h2>Conclusion</h2>
-
-<p>Struggle isn&#x27;t a flaw in the learning process; it&#x27;s the mechanism that turns information into a durable skill. Each time you spell out an argument, solve a problem unaided, or rewrite a rough paragraph, you’re laying the neural routes that make future work faster and better. Generative AI can accelerate everything around that core effort, things like formatting tables, checking citations, generating quick background facts, but it can’t replace the reps your brain needs.</p>
-
-<p>Use the playbook: understand the learning activity, follow the AI policy, separate human tasks from AI tasks, interleave your own thinking with carefully limited AI assists, verify the results, and log what you learned. Follow it and you’ll finish each assignment not just with a grade, but with stronger reasoning habits that no algorithm can provide.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Learning is Hard - and it&#x27;s supposed to be</h2>
+            <div>
+
+            <div>
+            <h1> </h1>
+
+            <div>
+            <p>Wouldn&#x27;t it be fantastic if we could achieve mastery of our subject without effort - like Neo in the Matrix plugging the computer into his brain to instantly learn kung fu. The truth is, the science of learning shows that struggle is the engine of growth. Lasting learning requires an effortful, cognitive process to build the neural pathways in your brain to build deep understanding. Generative AI is a powerful tool that can support that process, but if you use it to bypass the &quot;heavy lifting&quot;, you are undermining actual skill acquisition and knowledge retention.</p>
+
+            <div id="worth-watching">
+            <h5><i></i> Worth Watching</h5>
+
+            <p>The inspiration for this page: <a href="https://www.youtube.com/watch?v=0xS68sl2D70" rel="noopener noreferrer" target="_blank"> What Everyone Gets Wrong About AI and Learning </a></p>
+
+            <details><summary> <i></i> Chapters </summary>
+
+            <div>
+            <ul>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=6" rel="noopener noreferrer" target="_blank"><strong>Introduction</strong> — 00:06</a></li>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=33" rel="noopener noreferrer" target="_blank"><strong>The AI Tutor</strong> — 00:33</a></li>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=126" rel="noopener noreferrer" target="_blank"><strong>Failures of Education</strong> — 02:06</a></li>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=264" rel="noopener noreferrer" target="_blank"><strong>Previous &quot;Revolutions&quot; in Education</strong> — 04:24</a></li>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=558" rel="noopener noreferrer" target="_blank"><strong>Why Revolutions Haven&#x27;t Materialized</strong> — 09:18</a></li>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=665" rel="noopener noreferrer" target="_blank"><strong>Thinking, Fast and Slow</strong> — 11:05</a></li>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=1100" rel="noopener noreferrer" target="_blank"><strong>Cognitive Load</strong> — 18:20</a></li>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=1198" rel="noopener noreferrer" target="_blank"><strong>The Chess Master&#x27;s Secret</strong> — 19:58</a></li>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=1581" rel="noopener noreferrer" target="_blank"><strong>Implications for Education</strong> — 26:21</a></li>
+            	<li><a href="https://www.youtube.com/watch?v=0xS68sl2D70&amp;t=1831" rel="noopener noreferrer" target="_blank"><strong>The Dangers of Discovery Learning</strong> — 30:31</a></li>
+            </ul>
+            </div>
+            </details>
+            </div>
+
+            <h4>What&#x27;s Next?</h4>
+
+            <p>Science of effort ➔ forklifting vs weight-lifting ➔ guidelines for productive AI use.</p>
+            </div>
+
+            <hr>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>The Science of &quot;Hard&quot;</h2>
+            <p><em>Why Your Brain Needs the Strain to Get the Gain</em></p>
+
+            <p><em>You know how a workout hurts before it helps? Learning runs on the same principle.</em> Each jolt of mental strain (remembering a fact, untangling a proof, re-testing yourself) signals your brain to lay fresh neural wiring. Skip the “burn” and no new circuits stick. Cognitive science shows that the very effort we try to avoid is the price we pay for automatic skill.</p>
+
+            <div><img alt="" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/effortful_vs_effortless_work.png"> </div>
+
+            <p>Think of your brain as a living switchboard. When one neuron keeps stimulating another, the connection between them strengthens in a process that can be summed up as <em>“neurons that fire together, wire together.”</em> (aka, <a href="https://www.ncbi.nlm.nih.gov/books/NBK557811/" rel="noopener noreferrer" target="_blank">neural plasticity</a>). When learning, that wiring happens best under strain which psychologists call <strong><em><a href="https://bjorklab.psych.ucla.edu/wp-content/uploads/sites/13/2016/04/EBjork_RBjork_2011.pdf" rel="noopener noreferrer" target="_blank">desirable difficulty</a></em></strong>. The strongest trio of desirable difficulties is:</p>
+
+            <ul>
+            	<li><strong>Retrieval Practice (Testing Effect)</strong> - This is the heavyweight champion of the three. Each time you try to pull up a fact from your memory, solve a chemistry equation, or explain a theorem in your own words, you’re deepening the connections. <a href="https://en.wikipedia.org/wiki/Testing_effect" rel="noopener noreferrer" target="_blank">Learn More</a></li>
+            	<li><strong>Spaced Repetition</strong> - Reviewing material at widening time-gaps trains the brain to hold onto it for the long haul. <a href="https://en.wikipedia.org/wiki/Spaced_repetition" rel="noopener noreferrer" target="_blank">Learn More</a></li>
+            	<li><strong>Levels-of-Processing Principle</strong>: The deeper you think about meaning and connections, the stronger and longer-lasting the memory trace. <a href="https://en.wikipedia.org/wiki/Levels_of_Processing_model" rel="noopener noreferrer" target="_blank">Learn More</a></li>
+            </ul>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Forklifting vs Weightlifting</h2>
+            <p><em>Would you let a forklift do your bench presses for you?</em></p>
+
+            <p>It would be absurd to drive a forklift up to the squat rack so that it can lift the weight for you. You&#x27;d leave the gym exactly as weak as you arrived. Now flip the scene: picture a worker carrying a pallet on his/her back across the loading bay instead of using a forklift. Both images are ridiculous. Similarly, it is ridiculous letting AI handle all your thinking (when the whole point of learning is to build your thinking muscle) it&#x27;s also silly forcing yourself to grunt through thoughtless drudgery that a bot could do better.</p>
+
+            <div><img alt="Illustration contrasting forklifting for heavy lifting tasks vs. weightlifting for building strength." loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/forklifting_vs_weightlifting.png"> </div>
+
+            <h3><i></i>Key Tips</h3>
+
+            <ul>
+            	<li><strong>Match the tool to the goal</strong>. If the task would build strength (analysis, drafting, problem-solving), grab the bar yourself.</li>
+            	<li><strong>Off-load grunt work</strong>. If the task is requires time, but no thought or effort (formatting citations, tidying a table, re-writing messy notes) let the AI forklift roll in.</li>
+            	<li><strong>Lift first, then automate</strong>: Even when AI use is permitted, put your own brain power to the task <em>before</em> you turn to the AI.</li>
+            	<li><strong>Documentation</strong>: Note every time AI assists with the lift so you and our instructor can see the dividing line.</li>
+            </ul>
+
+            <p>On your next assignment, before you get down to work, identify every &quot;weight-lift&quot; step and every &quot;forklift step&quot; while making sure you follow the AI use policies for your class. If you catch a forklift in the squat rack, or catch yourself hauling pallets on your back, rethink your approach.</p>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Human-Led, AI-Boosted</h2>
+            <p><em>A Playbook for Productive Struggle</em></p>
+
+            <p>The table below outlines a general playbook for combining your own thinking with responsible AI assistance. Adapt the steps to suit your specific task - essay, lab report, slide deck, or problem set. Make sure you keep one principle constant: handle the core reasoning and final decision making yourself; let AI handle only the routine support that is permitted...and record where that boundary is.</p>
+
+            <h3>Best-in-Class Approach to Balance Forklifting and Weightlifting</h3>
+
+            <table>
+            	<thead>
+            		<tr>
+            			<th>Stage</th>
+            			<th>What you do</th>
+            			<th>Why it matters</th>
+            			<th>Where AI fits (never leads)</th>
+            		</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><strong>Figure out what to do</strong></td>
+            			<td>
+            			<ul>
+            				<li><strong>Read and understand assignment and (if supplied) the rubric</strong></li>
+            			</ul>
+            			</td>
+            			<td>A clear target = less wandering &amp; fewer restarts</td>
+            			<td><i></i> After you&#x27;ve read and understood the assignment, ask AI to summarise the assignment; compare for gaps.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Understand the Policies</strong></td>
+            			<td>
+            			<ul>
+            				<li><strong>Read and understand</strong> course, department, and assignment AI policies.</li>
+            				<li>Write down the “no-go” items so you don&#x27;t forget</li>
+            			</ul>
+            			</td>
+            			<td>Prevents accidental integrity violations.</td>
+            			<td><i></i> None—policy comprehension is a human lift.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Weight-Lift / Fork-Lift Split</strong></td>
+            			<td>
+            			<ul>
+            				<li>Make a two-column list.</li>
+            				<li><strong>Weight-lifting (required learning)</strong> = idea generation, calculations, outlining, reasoning, debugging, drafting.</li>
+            				<li><strong>Fork-lifting (support/enhance)</strong> = formatting, citation styling, converting raw data, quick background facts.</li>
+            				<li>Cross-check your list against the AI Policy; move anything forbidden back to the weightlift column.</li>
+            			</ul>
+            			</td>
+            			<td>Forces you to spot where true learning lives and keeps AI in the right lane.</td>
+            			<td><i></i> After you create your initial list, upload the assignment and policy and prompt AI: “Suggest 3 routine support tasks for this assignment that would not violate policy.”</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Do the Work (Iterate)</strong></td>
+            			<td><strong>A. Start with a lift task</strong> you identified.<br>
+            			<strong>B. When you hit a routine support step, pause and deploy AI</strong> (e.g., format citations, tidy a table).<br>
+            			<strong>C. Return immediately to the next lift task.</strong><br>
+            			<strong>D. You&#x27;ll generally want to rewrite or tweak AI output. At the very least read and check it.</strong></td>
+            			<td>Interleaving keeps momentum and shows where AI genuinely saves time without stealing reps.</td>
+            			<td><i></i> Limited to “support” tasks you flagged, plus quick clarifying Q&amp;A (“What’s the APA rule for…?”).</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Accuracy &amp; Voice Check</strong></td>
+            			<td>
+            			<ul>
+            				<li>Verify every AI-touched sentence, number, or graphic against high-quality sources (course texts, peer-reviewed articles, instructor slides).</li>
+            				<li>Read aloud for tone drift; your voice should still sound like you.</li>
+            			</ul>
+            			</td>
+            			<td>Catches hallucinations and keeps things in your voice.</td>
+            			<td><i></i> Optional: “Highlight any claim without a citation”; you confirm or delete.</td>
+            		</tr>
+            		<tr>
+            			<td><strong>Reflect &amp; Log</strong></td>
+            			<td>
+            			<ul>
+            				<li>At minimimum (your assignment may require more) log two quick bullets:
+            				<ol>
+            					<li>Biggest lift insight (“I finally connected X to Y”).</li>
+            					<li>Most useful AI assist (“It reformatted 25 citations”).</li>
+            				</ol>
+            				</li>
+            			</ul>
+            			</td>
+            			<td>Reflection converts experience into transferable skill.</td>
+            			<td><i></i> Can format your log, but the insights come from you.</td>
+            		</tr>
+            	</tbody>
+            </table>
+
+            <p>This might all seem really formulaic and probably doesn&#x27;t fit every scenario. Use it as a guide to maximize your learning and minimize your chance of an academic integrity violation. It is helpful to be really deliberate about your approach at first and then as you get more comfortable balancing your own work with AI support you will be able to use your intuition more and more (oohhh, this is its own kind of learning).</p>
+
+            <p>You can find more subject specific examples <span>HERE - (add link when section is complete)</span></p>
+            </div>
+
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Conclusion</h2>
+            <p>Struggle isn&#x27;t a flaw in the learning process; it&#x27;s the mechanism that turns information into a durable skill. Each time you spell out an argument, solve a problem unaided, or rewrite a rough paragraph, you’re laying the neural routes that make future work faster and better. Generative AI can accelerate everything around that core effort, things like formatting tables, checking citations, generating quick background facts, but it can’t replace the reps your brain needs.</p>
+
+            <p>Use the playbook: understand the learning activity, follow the AI policy, separate human tasks from AI tasks, interleave your own thinking with carefully limited AI assists, verify the results, and log what you learned. Follow it and you’ll finish each assignment not just with a grade, but with stronger reasoning habits that no algorithm can provide.</p>
+            </div>
+            </div>
+
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/pillars-of-ai-literacy.html
+++ b/site/pillars-of-ai-literacy.html
@@ -4,204 +4,246 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Pillars of AI Literacy - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li class="active"><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Pillars of AI Literacy</h2>
-        <div>
-    
-
-
-<div>
-<header id="hero">
-<div>
-<div>
-<div>
-<h1>AI Literacy for Students</h1>
-
-<h2>Demystify the tech. Judge the output. Act with principle.</h2>
-<a href="#pillars">Start Learning Now <i></i> </a></div>
-
-<div><img alt="An abstract illustration showing three interconnected pillars representing the core concepts of AI literacy." loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract+representation+of+AI+literacy+pillars+-+technology,+evaluation,+ethics&amp;w=400&amp;h=400&amp;style=professional&amp;transparent=true"></div>
-</div>
-</div>
-</header>
-
-<main>
-<section>
-<div>
-<p>You already know AI is a force. The question is how to master it. This guide provides the framework, built on the three pillars below. Everything that follows is designed to build your expertise in these domains. Let&#x27;s get to work.</p>
-</div>
-</section>
-
-<section id="pillars">
-<div>
-<div>
-<h2>The Three Pillars of AI Literacy</h2>
-
-<p>A framework for responsible and effective AI use.</p>
-</div>
-
-<div>
-<div>
-<div><i></i>
-
-<h3>Technical Understanding</h3>
-</div>
-
-<p>Grasping what AI is, how large language models (LLMs) work, and what their core capabilities and limitations are.</p>
-
-<div>
-<h4>Why it matters:</h4>
-
-<p>Knowing the &quot;how&quot; helps you write better prompts, troubleshoot outputs, and use AI as a tool, not a magic box.</p>
-</div>
-</div>
-
-<div>
-<div><i></i>
-
-<h3>Evaluative Judgment</h3>
-</div>
-
-<p>Critically assessing AI-generated content for accuracy, relevance, bias, and appropriateness for your academic task.</p>
-
-<div>
-<h4>Why it matters:</h4>
-
-<p>You are the final authority. This pillar ensures the work you submit is correct, meets your requirements, and is truly your own.</p>
-</div>
-</div>
-
-<div>
-<div><i></i>
-
-<h3>Ethical Awareness</h3>
-</div>
-
-<p>Considering the societal impact of AI, from data privacy and algorithmic bias to its use in academic and professional settings.</p>
-
-<div>
-<h4>Why it matters:</h4>
-
-<p>This ensures your use of AI is not only compliant with academic rules but also responsible and fair to society at large.</p>
-</div>
-</div>
-</div>
-</div>
-</section>
-
-<section id="guide-overview">
-<div>
-<div>
-<h2>Your Guide to this AI Literacy Guide</h2>
-
-<p>Navigate the three core areas of AI literacy to build your skills from the ground up.</p>
-</div>
-
-<div>
-<div>
-<div>
-<h3><i></i>Understand &amp; Explore</h3>
-
-<p>Start here to demystify the technology. This section covers what GenAI is, how it works, and its fundamental capabilities and limitations.</p>
-
-
-<div>
-<ul>
-	<li><a href="gen-ai-fundamentals.html"><strong>Gen AI Fundamentals:</strong></a> Define what GenAI is and isn’t to build a solid foundation.</li>
-	<li><a href="gen-ai-behind-the-curtain.html"><strong>Gen AI - Behind the Curtain:</strong></a> Peek into the training process to understand how these models &quot;learn.&quot;</li>
-	<li><a href="gen-ai-tools-platforms-and-interfaces.html"><strong>Gen AI Tools, Platforms, and Interfaces:</strong></a> Survey the landscape of available tools and how to access them.</li>
-	<li><a href="potential-and-limitations-of-gen-ai.html"><strong>Potential and Limitations of Gen AI:</strong></a> Explore the exciting possibilities and critical shortcomings you must be aware of.</li>
-</ul>
-</div>
-</div>
-</div>
-
-
-<div>
-<div>
-<h3><i></i>Analyze &amp; Apply</h3>
-
-<p>Move from theory to practice. Learn how to critically evaluate AI outputs and use them as a tool for &quot;weightlifting,&quot; not &quot;forklifting.&quot;</p>
-
-
-<div>
-<ul>
-	<li><a href="essentials-for-smart-engagement.html"><strong>Essentials for Smart Engagement:</strong> </a> Learn the core mindset for using AI effectively and ethically in your studies.</li>
-	<li><a href="ai-quick-queries-and-idea-sparker.html"><strong>AI Quick Queries &amp; Idea Sparker:</strong></a> Use AI as a rapid brainstorming partner to kickstart your thinking.</li>
-	<li><a href="ai-study-buddy-and-skill-builder.html"><strong>AI Study Buddy &amp; Skill Builder:</strong></a> Discover techniques for using AI to create practice questions and explain complex topics.</li>
-	<li><a href="ai-generated-writing-effective-and-ethical-use.html"><strong>AI-Generated Writing:</strong></a> Master the art of using AI to enhance, not replace, your own writing process.</li>
-	<li><a href="ai-research-assistants.html"><strong>AI Research Assistant:</strong> </a>Leverage AI to organize research and explore counterarguments for deeper analysis.</li>
-	<li><a href="ais-jagged-frontier.html"><strong>AI&#x27;s Jagged Edge:</strong></a> AI is incredibly good at some things and surprisingly bad at others - let&#x27;s explore that jagged edge.</li>
-	<li><a href="ai-risks-and-ethical-considerations.html"><strong>Other Ethical Considerations:</strong></a> Examine the broader societal and environmental impacts of AI technology.</li>
-</ul>
-</div>
-</div>
-</div>
-
-
-<div>
-<div>
-<h3><i></i>Implement &amp; Lead</h3>
-
-<p>Go beyond basic use. This section focuses on strategic integration, responsible leadership, and how to explain and justify your AI-assisted work.</p>
-</div>
-</div>
-</div>
-</div>
-</section>
-
-<section>
-<div>
-<div><i></i>
-
-<h2>Your Commitment to Academic Integrity</h2>
-</div>
-
-<div>
-<div>
-<p>By using AI tools in my academic work, I commit to upholding the highest standards of integrity. I will adhere to the following principles:</p>
-
-<ul>
-	<li><b>Transparency:</b> I will clearly acknowledge and cite the use of AI tools in my work according to my instructor&#x27;s and the college&#x27;s guidelines.</li>
-	<li><b>Verification:</b> I will independently verify any facts, data, or citations provided by an AI, as I am responsible for the accuracy of my work.</li>
-	<li><b>Originality:</b> I will use AI as a tool to assist my learning and productivity, not to replace my own critical thinking and original thought.</li>
-</ul>
-
-<div><input name="pledge" type="checkbox"> <label for="genai-pledgeCheckbox">I have read and agree to this commitment.</label></div>
-</div>
-</div>
-</div>
-</section>
-</main>
-
-<footer>
-<p><span>NOTE: Clicking the checkbox doesn&#x27;t do anything on our servers, it only sets the commitment in your own brain</span></p>
-
-<div></div>
-</footer>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item site-nav__item--active'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Pillars of AI Literacy</h2>
+            <div>
+
+
+
+            <div>
+            <header id="hero">
+            <div>
+            <div>
+            <div>
+            <h1>AI Literacy for Students</h1>
+        </section>
+        <section class="gai-box">
+            <h2>Demystify the tech. Judge the output. Act with principle.</h2>
+            <a href="#pillars">Start Learning Now <i></i> </a></div>
+
+            <div><img alt="An abstract illustration showing three interconnected pillars representing the core concepts of AI literacy." loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract+representation+of+AI+literacy+pillars+-+technology,+evaluation,+ethics&amp;w=400&amp;h=400&amp;style=professional&amp;transparent=true"></div>
+            </div>
+            </div>
+            </header>
+
+
+            <section>
+            <div>
+            <p>You already know AI is a force. The question is how to master it. This guide provides the framework, built on the three pillars below. Everything that follows is designed to build your expertise in these domains. Let&#x27;s get to work.</p>
+            </div>
+            </section>
+
+            <section id="pillars">
+            <div>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>The Three Pillars of AI Literacy</h2>
+            <p>A framework for responsible and effective AI use.</p>
+            </div>
+
+            <div>
+            <div>
+            <div><i></i>
+
+            <h3>Technical Understanding</h3>
+            </div>
+
+            <p>Grasping what AI is, how large language models (LLMs) work, and what their core capabilities and limitations are.</p>
+
+            <div>
+            <h4>Why it matters:</h4>
+
+            <p>Knowing the &quot;how&quot; helps you write better prompts, troubleshoot outputs, and use AI as a tool, not a magic box.</p>
+            </div>
+            </div>
+
+            <div>
+            <div><i></i>
+
+            <h3>Evaluative Judgment</h3>
+            </div>
+
+            <p>Critically assessing AI-generated content for accuracy, relevance, bias, and appropriateness for your academic task.</p>
+
+            <div>
+            <h4>Why it matters:</h4>
+
+            <p>You are the final authority. This pillar ensures the work you submit is correct, meets your requirements, and is truly your own.</p>
+            </div>
+            </div>
+
+            <div>
+            <div><i></i>
+
+            <h3>Ethical Awareness</h3>
+            </div>
+
+            <p>Considering the societal impact of AI, from data privacy and algorithmic bias to its use in academic and professional settings.</p>
+
+            <div>
+            <h4>Why it matters:</h4>
+
+            <p>This ensures your use of AI is not only compliant with academic rules but also responsible and fair to society at large.</p>
+            </div>
+            </div>
+            </div>
+            </div>
+            </section>
+
+            <section id="guide-overview">
+            <div>
+            <div>
+        </section>
+        <section class="gai-box">
+            <h2>Your Guide to this AI Literacy Guide</h2>
+            <p>Navigate the three core areas of AI literacy to build your skills from the ground up.</p>
+            </div>
+
+            <div>
+            <div>
+            <div>
+            <h3><i></i>Understand &amp; Explore</h3>
+
+            <p>Start here to demystify the technology. This section covers what GenAI is, how it works, and its fundamental capabilities and limitations.</p>
+
+
+            <div>
+            <ul>
+            	<li><a href="gen-ai-fundamentals.html"><strong>Gen AI Fundamentals:</strong></a> Define what GenAI is and isn’t to build a solid foundation.</li>
+            	<li><a href="gen-ai-behind-the-curtain.html"><strong>Gen AI - Behind the Curtain:</strong></a> Peek into the training process to understand how these models &quot;learn.&quot;</li>
+            	<li><a href="gen-ai-tools-platforms-and-interfaces.html"><strong>Gen AI Tools, Platforms, and Interfaces:</strong></a> Survey the landscape of available tools and how to access them.</li>
+            	<li><a href="potential-and-limitations-of-gen-ai.html"><strong>Potential and Limitations of Gen AI:</strong></a> Explore the exciting possibilities and critical shortcomings you must be aware of.</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+
+            <div>
+            <div>
+            <h3><i></i>Analyze &amp; Apply</h3>
+
+            <p>Move from theory to practice. Learn how to critically evaluate AI outputs and use them as a tool for &quot;weightlifting,&quot; not &quot;forklifting.&quot;</p>
+
+
+            <div>
+            <ul>
+            	<li><a href="essentials-for-smart-engagement.html"><strong>Essentials for Smart Engagement:</strong> </a> Learn the core mindset for using AI effectively and ethically in your studies.</li>
+            	<li><a href="ai-quick-queries-and-idea-sparker.html"><strong>AI Quick Queries &amp; Idea Sparker:</strong></a> Use AI as a rapid brainstorming partner to kickstart your thinking.</li>
+            	<li><a href="ai-study-buddy-and-skill-builder.html"><strong>AI Study Buddy &amp; Skill Builder:</strong></a> Discover techniques for using AI to create practice questions and explain complex topics.</li>
+            	<li><a href="ai-generated-writing-effective-and-ethical-use.html"><strong>AI-Generated Writing:</strong></a> Master the art of using AI to enhance, not replace, your own writing process.</li>
+            	<li><a href="ai-research-assistants.html"><strong>AI Research Assistant:</strong> </a>Leverage AI to organize research and explore counterarguments for deeper analysis.</li>
+            	<li><a href="ais-jagged-frontier.html"><strong>AI&#x27;s Jagged Edge:</strong></a> AI is incredibly good at some things and surprisingly bad at others - let&#x27;s explore that jagged edge.</li>
+            	<li><a href="ai-risks-and-ethical-considerations.html"><strong>Other Ethical Considerations:</strong></a> Examine the broader societal and environmental impacts of AI technology.</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+
+            <div>
+            <div>
+            <h3><i></i>Implement &amp; Lead</h3>
+
+            <p>Go beyond basic use. This section focuses on strategic integration, responsible leadership, and how to explain and justify your AI-assisted work.</p>
+            </div>
+            </div>
+            </div>
+            </div>
+            </section>
+
+            <section>
+            <div>
+            <div><i></i>
+        </section>
+        <section class="gai-box">
+            <h2>Your Commitment to Academic Integrity</h2>
+            </div>
+
+            <div>
+            <div>
+            <p>By using AI tools in my academic work, I commit to upholding the highest standards of integrity. I will adhere to the following principles:</p>
+
+            <ul>
+            	<li><b>Transparency:</b> I will clearly acknowledge and cite the use of AI tools in my work according to my instructor&#x27;s and the college&#x27;s guidelines.</li>
+            	<li><b>Verification:</b> I will independently verify any facts, data, or citations provided by an AI, as I am responsible for the accuracy of my work.</li>
+            	<li><b>Originality:</b> I will use AI as a tool to assist my learning and productivity, not to replace my own critical thinking and original thought.</li>
+            </ul>
+
+            <div><input name="pledge" type="checkbox"> <label for="genai-pledgeCheckbox">I have read and agree to this commitment.</label></div>
+            </div>
+            </div>
+            </div>
+            </section>
+
+
+            <footer>
+            <p><span>NOTE: Clicking the checkbox doesn&#x27;t do anything on our servers, it only sets the commitment in your own brain</span></p>
+
+            
+            </footer>
+            </div>
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/potential-and-limitations-of-gen-ai.html
+++ b/site/potential-and-limitations-of-gen-ai.html
@@ -4,465 +4,480 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Potential and Limitations of Gen AI - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="active has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li class="active"><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Potential and Limitations of Gen AI</h2>
-        <div>
-    
-<link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div>
-<div><img alt="Student speaking with chatbot in futuristic setting" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/electronaxe_Vector_illustration_of_a_futuristic_AI_chatbot_inte_cd37a2a3-d22e-4fcd-9f35-739b853760cf.png">
-<h1><i></i>Generative AI&#x27;s Impact on Education</h1>
-
-<div><img alt="Abstract representation of AI enhancing education" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract%20concept%20of%20AI%20in%20education%2C%20glowing%20brain%20network%2C%20books%2C%20stylized&amp;w=120&amp;h=120&amp;style=professional&amp;transparent=false">
-<div>
-<p>Although we&#x27;re still unpacking what kinds of impacts <span>generative AI</span> will have on education, we are starting to get a handle on it. <span>Generative AI</span> is available, easy to access, easy to use, and a powerful tool when used correctly. Students and educators alike are already using it and making an impact on their learning and teaching. It promises benefits like enhanced personalized learning, accelerated curriculum development, and real-time feedback; but it can also support drawbacks like cheating, plagiarism, and serving as a crutch to bypass critical thinking. The task to ensure we maximize its potential to elevate learning and minimize the potential to undermine it is one of the key challenges we face as educators.</p>
-
-<p>This section outlines some examples of <span>generative AI</span> use in education, highlights pros and cons, and then considers its use from the perspective of a teacher and a student. Let&#x27;s start with some examples of how <span>generative AI</span> can be used in education:</p>
-</div>
-</div>
-
-<hr> 
-<div>
-<h3><i></i>Personalized Learning Content</h3>
-
-<p><span>Generative AI</span> can create tailored learning materials based on individual students&#x27; learning styles, preferences and performance, enhancing personalized education.</p>
-
-<h5>Applications:</h5>
-
-<ul>
-	<li>Adaptive textbooks</li>
-	<li>Interactive modules</li>
-	<li>Customized practice exercises</li>
-</ul>
-
-<div>
-<div>
-<h5><i></i>Pros</h5>
-
-<ul>
-	<li>Improve understanding</li>
-	<li>Improve retention</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Cons</h5>
-
-<ul>
-	<li>Quality of content will vary</li>
-	<li>Content would still need teacher oversight</li>
-	<li>Privacy concerns</li>
-	<li>Unequal accessibility</li>
-</ul>
-</div>
-</div>
-</div>
-
-<hr> 
-<div>
-<h3><i></i>Content Creation</h3>
-
-<p>Educators can use <span>generative AI</span> to develop a wide array of content from textbooks to interactive modules. These <span>AI</span> systems can create content that is aligned with the curriculum, updated in real-time, and customized to cater to a diverse student population.</p>
-
-<h5>Applications:</h5>
-
-<ul>
-	<li><span>AI</span> generated lesson plans</li>
-	<li>Worksheets</li>
-	<li>Videos</li>
-	<li>Case studies</li>
-	<li>Scenarios</li>
-	<li>Problems and challenges</li>
-</ul>
-
-<div>
-<div>
-<h5><i></i>Pros</h5>
-
-<ul>
-	<li>Save time</li>
-	<li>Easily customize content</li>
-	<li>Get immediate feedback</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Cons</h5>
-
-<ul>
-	<li>You still can&#x27;t 100% trust that <span>AI</span> output - quality assurance checks needed</li>
-</ul>
-</div>
-</div>
-</div>
-
-<hr> 
-<div>
-<h3><i></i>Personalized Tutor/Mentor/Coach</h3>
-
-<p>An <span>AI</span> chatbot can act as a virtual tutor/mentor/coach presenting content, checking for understanding, and providing prompts and coaching to support learning. <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4475995" rel="noopener noreferrer" target="_blank">Ethan and Lilach Mollick</a> have created and tested a few comprehensive prompts that work reasonably well in ChatGPT (GPT-4) and Microsoft Copilot, but they are not quite as capable as you would hope. It is likely that an LLM used as a tutor would have to be specially trained to act as a good tutor. Khan Academy (<a href="https://www.khanacademy.org/khan-labs" rel="noopener noreferrer" target="_blank">Khanmigo</a>), Google (<a href="https://learning.google.com/experiments/learn-about" rel="noopener noreferrer" target="_blank">Learn About</a>) and others are working on such things, but their effectiveness is not yet proven.</p>
-
-<h5>Applications:</h5>
-
-<ul>
-	<li>Directly support student learning at any time</li>
-</ul>
-
-<div>
-<div>
-<h5><i></i>Pros</h5>
-
-<ul>
-	<li>Tutor would be tireless, always available, endlessly patient</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Cons</h5>
-
-<ul>
-	<li>General purpose AIs are not reliable for this</li>
-	<li>Fine-tuned chatbots not readily available</li>
-	<li>Still relatively unproven</li>
-</ul>
-</div>
-</div>
-</div>
-
-<hr> 
-<div>
-<h3><i></i>Enhanced Student Work</h3>
-
-<p>If students are coached on effective and ethical use of <span>generative AI</span>, teachers can potentially set their quality expectations higher. For example, Ethan Mollick requires his <a href="https://twitter.com/emollick/status/1660794981286641670" rel="noopener noreferrer" target="_blank">entrepreneurship student to do at least one impossible task in their projects</a>. Basically, what he means by this is that <span>generative AI</span> can help you code, create a website, design an app without you needing to know how to do that.</p>
-
-<h5>Applications:</h5>
-
-<ul>
-	<li>More ambitious assignments</li>
-</ul>
-
-<div>
-<div>
-<h5><i></i>Pros</h5>
-
-<ul>
-	<li>Higher quality of work from students</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Cons</h5>
-
-<ul>
-	<li>Privacy concerns</li>
-	<li><span>Generative AI</span> training may take over other important aspects of class</li>
-</ul>
-</div>
-</div>
-</div>
-
-<hr> 
-<div>
-<h3><i></i>Real-time Feedback</h3>
-
-<p><span>Generative AI</span> is capable of providing immediate feedback on your writing, your coding, and even on your ideas..</p>
-
-<h5>Applications:</h5>
-
-<ul>
-	<li>Students can check their own work</li>
-	<li>Marking assistance</li>
-</ul>
-
-<div>
-<div>
-<h5><i></i>Pros</h5>
-
-<ul>
-	<li>Faster marking</li>
-	<li>Learners get feedback right away</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Cons</h5>
-
-<ul>
-	<li>Privacy concerns</li>
-	<li>Bias in <span>AI</span> could affect its feedback</li>
-	<li>Accuracy of marking</li>
-</ul>
-</div>
-</div>
-</div>
-
-<hr> 
-<div>
-<h3><i></i>Language Translation</h3>
-
-<p><span>AI</span> can instantly translate educational content (student or teacher generated) from and to many languages. General purpose chatbots are pretty good at this and specialized translators are even better.</p>
-
-<p><img alt="" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/World_and_Languages.png"></p>
-
-<h5>Applications:</h5>
-
-<ul>
-	<li>Translate educational content for English language learners</li>
-	<li>Translate student work into English</li>
-</ul>
-
-<div>
-<div>
-<h5><i></i>Pros</h5>
-
-<ul>
-	<li>Supports inclusivity</li>
-	<li>Facilitates international collaboration</li>
-	<li>Aids comprehension</li>
-</ul>
-</div>
-
-<div>
-<h5><i></i>Cons</h5>
-
-<ul>
-	<li>Translations might lack context and cultural sensitivity</li>
-	<li>Loss of meaning or nuance</li>
-</ul>
-</div>
-</div>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    
-<link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div><img alt="Robots in style of Andy Warhol" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/electronaxe_cute_robot_taking_careful_notes_13381e5d-a13e-4d70-b3a3-15cfb39f32d1.png"></div>
-
-<div>
-<div>
-<h1><i></i>Weighing the Benefits and Challenges of AI in Education</h1>
-
-<div><img alt="Abstract graphic representing balance in AI for education" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract%20graphic%20representing%20the%20balance%20of%20opportunities%20and%20challenges%20in%20AI%20for%20education%2C%20gears%2C%20lightbulb%2C%20question%20mark&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
-<div>
-<p>The integration of AI in education brings both <span>significant opportunities</span> and <span>notable challenges</span>. Understanding this balance is key to harnessing AI&#x27;s potential responsibly and effectively in learning environments.</p>
-</div>
-</div>
-
-<hr>
-
-
-
-<div>
-<h3><i></i>The Hurdles: Challenges and Concerns</h3>
-
-<ol>
-	<li><strong>Data Privacy Concerns:</strong> On the previous page, data privacy came up as an issue over and over again. Anytime that you enter something into a chatbot, you are &quot;feeding the beast&quot;, i.e., giving the AI company even more data. Different AI companies will have different privacy policies, but the reality is you are sending them your (or your students&#x27;) information and despite the policies, they have your data. AI companies are aware of these issues and are working on ways to support privacy-sensitive applications. One potential way to support privacy is to provide a private server for institutes. These are in the works, but currently require a large investment and/or a lot of specialized expertise.<br>
-	 </li>
-	<li><strong>Equity and Access Issues:</strong> AI can seem magical and spellbinding but it is not universally accessible. Not only are some LLMs geographically locked down, but the best tools cost money. The digital divide is real, and the question lingers - how do we ensure that every learner, irrespective of their socio-economic status has equal access.<br>
-	 </li>
-	<li><strong>Everything it Outputs is Made Up:</strong> This is a crucial point that&#x27;s often overlooked - LLMs don&#x27;t actually &quot;know&quot; anything in the way humans do. They create their responses by predicting what words should come next based on patterns in their training data. While these predictions can be remarkably accurate and useful, they&#x27;re still essentially sophisticated guesses. This means that even when an AI sounds completely confident, it might be completely wrong, or worse, it might blend truth and fiction in ways that are hard to detect. This is particularly problematic in education where accuracy and reliability are paramount.<br>
-	 </li>
-	<li><strong>Output May Not Be Reliable or Consistent:</strong> Ask an LLM the same question twice, and you&#x27;ll likely get two different answers. While these answers might convey similar information, they can vary significantly in their details, depth, and sometimes even accuracy. This inconsistency can be particularly challenging in educational settings where we need dependable, standardized information. Bottom line: Every AI output needs human verification, and using this critical verification skill is essential.</li>
-	<li><strong>Overuse and Overreliance</strong>: When individuals depend too heavily on AI for tasks like writing, problem-solving, or creative ideation, there&#x27;s a risk of diminishing their own critical thinking, analytical skills, and domain-specific expertise. Instead of developing a deep understanding or honing their abilities through practice, users might simply accept AI-generated outputs without sufficient scrutiny or personal engagement. This can lead to a passive learning approach, hinder the development of essential cognitive skills, and ultimately make individuals less capable when faced with novel situations or tasks where AI assistance is unavailable or inappropriate. Fostering a balance where AI serves as an assistant rather than a replacement is crucial to ensure that human intellect and creativity continue to flourish.</li>
-	<li><strong>The Need for New Pedagogical Approaches:</strong> The integration of AI into educational settings will require many teachers to re-examine their style and their approach to education. We are all going to have to think about how we provide content, how we do assessment, and how (or whether) we support our students to use AI as well.<br>
-	 </li>
-	<li><strong>Other Ethical Considerations:</strong> The rise of generative AI gives rise to a number of other ethical considerations, many of which we should consider as we integrate generative AI into our teaching and learning practices.
-	<ul>
-		<li>LLMs can perpetuate and amplify existing biases because of the data they were trained on.</li>
-		<li>The data used for training may have come from sources the LLMs didn&#x27;t have explicit rights to use. Should we consider not using an LLM because it may have violated intellectual property rights?</li>
-		<li>The servers used by LLMs for training and for running their neural networks use a lot of energy. Alphabet&#x27;s CEO estimates that <a href="https://www.reuters.com/technology/tech-giants-ai-like-bing-bard-poses-billion-dollar-search-problem-2023-02-22/" rel="noopener noreferrer" target="_blank">an LLM query could use as much as 10 times the energy of a standard Google search</a>. Companies like Microsoft are looking at lower carbon footprint solutions (like solar or <a href="https://www.theverge.com/2023/9/26/23889956/microsoft-next-generation-nuclear-energy-smr-job-hiring" rel="noopener noreferrer" target="_blank">small scale nuclear reactors</a>), but good solutions are not yet in use.</li>
-		<li>Generative AI will likely cause some level of job displacement. How should education adapt to mitigate this harm?</li>
-		<li>Social media already has a significant impact on our lives; affecting mental health and facilitating the spread of mis- and disinformation. Generative AI will enable a massive increase in the ability to create mis/disinformation. What role can we play in combating this?</li>
-	</ul>
-	</li>
-</ol>
-</div>
-<hr>
-
-
-<div>
-<h3><i></i>The Upside: Benefits of AI in Education</h3>
-
-<ol>
-	<li><strong>Personalized Learning Experiences:</strong> The ideal classroom is one where every student&#x27;s unique learning style, pace, and need is catered to. AI has the potential to make this happen. It&#x27;s not quite there yet, but if the pace of AI development over the last year or so is any indication, we are not far off. As a counter to this pro, we, as educators, really have to think deeply about what our role will be.<br>
-	 </li>
-	<li><strong>Enhanced Efficiency for Educators:</strong> Grading takes ages and planning can be a grind. Generative AI can potentially take care of a lot of this grunt work, but we have to be careful. AI still makes stuff up and feeding student work into ChatGPT is probably a privacy violation.<br>
-	 </li>
-	<li><strong>Ease of Generating Diverse Content:</strong> Generative AI makes it easy to take a base of content and modify it in ways that offer students multiple perspectives, make it more accessible for students with diverse needs, and adapt it to different languages.<br>
-	 </li>
-	<li><strong>Idea Generator:</strong> Are generative AI tools actually creative? I don&#x27;t know the answer to that, I do know that if you ask a chatbot for 50 unique ideas for a business related to shoe repair, it will give you 50 (or about 50, it&#x27;s not always great at counting) ideas in less than 30 seconds. Now, most of those ideas will be not so great, but I&#x27;m sure a few will be worthy of some thought and there may be a diamond. Even if you don&#x27;t use any of the ideas, you will probably be inspired for a new idea based on the ones the AI gives you. The best haiku I&#x27;ve ever written was 75% written by me, but 25% inspired by an idea that ChatGPT gave me.<br>
-	 </li>
-	<li><strong>Personal Assistant or Sounding Board:</strong> I recently took a course on course design supported by AI. The course facilitator had created a number of comprehensive prompts that helped us create a learner profile, generate knowledge maps and learning outcomes, and then a storyboard for a course. One thing that we (all the students) remarked on was that, while the AI did not actually save us much time, the quality of work that we produced was much better than if we did it without the AI. Having the AI as an idea generator and then sounding board to bounce other ideas off of significantly improved our work.<br>
-	 </li>
-	<li><strong>AI is Good at Giving Data-Driven Insights:</strong> Really, this is all AI does. It makes connections between the data that you train it with and then uses those connections to provide &quot;insight&quot; into any new data that you feed it. Image generators do this with pixels and LLMs do this with words. LLMs also do this with numbers and since data is really nothing more than a bunch of organized words and numbers LLMs are surprisingly good at analyzing spreadsheets, creating spreadsheets from raw data, and even highlighting links in data that you may have missed. ChatGPT Plus in Advanced Data Analysis mode is the best gen AI tool for doing this kind of thing.</li>
-</ol>
-</div>
-
-
-</div>
-</div>
-
-
-    </div><div>
-    
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-
-    
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer">
-
-    
-<div> 
-    <div>
-
-        <h1><i></i>Student Voices: Navigating AI in Education</h1>
-
-        <img alt="Dreamy vision of student studying with futuristic AI interface" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/midjourney_-_vector_illustration_of_futuristic_chatbot_interface.png">
-
-        <div>
-            <img alt="Abstract representation of student discussion" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=stylized%20icon%20of%20students%20discussing%20around%20a%20glowing%20AI%20symbol%2C%20vector%20art&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
-            <div>
-                <p>I came across an interesting comment from a student on <a href="https://www.cbc.ca/listen/live-radio/1-63-the-current/clip/16007287-questions-ais-role-classroom" target="_blank" rel="noopener noreferrer">a podcast by CBC&#x27;s The Current</a> about using generative AI like ChatGPT in education. This student was very motivated to learn but found some courses irrelevant. Due to a heavy course load, they focused on the courses they felt most relevant and used ChatGPT for the rest. Many students feel the same, especially when overwhelmed with work, and turn to ChatGPT for help. Cases like this show the willingness of students to use generative AI to cheat, but students also seem to understand the risks of doing so which they identified as not just academic penalties but also the learning they miss out on.</p>
-            </div>
-        </div>
-        
-        <hr>
-
-        <div>
-            <h3><i></i>Perceived Benefits of GenAI</h3>
-            <p>A survey by Cecilia Chan and Wenjie Hu of 339 students across six Hong Kong universities revealed that students find GenAI useful for:</p>
-            
-            <div>
-                <h5>Key Advantages Identified by Students:</h5>
-                <ul>
-                    <li>Personalized and immediate learning support</li>
-                    <li>Support with writing and brainstorming</li>
-                    <li>Help with research and analysis</li>
-                    <li>Support with visual and audio multimedia</li>
-                </ul>
-            </div>
-        </div>
-
-        <hr>
-
-        <div>
-            <h3><i></i>Student Concerns and Apprehensions</h3>
-            <p>The same study highlighted significant student concerns regarding the use of GenAI in education:</p>
-
-            <div>
-                <h5>Primary Concerns Voiced:</h5>
-                <ul>
-                    <li>Accuracy and transparency of AI-generated information</li>
-                    <li>Privacy issues and data security</li>
-                    <li>Potential loss of critical thinking and other essential skills</li>
-                    <li>Job displacement or hiring challenges due to AI advancements</li>
-                    <li>Exacerbation of socio-economic disparities</li>
-                    <li>Ambiguity in institutional policies: navigating ethical use without academic dishonesty</li>
-                </ul>
-            </div>
-        </div>
-
-        <hr>
-
-        <div>
-            <h3><i></i>Global Student Questions</h3>
-            <p>These concerns are echoed by students globally, as discussed in forums like the <a href="https://www.aixeducation.com/" target="_blank" rel="noopener noreferrer">AIxEducation conference</a>. Students worldwide are grappling with a new set of critical questions:</p>
-
-            <div> 
-                <h5>Pressing Questions from Students:</h5>
-                <ul>
-                    <li>How can I master these AI tools amidst an already demanding academic schedule?</li>
-                    <li>How can I afford access to premium AI tools?</li>
-                    <li>If I use AI for writing, does it compromise my authentic voice and learning?</li>
-                    <li>How will educators address the digital divide regarding access to advanced AI tools?</li>
-                    <li>Will AI ultimately devalue my hard-earned education and skills?</li>
-                </ul>
-            </div>
-            <p>The AI tide is rolling in, with or without an invitation. Students are savvy; they see the potential of AI as both a powerful tool and a complex challenge. They are ready to engage, albeit with understandable trepidation about the evolving rules of this new academic landscape.</p>
-        </div>
-
-        <hr>
-
-        <div>
-            <h3><i></i>The Educator&#x27;s Tightrope</h3>
-            <p>Educators, too, find themselves in a delicate balancing act. They are tasked with a dual mandate: to deter the misuse of AI while simultaneously championing its educational benefits. As they navigate this complex terrain, the core challenge is to ensure that the fundamental essence of education—critical thinking, creativity, and genuine understanding—isn&#x27;t lost amidst the growing capabilities of artificial intelligence.</p>
-        </div>
-
-    </div> 
-</div> 
-
-
-
-
-
-    </div><div>
-    
-<link href="https://fonts.googleapis.com" rel="preconnect">
-<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
-<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" referrerpolicy="no-referrer" rel="stylesheet">
-
-<div><img alt="Charismatic teacher surrounded by students" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/electronaxe_Digital_art_in_a_wide_51_aspect_ratio_showcasing_a__99bee07d-2145-48b4-9448-fc9b6db88aa5.png"></div>
-
-<div>
-<div>
-<h1><i></i>AI in the Classroom: Teacher Perspectives &amp; Evolving Practices</h1>
-
-<div><img alt="Abstract representation of AI transforming education" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=stylized%20brain%20with%20gears%20and%20digital%20network%20connections%2C%20representing%20AI%20in%20education%2C%20modern%20flat%20design&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
-<div>
-<p>When ChatGPT was first released in November 2022, many teachers had a moment of panic and thought that either &quot;this is the end of education as we know it <i></i>&quot; or &quot;this is the end of education as we know it <i></i>&quot;. Proponents like Ethan Mollick fully embraced ChatGPT and sought the best ways to use it in his classes. At the same time, school districts like the one in New York City banned ChatGPT outright because they didn&#x27;t know how to deal with it at the time. Ethan Mollick&#x27;s level of adoption is beyond what most of us know how to do and NYC school&#x27;s reaction was an excessive knee-jerk reaction to the new technology that has since been reversed. Now that the initial reactions are behind us, many educators have put a lot of thought into how to best make use of LLMs like ChatGPT to support the education of our students. Institutes have added AI to their academic policies and most of these that I have read are permissive and generally put the choice of if and how to allow its use in the hands of the teachers and professors. Institutes have also released guidelines on how educators might use AI in their classes along with suggestions on how to adapt assignments to support its use.</p>
-</div>
-</div>
-
-<hr>
-<div>
-<h3><i></i>Adapting to the New Landscape</h3>
-
-<p>It&#x27;s clear that most teachers are going to need to change their practices somewhat, but the amount of change will vary from level to level and from topic to topic. Primary school teachers have likely changed their approach very little and instructors teaching exclusively hands-on topics probably haven&#x27;t changed much either. On the other hand first year English and computer science professors have likely had to change their approach a lot - these are courses for which ChatGPT can probably help the most (write an essay, write some simple code), and first year courses (especially ones that students only take because they have to) are the courses in which students are most likely to look for outside &quot;help&quot;. The value of the AI output for courses like this is high and so is the incentive.</p>
-</div>
-
-<hr>
-<div>
-<h3><i></i>The Path Forward: Thoughtful Integration</h3>
-
-<p>Most educators are finding a middle ground between full adoption and complete rejection, adapting their teaching methods thoughtfully rather than radically. The key is to focus on what matters most: developing students&#x27; critical thinking, creativity, and ability to evaluate information. In many ways, AI is pushing us to do what good teachers have always done - move beyond rote learning to deeper understanding. The challenge now isn&#x27;t just teaching subject matter, but teaching students how to learn and think in a world where AI is a constant companion.</p>
-</div>
-</div>
-</div>
-
-
-    </div><div>
-    <p>Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg"></p>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem site-nav__subitem--active'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Potential and Limitations of Gen AI</h2>
+            <div>
+
+            <div>
+            <div><img alt="Student speaking with chatbot in futuristic setting" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/electronaxe_Vector_illustration_of_a_futuristic_AI_chatbot_inte_cd37a2a3-d22e-4fcd-9f35-739b853760cf.png">
+            <h1><i></i>Generative AI&#x27;s Impact on Education</h1>
+
+            <div><img alt="Abstract representation of AI enhancing education" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract%20concept%20of%20AI%20in%20education%2C%20glowing%20brain%20network%2C%20books%2C%20stylized&amp;w=120&amp;h=120&amp;style=professional&amp;transparent=false">
+            <div>
+            <p>Although we&#x27;re still unpacking what kinds of impacts <span>generative AI</span> will have on education, we are starting to get a handle on it. <span>Generative AI</span> is available, easy to access, easy to use, and a powerful tool when used correctly. Students and educators alike are already using it and making an impact on their learning and teaching. It promises benefits like enhanced personalized learning, accelerated curriculum development, and real-time feedback; but it can also support drawbacks like cheating, plagiarism, and serving as a crutch to bypass critical thinking. The task to ensure we maximize its potential to elevate learning and minimize the potential to undermine it is one of the key challenges we face as educators.</p>
+
+            <p>This section outlines some examples of <span>generative AI</span> use in education, highlights pros and cons, and then considers its use from the perspective of a teacher and a student. Let&#x27;s start with some examples of how <span>generative AI</span> can be used in education:</p>
+            </div>
+            </div>
+
+            <hr> 
+            <div>
+            <h3><i></i>Personalized Learning Content</h3>
+
+            <p><span>Generative AI</span> can create tailored learning materials based on individual students&#x27; learning styles, preferences and performance, enhancing personalized education.</p>
+
+            <h5>Applications:</h5>
+
+            <ul>
+            	<li>Adaptive textbooks</li>
+            	<li>Interactive modules</li>
+            	<li>Customized practice exercises</li>
+            </ul>
+
+            <div>
+            <div>
+            <h5><i></i>Pros</h5>
+
+            <ul>
+            	<li>Improve understanding</li>
+            	<li>Improve retention</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Cons</h5>
+
+            <ul>
+            	<li>Quality of content will vary</li>
+            	<li>Content would still need teacher oversight</li>
+            	<li>Privacy concerns</li>
+            	<li>Unequal accessibility</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+            <hr> 
+            <div>
+            <h3><i></i>Content Creation</h3>
+
+            <p>Educators can use <span>generative AI</span> to develop a wide array of content from textbooks to interactive modules. These <span>AI</span> systems can create content that is aligned with the curriculum, updated in real-time, and customized to cater to a diverse student population.</p>
+
+            <h5>Applications:</h5>
+
+            <ul>
+            	<li><span>AI</span> generated lesson plans</li>
+            	<li>Worksheets</li>
+            	<li>Videos</li>
+            	<li>Case studies</li>
+            	<li>Scenarios</li>
+            	<li>Problems and challenges</li>
+            </ul>
+
+            <div>
+            <div>
+            <h5><i></i>Pros</h5>
+
+            <ul>
+            	<li>Save time</li>
+            	<li>Easily customize content</li>
+            	<li>Get immediate feedback</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Cons</h5>
+
+            <ul>
+            	<li>You still can&#x27;t 100% trust that <span>AI</span> output - quality assurance checks needed</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+            <hr> 
+            <div>
+            <h3><i></i>Personalized Tutor/Mentor/Coach</h3>
+
+            <p>An <span>AI</span> chatbot can act as a virtual tutor/mentor/coach presenting content, checking for understanding, and providing prompts and coaching to support learning. <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4475995" rel="noopener noreferrer" target="_blank">Ethan and Lilach Mollick</a> have created and tested a few comprehensive prompts that work reasonably well in ChatGPT (GPT-4) and Microsoft Copilot, but they are not quite as capable as you would hope. It is likely that an LLM used as a tutor would have to be specially trained to act as a good tutor. Khan Academy (<a href="https://www.khanacademy.org/khan-labs" rel="noopener noreferrer" target="_blank">Khanmigo</a>), Google (<a href="https://learning.google.com/experiments/learn-about" rel="noopener noreferrer" target="_blank">Learn About</a>) and others are working on such things, but their effectiveness is not yet proven.</p>
+
+            <h5>Applications:</h5>
+
+            <ul>
+            	<li>Directly support student learning at any time</li>
+            </ul>
+
+            <div>
+            <div>
+            <h5><i></i>Pros</h5>
+
+            <ul>
+            	<li>Tutor would be tireless, always available, endlessly patient</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Cons</h5>
+
+            <ul>
+            	<li>General purpose AIs are not reliable for this</li>
+            	<li>Fine-tuned chatbots not readily available</li>
+            	<li>Still relatively unproven</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+            <hr> 
+            <div>
+            <h3><i></i>Enhanced Student Work</h3>
+
+            <p>If students are coached on effective and ethical use of <span>generative AI</span>, teachers can potentially set their quality expectations higher. For example, Ethan Mollick requires his <a href="https://twitter.com/emollick/status/1660794981286641670" rel="noopener noreferrer" target="_blank">entrepreneurship student to do at least one impossible task in their projects</a>. Basically, what he means by this is that <span>generative AI</span> can help you code, create a website, design an app without you needing to know how to do that.</p>
+
+            <h5>Applications:</h5>
+
+            <ul>
+            	<li>More ambitious assignments</li>
+            </ul>
+
+            <div>
+            <div>
+            <h5><i></i>Pros</h5>
+
+            <ul>
+            	<li>Higher quality of work from students</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Cons</h5>
+
+            <ul>
+            	<li>Privacy concerns</li>
+            	<li><span>Generative AI</span> training may take over other important aspects of class</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+            <hr> 
+            <div>
+            <h3><i></i>Real-time Feedback</h3>
+
+            <p><span>Generative AI</span> is capable of providing immediate feedback on your writing, your coding, and even on your ideas..</p>
+
+            <h5>Applications:</h5>
+
+            <ul>
+            	<li>Students can check their own work</li>
+            	<li>Marking assistance</li>
+            </ul>
+
+            <div>
+            <div>
+            <h5><i></i>Pros</h5>
+
+            <ul>
+            	<li>Faster marking</li>
+            	<li>Learners get feedback right away</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Cons</h5>
+
+            <ul>
+            	<li>Privacy concerns</li>
+            	<li>Bias in <span>AI</span> could affect its feedback</li>
+            	<li>Accuracy of marking</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+
+            <hr> 
+            <div>
+            <h3><i></i>Language Translation</h3>
+
+            <p><span>AI</span> can instantly translate educational content (student or teacher generated) from and to many languages. General purpose chatbots are pretty good at this and specialized translators are even better.</p>
+
+            <p><img alt="" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/World_and_Languages.png"></p>
+
+            <h5>Applications:</h5>
+
+            <ul>
+            	<li>Translate educational content for English language learners</li>
+            	<li>Translate student work into English</li>
+            </ul>
+
+            <div>
+            <div>
+            <h5><i></i>Pros</h5>
+
+            <ul>
+            	<li>Supports inclusivity</li>
+            	<li>Facilitates international collaboration</li>
+            	<li>Aids comprehension</li>
+            </ul>
+            </div>
+
+            <div>
+            <h5><i></i>Cons</h5>
+
+            <ul>
+            	<li>Translations might lack context and cultural sensitivity</li>
+            	<li>Loss of meaning or nuance</li>
+            </ul>
+            </div>
+            </div>
+            </div>
+            </div>
+            </div>
+
+
+                </div><div>
+
+            <div><img alt="Robots in style of Andy Warhol" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/electronaxe_cute_robot_taking_careful_notes_13381e5d-a13e-4d70-b3a3-15cfb39f32d1.png"></div>
+
+            <div>
+            <div>
+            <h1><i></i>Weighing the Benefits and Challenges of AI in Education</h1>
+
+            <div><img alt="Abstract graphic representing balance in AI for education" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=abstract%20graphic%20representing%20the%20balance%20of%20opportunities%20and%20challenges%20in%20AI%20for%20education%2C%20gears%2C%20lightbulb%2C%20question%20mark&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
+            <div>
+            <p>The integration of AI in education brings both <span>significant opportunities</span> and <span>notable challenges</span>. Understanding this balance is key to harnessing AI&#x27;s potential responsibly and effectively in learning environments.</p>
+            </div>
+            </div>
+
+            <hr>
+
+
+
+            <div>
+            <h3><i></i>The Hurdles: Challenges and Concerns</h3>
+
+            <ol>
+            	<li><strong>Data Privacy Concerns:</strong> On the previous page, data privacy came up as an issue over and over again. Anytime that you enter something into a chatbot, you are &quot;feeding the beast&quot;, i.e., giving the AI company even more data. Different AI companies will have different privacy policies, but the reality is you are sending them your (or your students&#x27;) information and despite the policies, they have your data. AI companies are aware of these issues and are working on ways to support privacy-sensitive applications. One potential way to support privacy is to provide a private server for institutes. These are in the works, but currently require a large investment and/or a lot of specialized expertise.<br>
+            	 </li>
+            	<li><strong>Equity and Access Issues:</strong> AI can seem magical and spellbinding but it is not universally accessible. Not only are some LLMs geographically locked down, but the best tools cost money. The digital divide is real, and the question lingers - how do we ensure that every learner, irrespective of their socio-economic status has equal access.<br>
+            	 </li>
+            	<li><strong>Everything it Outputs is Made Up:</strong> This is a crucial point that&#x27;s often overlooked - LLMs don&#x27;t actually &quot;know&quot; anything in the way humans do. They create their responses by predicting what words should come next based on patterns in their training data. While these predictions can be remarkably accurate and useful, they&#x27;re still essentially sophisticated guesses. This means that even when an AI sounds completely confident, it might be completely wrong, or worse, it might blend truth and fiction in ways that are hard to detect. This is particularly problematic in education where accuracy and reliability are paramount.<br>
+            	 </li>
+            	<li><strong>Output May Not Be Reliable or Consistent:</strong> Ask an LLM the same question twice, and you&#x27;ll likely get two different answers. While these answers might convey similar information, they can vary significantly in their details, depth, and sometimes even accuracy. This inconsistency can be particularly challenging in educational settings where we need dependable, standardized information. Bottom line: Every AI output needs human verification, and using this critical verification skill is essential.</li>
+            	<li><strong>Overuse and Overreliance</strong>: When individuals depend too heavily on AI for tasks like writing, problem-solving, or creative ideation, there&#x27;s a risk of diminishing their own critical thinking, analytical skills, and domain-specific expertise. Instead of developing a deep understanding or honing their abilities through practice, users might simply accept AI-generated outputs without sufficient scrutiny or personal engagement. This can lead to a passive learning approach, hinder the development of essential cognitive skills, and ultimately make individuals less capable when faced with novel situations or tasks where AI assistance is unavailable or inappropriate. Fostering a balance where AI serves as an assistant rather than a replacement is crucial to ensure that human intellect and creativity continue to flourish.</li>
+            	<li><strong>The Need for New Pedagogical Approaches:</strong> The integration of AI into educational settings will require many teachers to re-examine their style and their approach to education. We are all going to have to think about how we provide content, how we do assessment, and how (or whether) we support our students to use AI as well.<br>
+            	 </li>
+            	<li><strong>Other Ethical Considerations:</strong> The rise of generative AI gives rise to a number of other ethical considerations, many of which we should consider as we integrate generative AI into our teaching and learning practices.
+            	<ul>
+            		<li>LLMs can perpetuate and amplify existing biases because of the data they were trained on.</li>
+            		<li>The data used for training may have come from sources the LLMs didn&#x27;t have explicit rights to use. Should we consider not using an LLM because it may have violated intellectual property rights?</li>
+            		<li>The servers used by LLMs for training and for running their neural networks use a lot of energy. Alphabet&#x27;s CEO estimates that <a href="https://www.reuters.com/technology/tech-giants-ai-like-bing-bard-poses-billion-dollar-search-problem-2023-02-22/" rel="noopener noreferrer" target="_blank">an LLM query could use as much as 10 times the energy of a standard Google search</a>. Companies like Microsoft are looking at lower carbon footprint solutions (like solar or <a href="https://www.theverge.com/2023/9/26/23889956/microsoft-next-generation-nuclear-energy-smr-job-hiring" rel="noopener noreferrer" target="_blank">small scale nuclear reactors</a>), but good solutions are not yet in use.</li>
+            		<li>Generative AI will likely cause some level of job displacement. How should education adapt to mitigate this harm?</li>
+            		<li>Social media already has a significant impact on our lives; affecting mental health and facilitating the spread of mis- and disinformation. Generative AI will enable a massive increase in the ability to create mis/disinformation. What role can we play in combating this?</li>
+            	</ul>
+            	</li>
+            </ol>
+            </div>
+            <hr>
+
+
+            <div>
+            <h3><i></i>The Upside: Benefits of AI in Education</h3>
+
+            <ol>
+            	<li><strong>Personalized Learning Experiences:</strong> The ideal classroom is one where every student&#x27;s unique learning style, pace, and need is catered to. AI has the potential to make this happen. It&#x27;s not quite there yet, but if the pace of AI development over the last year or so is any indication, we are not far off. As a counter to this pro, we, as educators, really have to think deeply about what our role will be.<br>
+            	 </li>
+            	<li><strong>Enhanced Efficiency for Educators:</strong> Grading takes ages and planning can be a grind. Generative AI can potentially take care of a lot of this grunt work, but we have to be careful. AI still makes stuff up and feeding student work into ChatGPT is probably a privacy violation.<br>
+            	 </li>
+            	<li><strong>Ease of Generating Diverse Content:</strong> Generative AI makes it easy to take a base of content and modify it in ways that offer students multiple perspectives, make it more accessible for students with diverse needs, and adapt it to different languages.<br>
+            	 </li>
+            	<li><strong>Idea Generator:</strong> Are generative AI tools actually creative? I don&#x27;t know the answer to that, I do know that if you ask a chatbot for 50 unique ideas for a business related to shoe repair, it will give you 50 (or about 50, it&#x27;s not always great at counting) ideas in less than 30 seconds. Now, most of those ideas will be not so great, but I&#x27;m sure a few will be worthy of some thought and there may be a diamond. Even if you don&#x27;t use any of the ideas, you will probably be inspired for a new idea based on the ones the AI gives you. The best haiku I&#x27;ve ever written was 75% written by me, but 25% inspired by an idea that ChatGPT gave me.<br>
+            	 </li>
+            	<li><strong>Personal Assistant or Sounding Board:</strong> I recently took a course on course design supported by AI. The course facilitator had created a number of comprehensive prompts that helped us create a learner profile, generate knowledge maps and learning outcomes, and then a storyboard for a course. One thing that we (all the students) remarked on was that, while the AI did not actually save us much time, the quality of work that we produced was much better than if we did it without the AI. Having the AI as an idea generator and then sounding board to bounce other ideas off of significantly improved our work.<br>
+            	 </li>
+            	<li><strong>AI is Good at Giving Data-Driven Insights:</strong> Really, this is all AI does. It makes connections between the data that you train it with and then uses those connections to provide &quot;insight&quot; into any new data that you feed it. Image generators do this with pixels and LLMs do this with words. LLMs also do this with numbers and since data is really nothing more than a bunch of organized words and numbers LLMs are surprisingly good at analyzing spreadsheets, creating spreadsheets from raw data, and even highlighting links in data that you may have missed. ChatGPT Plus in Advanced Data Analysis mode is the best gen AI tool for doing this kind of thing.</li>
+            </ol>
+            </div>
+
+
+            </div>
+            </div>
+
+
+                </div><div>
+
+                <div> 
+                <div>
+
+                    <h1><i></i>Student Voices: Navigating AI in Education</h1>
+
+                    <img alt="Dreamy vision of student studying with futuristic AI interface" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/midjourney_-_vector_illustration_of_futuristic_chatbot_interface.png">
+
+                    <div>
+                        <img alt="Abstract representation of student discussion" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=stylized%20icon%20of%20students%20discussing%20around%20a%20glowing%20AI%20symbol%2C%20vector%20art&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
+                        <div>
+                            <p>I came across an interesting comment from a student on <a href="https://www.cbc.ca/listen/live-radio/1-63-the-current/clip/16007287-questions-ais-role-classroom" target="_blank" rel="noopener noreferrer">a podcast by CBC&#x27;s The Current</a> about using generative AI like ChatGPT in education. This student was very motivated to learn but found some courses irrelevant. Due to a heavy course load, they focused on the courses they felt most relevant and used ChatGPT for the rest. Many students feel the same, especially when overwhelmed with work, and turn to ChatGPT for help. Cases like this show the willingness of students to use generative AI to cheat, but students also seem to understand the risks of doing so which they identified as not just academic penalties but also the learning they miss out on.</p>
+                        </div>
+                    </div>
+
+                    <hr>
+
+                    <div>
+                        <h3><i></i>Perceived Benefits of GenAI</h3>
+                        <p>A survey by Cecilia Chan and Wenjie Hu of 339 students across six Hong Kong universities revealed that students find GenAI useful for:</p>
+
+                        <div>
+                            <h5>Key Advantages Identified by Students:</h5>
+                            <ul>
+                                <li>Personalized and immediate learning support</li>
+                                <li>Support with writing and brainstorming</li>
+                                <li>Help with research and analysis</li>
+                                <li>Support with visual and audio multimedia</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <hr>
+
+                    <div>
+                        <h3><i></i>Student Concerns and Apprehensions</h3>
+                        <p>The same study highlighted significant student concerns regarding the use of GenAI in education:</p>
+
+                        <div>
+                            <h5>Primary Concerns Voiced:</h5>
+                            <ul>
+                                <li>Accuracy and transparency of AI-generated information</li>
+                                <li>Privacy issues and data security</li>
+                                <li>Potential loss of critical thinking and other essential skills</li>
+                                <li>Job displacement or hiring challenges due to AI advancements</li>
+                                <li>Exacerbation of socio-economic disparities</li>
+                                <li>Ambiguity in institutional policies: navigating ethical use without academic dishonesty</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <hr>
+
+                    <div>
+                        <h3><i></i>Global Student Questions</h3>
+                        <p>These concerns are echoed by students globally, as discussed in forums like the <a href="https://www.aixeducation.com/" target="_blank" rel="noopener noreferrer">AIxEducation conference</a>. Students worldwide are grappling with a new set of critical questions:</p>
+
+                        <div> 
+                            <h5>Pressing Questions from Students:</h5>
+                            <ul>
+                                <li>How can I master these AI tools amidst an already demanding academic schedule?</li>
+                                <li>How can I afford access to premium AI tools?</li>
+                                <li>If I use AI for writing, does it compromise my authentic voice and learning?</li>
+                                <li>How will educators address the digital divide regarding access to advanced AI tools?</li>
+                                <li>Will AI ultimately devalue my hard-earned education and skills?</li>
+                            </ul>
+                        </div>
+                        <p>The AI tide is rolling in, with or without an invitation. Students are savvy; they see the potential of AI as both a powerful tool and a complex challenge. They are ready to engage, albeit with understandable trepidation about the evolving rules of this new academic landscape.</p>
+                    </div>
+
+                    <hr>
+
+                    <div>
+                        <h3><i></i>The Educator&#x27;s Tightrope</h3>
+                        <p>Educators, too, find themselves in a delicate balancing act. They are tasked with a dual mandate: to deter the misuse of AI while simultaneously championing its educational benefits. As they navigate this complex terrain, the core challenge is to ensure that the fundamental essence of education—critical thinking, creativity, and genuine understanding—isn&#x27;t lost amidst the growing capabilities of artificial intelligence.</p>
+                    </div>
+
+                </div> 
+            </div> 
+
+
+
+
+
+                </div><div>
+
+            <div><img alt="Charismatic teacher surrounded by students" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/electronaxe_Digital_art_in_a_wide_51_aspect_ratio_showcasing_a__99bee07d-2145-48b4-9448-fc9b6db88aa5.png"></div>
+
+            <div>
+            <div>
+            <h1><i></i>AI in the Classroom: Teacher Perspectives &amp; Evolving Practices</h1>
+
+            <div><img alt="Abstract representation of AI transforming education" loading="lazy" src="https://cdn.simulationtheory.ai/gasset/?asset=img&amp;prompt=stylized%20brain%20with%20gears%20and%20digital%20network%20connections%2C%20representing%20AI%20in%20education%2C%20modern%20flat%20design&amp;w=150&amp;h=150&amp;style=professional&amp;transparent=false">
+            <div>
+            <p>When ChatGPT was first released in November 2022, many teachers had a moment of panic and thought that either &quot;this is the end of education as we know it <i></i>&quot; or &quot;this is the end of education as we know it <i></i>&quot;. Proponents like Ethan Mollick fully embraced ChatGPT and sought the best ways to use it in his classes. At the same time, school districts like the one in New York City banned ChatGPT outright because they didn&#x27;t know how to deal with it at the time. Ethan Mollick&#x27;s level of adoption is beyond what most of us know how to do and NYC school&#x27;s reaction was an excessive knee-jerk reaction to the new technology that has since been reversed. Now that the initial reactions are behind us, many educators have put a lot of thought into how to best make use of LLMs like ChatGPT to support the education of our students. Institutes have added AI to their academic policies and most of these that I have read are permissive and generally put the choice of if and how to allow its use in the hands of the teachers and professors. Institutes have also released guidelines on how educators might use AI in their classes along with suggestions on how to adapt assignments to support its use.</p>
+            </div>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>Adapting to the New Landscape</h3>
+
+            <p>It&#x27;s clear that most teachers are going to need to change their practices somewhat, but the amount of change will vary from level to level and from topic to topic. Primary school teachers have likely changed their approach very little and instructors teaching exclusively hands-on topics probably haven&#x27;t changed much either. On the other hand first year English and computer science professors have likely had to change their approach a lot - these are courses for which ChatGPT can probably help the most (write an essay, write some simple code), and first year courses (especially ones that students only take because they have to) are the courses in which students are most likely to look for outside &quot;help&quot;. The value of the AI output for courses like this is high and so is the incentive.</p>
+            </div>
+
+            <hr>
+            <div>
+            <h3><i></i>The Path Forward: Thoughtful Integration</h3>
+
+            <p>Most educators are finding a middle ground between full adoption and complete rejection, adapting their teaching methods thoughtfully rather than radically. The key is to focus on what matters most: developing students&#x27; critical thinking, creativity, and ability to evaluate information. In many ways, AI is pushing us to do what good teachers have always done - move beyond rote learning to deeper understanding. The challenge now isn&#x27;t just teaching subject matter, but teaching students how to learn and think in a world where AI is a constant companion.</p>
+            </div>
+            </div>
+            </div>
+
+
+                </div>
+        </section>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,199 +1,1285 @@
-:root {
-    --color-background: #f8fafc;
-    --color-surface: #ffffff;
-    --color-text: #1f2937;
-    --color-accent: #2563eb;
-    --color-muted: #475569;
-    --color-border: #e2e8f0;
-}
-
-* {
-    box-sizing: border-box;
+/* Base structure */
+html {
+    font-size: 77%;
 }
 
 body {
     margin: 0;
-    font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-    line-height: 1.65;
-    background: var(--color-background);
-    color: var(--color-text);
+    font-family: 'Inter', sans-serif;
+    line-height: 1.6;
+    color: #1f2937;
+    background-color: #f3f4f6;
 }
 
-a {
-    color: var(--color-accent);
-    text-decoration: none;
+#gai-wrap {
+    padding: 0.0625rem 0;
 }
 
-a:hover,
-a:focus {
-    text-decoration: underline;
+#gai-wrap .gai-cont {
+    max-width: 56.25rem;
+    margin: 2rem auto;
+    padding: 0 1rem;
 }
 
-header {
-    background: var(--color-text);
-    color: #ffffff;
-    padding: 2.5rem 1.5rem 2rem;
+/* Typography */
+#gai-wrap h1,
+#gai-wrap h2,
+#gai-wrap h3,
+#gai-wrap h4,
+#gai-wrap h5 {
+    margin-top: 0;
+    margin-bottom: 0.85rem;
+    font-weight: 600;
+    color: #111827;
 }
 
-header .site-title {
-    max-width: 1024px;
-    margin: 0 auto;
-}
-
-header h1 {
-    margin: 0;
+#gai-wrap h1 {
     font-size: 2rem;
+    text-align: center;
+    margin-bottom: 1.5rem;
 }
 
-header h1 a {
-    color: inherit;
+#gai-wrap h2 {
+    font-size: 1.8rem;
+    margin-top: 2.5rem;
+    margin-bottom: 1.25rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 0.125rem solid #3b82f6;
 }
 
-header .tagline {
-    margin: 0.5rem 0 0;
-    font-size: 1rem;
-    color: #e2e8f0;
+#gai-wrap .gai-h2-underline {
+    padding-bottom: 0.5rem;
+    border-bottom: 0.125rem solid #3b82f6;
 }
 
-nav {
-    background: var(--color-surface);
-    border-bottom: 1px solid var(--color-border);
-    padding: 1rem 1.5rem;
+#gai-wrap h3 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+    color: #1d4ed8;
 }
 
-nav .nav-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+#gai-wrap h4 {
+    font-size: 1.4rem;
+    margin-bottom: 0.75rem;
+    color: #111827;
 }
 
-nav .nav-list > li {
-    margin-bottom: 0.5rem;
+#gai-wrap h5 {
+    color: #111827;
 }
 
-nav .nav-list li a {
-    display: inline-block;
-    padding: 0.35rem 0;
+#gai-wrap p {
+    margin-bottom: 1rem;
+    font-size: 1.3rem;
+    line-height: 1.6;
+    color: #374151;
 }
 
-nav .nav-list li.has-children > a {
+#gai-wrap p.no-mb {
+    margin-bottom: 0;
+}
+
+#gai-wrap .gai-end-txt,
+#gai-wrap .gai-tool-card p,
+#gai-wrap .gai-quick-activity p,
+#gai-wrap .gai-accordion-content,
+#gai-wrap .gai-instructor-notes p,
+#gai-wrap .genai-custom-info-box p,
+#gai-wrap .gai-warning-box p,
+#gai-wrap .gai-module-card p,
+#gai-wrap .gai-info li,
+#gai-wrap .gai-box ul li,
+#gai-wrap .gai-box ol li,
+#gai-wrap .gai-table td,
+#gai-wrap .gai-table th,
+#gai-wrap .gai-table td ul li,
+#gai-wrap .gai-table td ol li,
+#gai-wrap .gai-quick-activity ul li,
+#gai-wrap .gai-accordion-content ul li,
+#gai-wrap .gai-accordion-content ol li,
+#gai-wrap .gai-instructor-notes ul li,
+#gai-wrap .gai-tool-list li {
+    font-size: 1.3rem;
+    line-height: 1.6;
+}
+
+#gai-wrap .gai-info h5,
+#gai-wrap .gai-quick-activity h4,
+#gai-wrap .genai-custom-info-box h5,
+#gai-wrap .gai-workflow-box h5,
+#gai-wrap .gai-instructor-notes h5,
+#gai-wrap .gai-references h5,
+#gai-wrap .gai-tool-card h3,
+#gai-wrap .gai-clmn-card h3 {
     font-weight: 600;
 }
 
-nav .nav-list li.active > a {
-    color: var(--color-text);
-    font-weight: 700;
-}
-
-nav .nav-list ul {
-    list-style: none;
-    margin: 0.25rem 0 0 1.25rem;
-    padding: 0;
-    border-left: 2px solid var(--color-border);
-}
-
-main {
-    max-width: 1024px;
-    margin: 0 auto;
-    background: var(--color-surface);
-    padding: 2.5rem 1.5rem 3rem;
-    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
-}
-
-main h2 {
+#gai-wrap .gai-info h5,
+#gai-wrap .gai-quick-activity h4,
+#gai-wrap .gai-workflow-box h5,
+#gai-wrap .gai-instructor-notes h5,
+#gai-wrap .gai-references h5,
+#gai-wrap .gai-module-card h4 {
     margin-top: 0;
-    font-size: 2rem;
 }
 
-main h3 {
-    margin-top: 2rem;
+#gai-wrap .gai-info h5,
+#gai-wrap .gai-quick-activity h4,
+#gai-wrap .gai-tool-card h3,
+#gai-wrap .gai-clmn-card h3,
+#gai-wrap .gai-workflow-box h5,
+#gai-wrap .gai-instructor-notes h5,
+#gai-wrap .genai-custom-info-box h5 {
+    margin-bottom: 0.75rem;
+}
+
+#gai-wrap .gai-info h5 {
+    font-size: 1.6rem;
+    color: #1e3a8a;
+    margin-bottom: 0.5rem;
+}
+
+#gai-wrap .gai-quick-activity h4 {
+    font-size: 1.5rem;
+    color: #0369a1;
+}
+
+#gai-wrap .gai-workflow-box h5 {
+    font-size: 1.5rem;
+    color: #111827;
+}
+
+#gai-wrap .gai-module-card h4 {
     font-size: 1.4rem;
+    color: #0369a1;
+    margin-bottom: 0.75rem;
 }
 
-main h4 {
-    margin-top: 1.5rem;
+#gai-wrap .gai-instructor-notes h5 {
+    font-size: 1.5rem;
+    color: #166534;
+    margin-bottom: 0.5rem;
+}
+
+#gai-wrap .gai-references h5 {
+    font-size: 1.4rem;
+    color: #4b5563;
+}
+
+#gai-wrap .gai-tool-card h3 {
+    font-size: 1.5rem;
+    color: #1d4ed8;
+}
+
+#gai-wrap .gai-clmn-card h3 {
+    font-size: 1.5rem;
+    color: #2563eb;
+    display: flex;
+    align-items: center;
+}
+
+#gai-wrap .gai-icon-text {
+    margin-left: 0.5rem;
+    font-weight: 600;
+    font-size: 1.125rem;
+}
+
+#gai-wrap .gai-blockquote {
+    margin: 1.5em 0;
+    padding: 1em 1.5em;
+    border-left: 0.3125rem solid #f59e0b;
+    background-color: #fffbeb;
+    color: #78350f;
+    border-radius: 0.25rem;
+}
+
+#gai-wrap .gai-blockquote h2 {
+    margin-bottom: 0.5em;
+    color: #78350f;
+    border-bottom: none;
+}
+
+#gai-wrap .gai-inspiration-source {
+    margin: 1rem 0;
+    padding: 0.75rem 1rem;
+    border: 0.0625rem solid #e5e5e5;
+    border-radius: 0.375rem;
+    background-color: #fafafa;
+    color: #525252;
     font-size: 1.2rem;
 }
 
-main p {
-    margin: 1rem 0;
-    color: var(--color-muted);
+#gai-wrap .gai-inspiration-source i {
+    margin-right: 0.5rem;
+    color: #737373;
 }
 
-main ul,
-main ol {
+#gai-wrap .gai-inspiration-source a {
+    font-weight: 600;
+    color: #2563eb;
+}
+
+/* Links */
+#gai-wrap a {
+    color: #2563eb;
+    text-decoration: none;
+}
+
+#gai-wrap a:hover {
+    color: #1d4ed8;
+    text-decoration: underline;
+}
+
+#gai-wrap .gai-box a,
+#gai-wrap p a,
+#gai-wrap .gai-table a {
+    color: #2563eb;
+    text-decoration: underline;
+    text-decoration-thickness: 0.0625rem;
+    text-underline-offset: 0.125rem;
+}
+
+#gai-wrap .gai-box a:hover,
+#gai-wrap p a:hover,
+#gai-wrap .gai-table a:hover {
+    color: #1d4ed8;
+    text-decoration: none;
+}
+
+#gai-wrap .genai-custom-info-box a {
+    color: #0c4a6e;
+    font-weight: 600;
+}
+
+#gai-wrap .genai-custom-info-box a:hover {
+    color: #075985;
+}
+
+#gai-wrap .gai-references a {
+    color: #4b5563;
+    text-decoration: underline;
+}
+
+/* Lists */
+#gai-wrap ul,
+#gai-wrap ol {
+    list-style-position: outside;
+    padding-left: 1.75rem;
+    margin-bottom: 1rem;
+}
+
+#gai-wrap ul li,
+#gai-wrap ol li {
+    margin-bottom: 0.75rem;
+    color: #4b5563;
+}
+
+#gai-wrap .gai-box ul,
+#gai-wrap .gai-quick-activity ul,
+#gai-wrap .gai-instructor-notes ul {
+    list-style-type: disc;
+    margin-bottom: 1rem;
+}
+
+#gai-wrap .gai-box ul {
     padding-left: 1.5rem;
-    margin: 1rem 0;
 }
 
-main li + li {
-    margin-top: 0.35rem;
+#gai-wrap .gai-quick-activity ul {
+    padding-left: 1.5rem;
+    margin: 0.625rem 0 1rem;
 }
 
-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 1.5rem 0;
-    font-size: 0.95rem;
+#gai-wrap .gai-instructor-notes ul {
+    padding-left: 1.5rem;
+    margin-top: 0.625rem;
+    margin-bottom: 0;
 }
 
-table th,
-table td {
-    border: 1px solid var(--color-border);
-    padding: 0.75rem;
-    text-align: left;
+#gai-wrap .gai-box ol {
+    list-style-type: none;
+    padding-left: 0;
+    margin-bottom: 1rem;
+    counter-reset: gai-ol-counter;
 }
 
-table thead {
-    background: #f1f5f9;
+#gai-wrap .gai-box ol li {
+    position: relative;
+    padding-left: 2.8rem;
+    margin-bottom: 1rem;
+    color: #374151;
 }
 
-blockquote {
-    border-left: 4px solid var(--color-accent);
-    margin: 1.5rem 0;
-    padding: 0.75rem 1rem;
-    background: #eef2ff;
+#gai-wrap .gai-box ol li::before {
+    content: counter(gai-ol-counter);
+    counter-increment: gai-ol-counter;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 1.875rem;
+    height: 1.875rem;
+    line-height: 1.875rem;
+    border-radius: 50%;
+    background-color: #2563eb;
+    color: #ffffff;
+    text-align: center;
+    font-weight: 600;
+    font-size: 1rem;
 }
 
-footer {
-    max-width: 1024px;
-    margin: 2rem auto;
-    padding: 0 1.5rem 2rem;
-    color: var(--color-muted);
-    font-size: 0.9rem;
+#gai-wrap .gai-clmn-card ul {
+    list-style-type: disc;
+    list-style-position: outside;
+    padding-left: 1.25rem;
+    margin-bottom: 0;
 }
 
-footer p {
+#gai-wrap .gai-clmn-card li {
+    margin-bottom: 0.4rem;
+    color: #4b5563;
+    line-height: 1.5;
+    font-size: 1.3rem;
+}
+
+#gai-wrap .gai-tool-list {
+    list-style: none;
+    padding-left: 0;
+    margin-top: 1.5rem;
+}
+
+#gai-wrap .gai-tool-list li {
+    position: relative;
+    padding-left: 1.875rem;
+    margin-bottom: 1rem;
+    color: #374151;
+}
+
+#gai-wrap .gai-tool-list li::before {
+    position: absolute;
+    left: 0;
+    top: 0.25rem;
+    font-family: 'Font Awesome 6 Free';
+    font-weight: 900;
+    font-size: 1.4rem;
+}
+
+#gai-wrap .gai-tool-list li.pro::before {
+    content: '\\f058';
+    color: #16a34a;
+}
+
+#gai-wrap .gai-tool-list li.con::before {
+    content: '\\f057';
+    color: #dc2626;
+}
+
+#gai-wrap .gai-tool-list li.tip::before {
+    content: '\\f0eb';
+    color: #f59e0b;
+}
+
+#gai-wrap .gai-tool-list strong {
+    display: block;
+    margin-bottom: 0.25rem;
+    font-weight: 600;
+    color: #111827;
+}
+
+#gai-wrap .gai-info ul {
+    list-style: none;
+    padding-left: 0;
+    margin-top: 1rem;
+    margin-bottom: 0;
+}
+
+#gai-wrap .gai-info li {
+    position: relative;
+    padding-left: 1.75rem;
+    margin-bottom: 0.75rem;
+    color: #374151;
+}
+
+#gai-wrap .gai-info li::before {
+    content: '\\f00c';
+    position: absolute;
+    left: 0;
+    top: 0.25rem;
+    font-family: 'Font Awesome 6 Free';
+    font-weight: 900;
+    font-size: 1.3rem;
+    color: #28a745;
+}
+
+#gai-wrap .gai-info li strong {
+    color: #111827;
+    font-weight: 600;
+}
+
+#gai-wrap .gai-table td ul,
+#gai-wrap .gai-table td ol {
     margin: 0;
+    padding-left: 1.5rem;
+}
+
+#gai-wrap .gai-table td ul {
+    list-style-type: disc;
+    list-style-position: outside;
+}
+
+#gai-wrap .gai-table td ol {
+    list-style: none;
+    padding-left: 0;
+    counter-reset: gai-table-ol-counter;
+}
+
+#gai-wrap .gai-table td ol li {
+    position: relative;
+    padding-left: 2.2rem;
+    margin-bottom: 0.5rem;
+}
+
+#gai-wrap .gai-table td ol li::before {
+    content: counter(gai-table-ol-counter);
+    counter-increment: gai-table-ol-counter;
+    position: absolute;
+    left: 0;
+    top: 0.125rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    line-height: 1.5rem;
+    border-radius: 50%;
+    background-color: #2563eb;
+    color: #ffffff;
+    text-align: center;
+    font-weight: 600;
+    font-size: 0.875rem;
+}
+
+#gai-wrap .gai-table td ul li,
+#gai-wrap .gai-table td ol li {
+    margin-bottom: 0.5rem;
+}
+
+#gai-wrap .gai-table td ul li:last-child,
+#gai-wrap .gai-table td ol li:last-child {
+    margin-bottom: 0;
+}
+
+#gai-wrap .gai-simple-list ol li::before {
+    display: none !important;
+}
+
+/* Iconography */
+#gai-wrap h1 .genai-custom-icon,
+#gai-wrap h2 .genai-custom-icon {
+    margin-right: 0.75rem;
+    color: #1d4ed8;
+}
+
+#gai-wrap .gai-h-with-icon {
+    display: flex;
+    align-items: center;
+}
+
+#gai-wrap .gai-h-with-icon i {
+    margin-right: 0.625rem;
+    font-size: 1.7rem;
+    color: #2563eb;
+}
+
+#gai-wrap .gai-box .gai-h-with-icon i {
+    font-size: 1.6rem;
+}
+
+#gai-wrap .gai-icon-bar {
+    display: flex;
+    justify-content: space-around;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+#gai-wrap .gai-icon-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 6.25rem;
+    text-align: center;
+}
+
+#gai-wrap .gai-icon-item i {
+    margin-bottom: 0.5rem;
+    font-size: 1.7rem;
+    line-height: 1;
+}
+
+#gai-wrap .gai-icon-item .fa-search {
+    color: #ffc107;
+}
+
+#gai-wrap .gai-icon-item .fa-tv {
+    color: #dc3545;
+}
+
+#gai-wrap .gai-icon-item .fa-share-alt {
+    color: #6f42c1;
+}
+
+#gai-wrap .gai-icon-item .fa-pencil-alt {
+    color: #20c997;
+}
+
+#gai-wrap .gai-icon-item .fa-graduation-cap {
+    color: #563d7c;
+}
+
+#gai-wrap .gai-icon-item span {
+    font-size: 0.875rem;
+    color: #374151;
+    line-height: 1.3;
+}
+
+#gai-wrap .gai-accordion-summary .fa-wrench {
+    color: #2563eb;
+}
+
+#gai-wrap .gai-accordion-summary .fa-book-open {
+    color: #16a34a;
+}
+
+#gai-wrap .gai-accordion-summary i.fas,
+#gai-wrap .gai-accordion-summary i.fab {
+    margin-right: 0.5rem;
+    color: #2563eb;
+    font-size: 1.1em;
+}
+
+#gai-wrap .gai-tool-card h3 i {
+    margin-right: 0.75rem;
+    width: 1.25rem;
+    text-align: center;
+    color: #2563eb;
+}
+
+#gai-wrap .gai-clmn-card h3 i {
+    margin-right: 0.6rem;
+    font-size: 1.4rem;
+}
+
+#gai-wrap .gai-info h5 i,
+#gai-wrap .gai-quick-activity h4 i,
+#gai-wrap .genai-custom-info-box h5 i,
+#gai-wrap .gai-workflow-box h5 i,
+#gai-wrap .gai-instructor-notes h5 i {
+    margin-right: 0.5rem;
+}
+
+#gai-wrap .gai-info h5 i {
+    color: #3b82f6;
+}
+
+#gai-wrap .gai-quick-activity h4 i {
+    color: #0ea5e9;
+}
+
+#gai-wrap .genai-custom-info-box h5 i {
+    color: #0ea5e9;
+}
+
+#gai-wrap .gai-workflow-box h5 i {
+    color: #4b5563;
+}
+
+#gai-wrap .gai-instructor-notes h5 i {
+    color: #22c55e;
+}
+
+#gai-wrap .gai-button-visual i {
+    margin-right: 0.5rem;
+}
+
+/* Layout & containers */
+#gai-wrap .gai-box {
+    margin-bottom: 2.5rem;
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    background-color: #ffffff;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem rgba(0, 0, 0, 0.1),
+        0 0.125rem 0.25rem -0.0625rem rgba(0, 0, 0, 0.06);
+}
+
+#gai-wrap .gai-clmns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+#gai-wrap .gai-clmn-card {
+    flex: 1 1 18.75rem;
+    min-width: 17.5rem;
+    padding: 1.25rem;
+    border-radius: 0.5rem;
+    background-color: #f8f9fa;
+    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.05);
+}
+
+#gai-wrap .gai-hero-container {
+    height: 18.75rem;
+    margin-bottom: 2.5rem;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem rgba(0, 0, 0, 0.1),
+        0 0.125rem 0.25rem -0.0625rem rgba(0, 0, 0, 0.06);
+}
+
+#gai-wrap .gai-hero-graphic {
+    text-align: center;
+    margin-bottom: 2rem;
+    padding: 1rem 0;
+}
+
+#gai-wrap .gai-content-image {
+    margin: 1.25rem 0;
+    padding: 0.625rem;
+    border-radius: 0.5rem;
+    text-align: center;
+    background-color: #f9fafb;
+    border: 0.0625rem solid #e9ecef;
+    box-shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.05);
+}
+
+#gai-wrap .gai-workflow-box {
+    margin: 1.5rem 0;
+    padding: 1.25rem;
+    border-radius: 0.5rem;
+    border: 0.125rem dashed #6b7280;
+    background-color: #f9fafb;
+}
+
+#gai-wrap .gai-workflow-box p {
+    padding-left: 1.75rem;
+    margin-bottom: 0.625rem;
+    color: #374151;
+}
+
+#gai-wrap .gai-graphic-idea {
+    display: block;
+    margin: 1rem 0;
+    padding: 0.75rem;
+    border-radius: 0.375rem;
+    border: 0.0625rem dashed #d1d5db;
+    background-color: #f9fafb;
+    color: #6b7280;
+    font-style: italic;
+    line-height: 1.5;
+}
+
+#gai-wrap .gai-hero-img-tag {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+}
+
+#gai-wrap .gai-hero-graphic img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 0.5rem;
+    box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
+}
+
+#gai-wrap .gai-end-txt {
+    margin: 1.5rem 0.5rem 1rem;
+    text-align: left;
+    color: #374151;
+}
+
+#gai-wrap .gai-placeholder-link {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    border: 0.0625rem dashed #f59e0b;
+    background-color: #fffbeb;
+    color: #78350f;
+    font-style: italic;
+    font-size: 1.1em;
+}
+
+#gai-wrap .gai-str {
+    font-weight: 600;
+    color: #2563eb;
+}
+
+#gai-wrap .gai-gloss {
+    cursor: pointer;
+    color: #2563eb;
+    text-decoration: underline dotted;
+}
+
+#gai-wrap .gai-button-visual {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.375rem;
+    border: 0.0625rem solid #c7d2fe;
+    background-color: #eef2ff;
+    color: #4338ca;
+    font-weight: 600;
+    font-size: 1.2rem;
+}
+
+#gai-wrap .gai-tool-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(21.875rem, 1fr));
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+}
+
+/* Informational panels */
+#gai-wrap .gai-info,
+#gai-wrap .gai-quick-activity,
+#gai-wrap .gai-warning-box,
+#gai-wrap .genai-custom-info-box,
+#gai-wrap .gai-instructor-notes {
+    margin: 1.5rem 0;
+    padding: 1.25rem;
+    border-radius: 0 0.5rem 0.5rem 0;
+    box-shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.1),
+        0 0.0625rem 0.125rem rgba(0, 0, 0, 0.06);
+}
+
+#gai-wrap .gai-info {
+    border-left: 0.25rem solid #3b82f6;
+    background-color: #eff6ff;
+}
+
+#gai-wrap .gai-quick-activity {
+    border-left: 0.25rem solid #0ea5e9;
+    background-color: #f0f9ff;
+    box-shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.05),
+        0 0.0625rem 0.125rem rgba(0, 0, 0, 0.05);
+}
+
+#gai-wrap .gai-quick-activity p {
+    margin-bottom: 0.625rem;
+    color: #374151;
+}
+
+#gai-wrap .gai-warning-box {
+    border-left: 0.25rem solid #f59e0b;
+    background-color: #fffbeb;
+    color: #78350f;
+    box-shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.05),
+        0 0.0625rem 0.125rem rgba(0, 0, 0, 0.05);
+}
+
+#gai-wrap .genai-custom-info-box {
+    border-left: 0.25rem solid #0ea5e9;
+    background-color: #e0f2fe;
+}
+
+#gai-wrap .genai-custom-info-box p {
+    margin-bottom: 0;
+    color: #075985;
+}
+
+#gai-wrap .gai-instructor-notes {
+    border-left: 0.25rem solid #22c55e;
+    background-color: #f0fdf4;
+}
+
+#gai-wrap .gai-instructor-notes p {
+    margin-bottom: 0.625rem;
+    color: #15803d;
+}
+
+#gai-wrap .gai-info h5,
+#gai-wrap .gai-quick-activity h4,
+#gai-wrap .gai-warning-box p,
+#gai-wrap .genai-custom-info-box h5,
+#gai-wrap .gai-instructor-notes h5 {
+    margin-bottom: 0.5rem;
+}
+
+#gai-wrap .gai-warning-box p {
+    font-weight: 500;
+    margin-bottom: 0;
+}
+
+/* Accordion */
+#gai-wrap .gai-accordion-group {
+    margin: 1.5rem 0;
+}
+
+#gai-wrap .gai-accordion-item {
+    margin-bottom: 0.75rem;
+    border: 0.0625rem solid #e5e7eb;
+    border-radius: 0.375rem;
+    overflow: hidden;
+}
+
+#gai-wrap .gai-accordion-summary {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    list-style: none;
+    outline: none;
+    font-weight: 600;
+    color: #374151;
+    background-color: #f9fafb;
+    transition: background-color 0.2s ease-in-out;
+}
+
+#gai-wrap .gai-accordion-summary::-webkit-details-marker,
+#gai-wrap .gai-accordion-summary::marker {
+    display: none;
+}
+
+#gai-wrap .gai-accordion-summary::before {
+    content: '\\f0da';
+    margin-right: 0.75rem;
+    font-family: 'Font Awesome 6 Free';
+    font-weight: 900;
+    font-size: 1rem;
+    transition: transform 0.2s ease-in-out;
+}
+
+#gai-wrap .gai-accordion-item[open] > .gai-accordion-summary::before {
+    transform: rotate(90deg);
+}
+
+#gai-wrap .gai-accordion-summary:focus-visible {
+    outline: 0.125rem solid #2563eb;
+    outline-offset: 0.125rem;
+    box-shadow: 0 0 0 0.125rem #ffffff, 0 0 0 0.25rem #2563eb;
+}
+
+#gai-wrap .gai-accordion-content {
+    padding: 1rem;
+    border-top: 0.0625rem solid #e5e7eb;
+    background-color: #ffffff;
+    color: #4b5563;
+}
+
+#gai-wrap .gai-accordion-content ul,
+#gai-wrap .gai-accordion-content ol {
+    margin-bottom: 1rem;
+    padding-left: 1.5rem;
+}
+
+#gai-wrap .gai-accordion-special > .gai-accordion-summary {
+    background-color: #f5f3ff;
+    color: #5b21b6;
+}
+
+#gai-wrap .gai-accordion-special > .gai-accordion-summary::before,
+#gai-wrap .gai-accordion-special > .gai-accordion-summary i.fas {
+    color: #6d28d9;
+}
+
+/* Tables */
+#gai-wrap .gai-table {
+    width: 100%;
+    margin: 1.5rem 0;
+    border-collapse: collapse;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    background-color: #ffffff;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem rgba(0, 0, 0, 0.05),
+        0 0.125rem 0.25rem -0.0625rem rgba(0, 0, 0, 0.03);
+    font-size: 1.3rem;
+    line-height: 1.6;
+}
+
+#gai-wrap .gai-table th,
+#gai-wrap .gai-table td {
+    border: 0.0625rem solid #e5e7eb;
+    padding: 0.75rem 1rem;
+    text-align: left;
+    vertical-align: top;
+    color: #374151;
+}
+
+#gai-wrap .gai-table th {
+    background-color: #f9fafb;
+    color: #111827;
+    font-size: 1.4rem;
+    font-weight: 600;
+}
+
+#gai-wrap .gai-table sup {
+    font-size: 0.75em;
+    line-height: 0;
+    vertical-align: super;
+}
+
+#gai-wrap .gai-table .gai-table-stage-column {
+    width: 18%;
+    color: #111827;
+    font-weight: 600;
+}
+
+#gai-wrap .gai-table .gai-table-what-you-do-column {
+    width: 35%;
+}
+
+#gai-wrap .gai-table .gai-table-why-it-matters-column {
+    width: 22%;
+}
+
+#gai-wrap .gai-table .gai-table-where-ai-fits-column {
+    width: 25%;
+}
+
+#gai-wrap .gai-table .gai-table-where-ai-fits-column i.fas,
+#gai-wrap .gai-table .gai-table-where-ai-fits-column .fa-robot {
+    margin-right: 0.375rem;
+    color: #2563eb;
+}
+
+/* Cards & media */
+#gai-wrap .gai-tool-card,
+#gai-wrap .gai-module-card {
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    background-color: #ffffff;
+    border: 0.0625rem solid #e5e7eb;
+    box-shadow: 0 0.25rem 0.375rem -0.0625rem rgba(0, 0, 0, 0.1),
+        0 0.125rem 0.25rem -0.125rem rgba(0, 0, 0, 0.1);
+}
+
+#gai-wrap .gai-module-card {
+    margin: 1rem 0;
+    border-color: #bae6fd;
+    background-color: #f0f9ff;
+}
+
+#gai-wrap .gai-tool-card {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+#gai-wrap .gai-tool-card p {
+    margin-bottom: 1rem;
+    color: #4b5563;
+    flex-grow: 1;
+}
+
+#gai-wrap .gai-tool-card:hover {
+    transform: translateY(-0.3125rem);
+    box-shadow: 0 0.625rem 0.9375rem -0.1875rem rgba(0, 0, 0, 0.1),
+        0 0.25rem 0.375rem -0.25rem rgba(0, 0, 0, 0.1);
+}
+
+#gai-wrap .gai-tool-card .gai-tool-meta {
+    margin-top: auto;
+    padding-top: 1rem;
+    border-top: 0.0625rem solid #e5e7eb;
+    font-size: 1.2rem;
+    color: #6b7280;
+}
+
+#gai-wrap .gai-tool-card .gai-tool-meta p {
+    margin-bottom: 0.5rem;
+    color: #6b7280;
+    font-size: 1.2rem;
+}
+
+#gai-wrap .gai-tool-card .gai-tool-meta strong {
+    color: #374151;
+    font-weight: 600;
+}
+
+#gai-wrap .gai-module-card p {
+    margin-bottom: 0;
+    color: #075985;
+}
+
+#gai-wrap .gai-info p {
+    color: #374151;
+}
+
+#gai-wrap .gai-info li {
+    color: #374151;
+}
+
+#gai-wrap .gai-box pre {
+    margin: 1em 0;
+    padding: 1em;
+    border-radius: 0.375rem;
+    border: 0.0625rem solid #d1d5db;
+    background-color: #f3f4f6;
+    color: #1f2937;
+    font-family: monospace, monospace;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+#gai-wrap .gai-box pre code {
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    background-color: transparent;
+    color: inherit;
+    font-family: inherit;
+}
+
+#gai-wrap .gai-info,
+#gai-wrap .gai-quick-activity,
+#gai-wrap .genai-custom-info-box,
+#gai-wrap .gai-warning-box,
+#gai-wrap .gai-instructor-notes {
+    border-radius: 0 0.5rem 0.5rem 0;
+}
+
+#gai-wrap .gai-hero-graphic img,
+#gai-wrap .gai-content-image img {
+    border-radius: 0.375rem;
+}
+
+#gai-wrap .gai-content-image img {
+    display: inline-block;
+    vertical-align: middle;
+    max-width: 100%;
+    height: auto;
+}
+
+/* Buttons & interactive elements */
+#gai-wrap .gai-btn {
+    display: inline-block;
+    margin-right: 0.5em;
+    margin-bottom: 0.5em;
+    padding: 0.65em 1.2em;
+    border-radius: 0.375rem;
+    border: 0.0625rem solid #bfdbfe;
+    background-color: #e0f2fe;
+    color: #2563eb;
+    font-weight: 600;
+    text-decoration: none;
+    text-align: center;
+    line-height: 1.4;
+    cursor: pointer;
+    box-shadow: 0 0.0625rem 0.125rem rgba(0, 0, 0, 0.05);
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.1s ease;
+}
+
+#gai-wrap .gai-btn:hover {
+    transform: translateY(-0.0625rem);
+    background-color: #d1e9fc;
+    border-color: #93c5fd;
+    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
+}
+
+#gai-wrap .gai-btn i.fas,
+#gai-wrap .gai-btn i.fab {
+    margin-left: 0.5em;
+    font-size: 0.9em;
+    color: #2563eb;
+}
+
+#gai-wrap .gai-accordion-summary,
+#gai-wrap .gai-btn,
+#gai-wrap .gai-button-visual {
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.1s ease;
+}
+
+/* Dividers & utilities */
+#gai-wrap .genai-custom-divider {
+    margin: 3rem 0;
+    border: 0;
+    height: 0.0625rem;
+    background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0));
+}
+
+#gai-wrap .gai-hr {
+    margin: 2.5rem 0;
+    border: none;
+    height: 0.0625rem;
+    background-color: #e5e7eb;
+}
+
+#gai-wrap .gai-references {
+    margin-top: 1.5rem;
+    padding: 1rem;
+    border-radius: 0.375rem;
+    background-color: #f9fafb;
+}
+
+#gai-wrap .gai-references p {
+    margin-bottom: 0.5rem;
+    color: #4b5563;
+    font-size: 1.2rem;
+}
+
+#gai-wrap .gai-hero-graphic,
+#gai-wrap .gai-tool-card,
+#gai-wrap .gai-module-card,
+#gai-wrap .gai-info,
+#gai-wrap .gai-quick-activity,
+#gai-wrap .gai-warning-box,
+#gai-wrap .genai-custom-info-box,
+#gai-wrap .gai-instructor-notes,
+#gai-wrap .gai-workflow-box,
+#gai-wrap .gai-graphic-idea,
+#gai-wrap .gai-placeholder-link,
+#gai-wrap .gai-button-visual,
+#gai-wrap .gai-tool-grid,
+#gai-wrap .gai-accordion-group,
+#gai-wrap .gai-table,
+#gai-wrap .gai-hr,
+#gai-wrap .genai-custom-divider {
+    color: inherit;
+}
+
+#gai-wrap .gai-hero-graphic,
+#gai-wrap .gai-tool-grid {
+    text-align: inherit;
+}
+
+#gai-wrap .gai-table,
+#gai-wrap .gai-tool-grid {
+    width: 100%;
+}
+
+
+
+/* Global navigation */
+.site-header {
+    background-color: #0f172a;
+    color: #f8fafc;
+    padding: 2rem 1.5rem;
+}
+
+.site-header__inner {
+    max-width: 56.25rem;
+    margin: 0 auto;
+}
+
+.site-header__title {
+    display: inline-block;
+    color: inherit;
+    font-size: 2rem;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.site-header__title:hover {
+    color: #cbd5f5;
+    text-decoration: none;
+}
+
+.site-header__tagline {
+    margin: 0.5rem 0 0;
+    font-size: 1.05rem;
+    color: rgba(248, 250, 252, 0.85);
+}
+
+.site-nav {
+    background-color: #ffffff;
+    border-bottom: 0.0625rem solid #e5e7eb;
+    box-shadow: 0 0.25rem 0.75rem rgba(15, 23, 42, 0.08);
+}
+
+.site-nav__list {
+    max-width: 56.25rem;
+    margin: 0 auto;
+    padding: 1.25rem 1.5rem;
+    list-style: none;
+}
+
+.site-nav__item {
+    margin-bottom: 1rem;
+}
+
+.site-nav__item:last-child {
+    margin-bottom: 0;
+}
+
+.site-nav__item > a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    background-color: #e2e8f0;
+    color: #0f172a;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.site-nav__item > a:hover {
+    background-color: #cbd5f5;
+    color: #1d4ed8;
+    text-decoration: none;
+}
+
+.site-nav__item--has-children > a {
+    background-color: #e0f2fe;
+    color: #075985;
+}
+
+.site-nav__item--active > a,
+.site-nav__item--has-children.site-nav__item--active > a {
+    background-color: #2563eb;
+    color: #ffffff;
+}
+
+.site-nav__sublist {
+    list-style: none;
+    margin: 0.5rem 0 0;
+    padding-left: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.site-nav__subitem > a {
+    display: inline-flex;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background-color: #eff6ff;
+    color: #1d4ed8;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.site-nav__subitem > a:hover {
+    background-color: #dbeafe;
+    color: #1e3a8a;
+}
+
+.site-nav__subitem--active > a {
+    background-color: #1d4ed8;
+    color: #ffffff;
 }
 
 @media (min-width: 960px) {
-    body {
-        display: grid;
-        grid-template-columns: 320px 1fr;
-        grid-template-areas: "header header" "nav main" "footer footer";
+    .site-header {
+        padding-left: calc((100vw - 56.25rem) / 2 + 1.5rem);
+        padding-right: calc((100vw - 56.25rem) / 2 + 1.5rem);
     }
 
-    header {
-        grid-area: header;
-        padding-left: calc((100vw - 1024px) / 2 + 1.5rem);
-        padding-right: calc((100vw - 1024px) / 2 + 1.5rem);
+    .site-nav__list {
+        padding-left: calc((100vw - 56.25rem) / 2 + 1.5rem);
+        padding-right: calc((100vw - 56.25rem) / 2 + 1.5rem);
     }
+}
 
-    nav {
-        grid-area: nav;
-        padding-left: calc((100vw - 1024px) / 2 + 1.5rem);
-        padding-right: calc((100vw - 1024px) / 2 + 1.5rem);
-    }
+.gai-cc-icons {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-left: 0.5rem;
+}
 
-    main {
-        grid-area: main;
-        margin: 2rem calc((100vw - 1024px) / 2 + 1.5rem) 2rem 0;
-    }
-
-    footer {
-        grid-area: footer;
-        margin-left: calc((100vw - 1024px) / 2 + 1.5rem);
-        margin-right: calc((100vw - 1024px) / 2 + 1.5rem);
-    }
+.gai-cc-icons img {
+    width: 1.125rem;
+    height: 1.125rem;
 }

--- a/site/understand-and-explore-generative-ai.html
+++ b/site/understand-and-explore-generative-ai.html
@@ -4,79 +4,121 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Understand and Explore Generative AI - AI Literacy for Students</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <header>
-        <div class="site-title">
-            <h1><a href="pillars-of-ai-literacy.html">AI Literacy for Students</a></h1>
-            <p class="tagline">Understand, explore, and apply generative AI responsibly.</p>
-        </div>
-    </header>
-    <nav>
-        <ul class='nav-list'><li><a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a></li><li class="has-children"><a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a><ul class='nav-list'><li><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it&#x27;s supposed to be</a></li></ul></li><li class="active has-children"><a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a><ul class='nav-list'><li><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li><li><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li><li><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li><li><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li></ul></li><li class="has-children"><a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a><ul class='nav-list'><li><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li><li><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries &amp; Idea Sparker</a></li><li><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy &amp; Skill Builder</a></li><li><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li><li><a href='ai-research-assistants.html'>AI Research Assistants</a></li><li><a href='ai-risks-and-ethical-considerations.html'>AI Risks &amp; Ethical Considerations</a></li><li><a href='ais-jagged-frontier.html'>AI&#x27;s Jagged Frontier</a></li></ul></li><li><a href='ai-contribution-statement.html'>AI Contribution Statement</a></li></ul>
-    </nav>
-    <main>
-        <h2>Understand and Explore Generative AI</h2>
-        <div>
-    
-<div>
-<figure><img alt="human in center of block diagram, surrounded by tech icons" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx_Human_figure_at_center__surrounded_by_5_floating_tech_icons_forming_neural_network_pattern__minimalist_blue_line_art_style__represents_AI_in_daily_life_minimal_dream_aesthetic.jpg"></figure>
-
-<section>
-<p><b>Artificial intelligence (AI)</b> refers to computer systems capable of performing tasks that normally required human intelligence, such as interpreting language, recognizing patterns from large amounts of data, and making decisions. Some of the names given to AI, based on the way in which it is designed and what it can do, include neural networks, natural language processing, computer vision, speech recognition, machine learning, and deep learning.</p>
-
-<p>While we tend to think of it as a product of the 21<sup>st</sup> century, it has been around since the middle of the 20<sup>th</sup> century. Chances are good that you interact with AI every day. Examples of AI include:</p>
-</section>
-
-<section>
-<ul>
-	<li><img alt="Phone using face recognition to unlock" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Face_Recognition_in_Action.png">
-	<div>Asking your Smartphone to unlock your phone by recognizing your face;</div>
-	</li>
-	<li><img alt="Navigation app with a route on a phone" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Navigating_with_Smartphone_Map.png">
-	<div>Navigating to your destination using apps like Google Map or Waze to find the quickest route;</div>
-	</li>
-	<li><img alt="Social media like button on a smartphone" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_BookofFaces.png">
-	<div>Getting more posts in your social media feeds that match those with which you previously interacted (that you liked or commented on);</div>
-	</li>
-	<li><img alt="Mobile banking alert about unusual activity" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Concerned_Woman_Receiving_Alert_Message.png">
-	<div>Getting a notification from your bank that there has been unusual activity in your account;</div>
-	</li>
-	<li><img alt="Shopping app product recommendations" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Smartphone_Displaying_Product_Recommendations.png">
-	<div>Obtaining a recommendation from an online store (or music or video streaming platform) based on your previous purchases;</div>
-	</li>
-	<li><img alt="Customer service chatbot interface" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Working_with_Chatbot.png">
-	<div>Interacting with a customer service chatbot;</div>
-	</li>
-	<li><img alt="Grammar and writing suggestions overlay on text" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Laptop_with_Grammar_Suggestions_in_Word.png">
-	<div>Feeding your text through a grammar software that suggests better ways to write your text;</div>
-	</li>
-	<li><img alt="English speaker using translation app to talk to Spanish speaker" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Bilingual_Conversation_Between_Friends.png">
-	<div>Using a translate tool to translate text from one language into another;</div>
-	</li>
-	<li><img alt="Voice-to-text app recording on a smartphone" loading="lazy" src="images/voice-to-text.jpg">
-	<div>Using a voice-to-text app on a smartphone;</div>
-	</li>
-	<li><img alt="Woman speaking to Alexa personal assistant on a speaker" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Alexa.png">
-	<div>Using a personal assistant like Siri, Alex, or Cortana.</div>
-	</li>
-</ul>
-<br>
-</section>
-
-<section>
-<p>AI has been around in education for decades, usually embedded as part of the student management system or the learning management system. These sorts of AI monitored student engagements with their platforms and analyzed large amounts of data to predict which student was likely to succeed or withdraw from a course (and therefore which ones might benefit from additional support), and how to optimize and personalize learning.</p>
-
-<p>Source of the above content: FLO Micro – Future Facing Assessment Course by Eliana Elkhoury and Annie Prud’homme-Généreux  (CC-BY)</p>
-</section>
-</div>
-
-
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
+</header>
+<nav class="site-nav" aria-label="Primary">
+    <ul class="site-nav__list">
+        <li class='site-nav__item'>
+            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
+            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
+                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
+                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item site-nav__item--has-children'>
+            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
+            <ul class='site-nav__sublist'>
+                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
+                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
+                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
+                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
+                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
+                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
+                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
+            </ul>
+        </li>
+        <li class='site-nav__item'>
+            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
+        </li>
+    </ul>
+</nav>
+<div id="gai-wrap">
+    <main>
+        <div class="gai-cont">
+        <section class="gai-box">
+            <h2>Understand and Explore Generative AI</h2>
+            <div>
+
+            <div>
+            <figure><img alt="human in center of block diagram, surrounded by tech icons" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/image_fx_Human_figure_at_center__surrounded_by_5_floating_tech_icons_forming_neural_network_pattern__minimalist_blue_line_art_style__represents_AI_in_daily_life_minimal_dream_aesthetic.jpg"></figure>
+
+            <section>
+            <p><b>Artificial intelligence (AI)</b> refers to computer systems capable of performing tasks that normally required human intelligence, such as interpreting language, recognizing patterns from large amounts of data, and making decisions. Some of the names given to AI, based on the way in which it is designed and what it can do, include neural networks, natural language processing, computer vision, speech recognition, machine learning, and deep learning.</p>
+
+            <p>While we tend to think of it as a product of the 21<sup>st</sup> century, it has been around since the middle of the 20<sup>th</sup> century. Chances are good that you interact with AI every day. Examples of AI include:</p>
+            </section>
+
+            <section>
+            <ul>
+            	<li><img alt="Phone using face recognition to unlock" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Face_Recognition_in_Action.png">
+            	<div>Asking your Smartphone to unlock your phone by recognizing your face;</div>
+            	</li>
+            	<li><img alt="Navigation app with a route on a phone" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Navigating_with_Smartphone_Map.png">
+            	<div>Navigating to your destination using apps like Google Map or Waze to find the quickest route;</div>
+            	</li>
+            	<li><img alt="Social media like button on a smartphone" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_BookofFaces.png">
+            	<div>Getting more posts in your social media feeds that match those with which you previously interacted (that you liked or commented on);</div>
+            	</li>
+            	<li><img alt="Mobile banking alert about unusual activity" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Concerned_Woman_Receiving_Alert_Message.png">
+            	<div>Getting a notification from your bank that there has been unusual activity in your account;</div>
+            	</li>
+            	<li><img alt="Shopping app product recommendations" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Smartphone_Displaying_Product_Recommendations.png">
+            	<div>Obtaining a recommendation from an online store (or music or video streaming platform) based on your previous purchases;</div>
+            	</li>
+            	<li><img alt="Customer service chatbot interface" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Working_with_Chatbot.png">
+            	<div>Interacting with a customer service chatbot;</div>
+            	</li>
+            	<li><img alt="Grammar and writing suggestions overlay on text" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Laptop_with_Grammar_Suggestions_in_Word.png">
+            	<div>Feeding your text through a grammar software that suggests better ways to write your text;</div>
+            	</li>
+            	<li><img alt="English speaker using translation app to talk to Spanish speaker" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Bilingual_Conversation_Between_Friends.png">
+            	<div>Using a translate tool to translate text from one language into another;</div>
+            	</li>
+            	<li><img alt="Voice-to-text app recording on a smartphone" loading="lazy" src="images/voice-to-text.jpg">
+            	<div>Using a voice-to-text app on a smartphone;</div>
+            	</li>
+            	<li><img alt="Woman speaking to Alexa personal assistant on a speaker" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/165495/images/ChatGPT_-_Alexa.png">
+            	<div>Using a personal assistant like Siri, Alex, or Cortana.</div>
+            	</li>
+            </ul>
+            <br>
+            </section>
+
+            <section>
+            <p>AI has been around in education for decades, usually embedded as part of the student management system or the learning management system. These sorts of AI monitored student engagements with their platforms and analyzed large amounts of data to predict which student was likely to succeed or withdraw from a course (and therefore which ones might benefit from additional support), and how to optimize and personalize learning.</p>
+
+            <p>Source of the above content: FLO Micro – Future Facing Assessment Course by Eliana Elkhoury and Annie Prud’homme-Généreux  (CC-BY)</p>
+            </section>
+            </div>
+
+
+                </div>
+        </section>
+                <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        </div>
     </main>
-    <footer>
-        <p>&copy; 2024 AI Literacy for Students.</p>
-    </footer>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace the per-page styling on the cleaned site pages with a common layout that links to `styles.css`, including the shared navigation structure.
- Rebuild `styles.css` from the base theme and extend it with header, navigation, and license icon styling used by every page.
- Normalize the Creative Commons footer so each page references the same concluding block.

## Testing
- Not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68db754897f0832cbcacde0e32b32e70