### PR TITLE
Promote pillars page to site index

### DIFF
--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -35,8 +35,9 @@ class Page:
         return cls(title=title, slug=slugify(title), children=tuple(children or ()))
 
 SITE_PAGES: Tuple[Page, ...] = (
-    Page.build(
-        "Pillars of AI Literacy",
+    Page(
+        title="Pillars of AI Literacy",
+        slug="index",
     ),
     Page.build(
         "Authentic Learning and AI Use",
@@ -233,8 +234,8 @@ def update_internal_links(content: str, id_to_slug: Dict[str, str]) -> str:
         return f"{slug}.html{suffix}"
 
     content = INTERNAL_GUIDE_PATTERN.sub(lambda m: replace(m), content)
-    content = LIBGUIDE_HOME_PATTERN.sub(lambda m: f"pillars-of-ai-literacy.html{m.group(1) or ''}", content)
-    content = LIBGUIDE_PAGE_PATTERN.sub(lambda m: f"pillars-of-ai-literacy.html{m.group(1) or ''}", content)
+    content = LIBGUIDE_HOME_PATTERN.sub(lambda m: f"index.html{m.group(1) or ''}", content)
+    content = LIBGUIDE_PAGE_PATTERN.sub(lambda m: f"index.html{m.group(1) or ''}", content)
 
     def replace_hash(match: re.Match[str]) -> str:
         page_id, anchor = match.groups()
@@ -295,7 +296,7 @@ PAGE_TEMPLATE = """<!DOCTYPE html>
 <body>
     <header>
         <div class=\"site-title\">
-            <h1><a href=\"pillars-of-ai-literacy.html\">AI Literacy for Students</a></h1>
+            <h1><a href=\"index.html\">AI Literacy for Students</a></h1>
             <p class=\"tagline\">Understand, explore, and apply generative AI responsibly.</p>
         </div>
     </header>

--- a/site/ai-contribution-statement.html
+++ b/site/ai-contribution-statement.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -227,7 +227,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/ai-generated-writing-effective-and-ethical-use-activities.html
+++ b/site/ai-generated-writing-effective-and-ethical-use-activities.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -508,7 +508,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/ai-generated-writing-effective-and-ethical-use-ai-for-brainstorming-amp-structuring-ideas.html
+++ b/site/ai-generated-writing-effective-and-ethical-use-ai-for-brainstorming-amp-structuring-ideas.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-generated-writing-effective-and-ethical-use-drafting-support-brain-driven-prose-ai-assisted-polish.html
+++ b/site/ai-generated-writing-effective-and-ethical-use-drafting-support-brain-driven-prose-ai-assisted-polish.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-generated-writing-effective-and-ethical-use-the-core-of-ethical-ai-use-the-contribution-statement.html
+++ b/site/ai-generated-writing-effective-and-ethical-use-the-core-of-ethical-ai-use-the-contribution-statement.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-generated-writing-effective-and-ethical-use.html
+++ b/site/ai-generated-writing-effective-and-ethical-use.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-quick-queries-and-idea-sparker-ii-ai-as-a-quot-quick-information-scout-quot-testing-ai-x27-s-knowledge-amp-your-critical-skills.html
+++ b/site/ai-quick-queries-and-idea-sparker-ii-ai-as-a-quot-quick-information-scout-quot-testing-ai-x27-s-knowledge-amp-your-critical-skills.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-quick-queries-and-idea-sparker-iii-ai-as-a-brainstorming-partner-idea-sparker.html
+++ b/site/ai-quick-queries-and-idea-sparker-iii-ai-as-a-brainstorming-partner-idea-sparker.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-quick-queries-and-idea-sparker-iv-wrap-up-sparking-your-own-brilliance.html
+++ b/site/ai-quick-queries-and-idea-sparker-iv-wrap-up-sparking-your-own-brilliance.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -88,7 +88,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/ai-quick-queries-and-idea-sparker.html
+++ b/site/ai-quick-queries-and-idea-sparker.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-research-assistants-what-a-deep-research-tool-does.html
+++ b/site/ai-research-assistants-what-a-deep-research-tool-does.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -233,7 +233,7 @@
 
                 </div>
         </section>
-                <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+                <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/ai-research-assistants.html
+++ b/site/ai-research-assistants.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-risks-and-ethical-considerations-ai-risks-and-ethical-impacts-part-2.html
+++ b/site/ai-risks-and-ethical-considerations-ai-risks-and-ethical-impacts-part-2.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-risks-and-ethical-considerations-other-resources.html
+++ b/site/ai-risks-and-ethical-considerations-other-resources.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -107,7 +107,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/ai-risks-and-ethical-considerations.html
+++ b/site/ai-risks-and-ethical-considerations.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-study-buddy-and-skill-builder-1-socratic-dialogue-amp-questioning.html
+++ b/site/ai-study-buddy-and-skill-builder-1-socratic-dialogue-amp-questioning.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-study-buddy-and-skill-builder-1-unpacking-complex-ideas.html
+++ b/site/ai-study-buddy-and-skill-builder-1-unpacking-complex-ideas.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ai-study-buddy-and-skill-builder-enhancing-presentation-amp-speaking-skills.html
+++ b/site/ai-study-buddy-and-skill-builder-enhancing-presentation-amp-speaking-skills.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -633,7 +633,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/ai-study-buddy-and-skill-builder.html
+++ b/site/ai-study-buddy-and-skill-builder.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/ais-jagged-frontier-what-are-ai-benchmarks.html
+++ b/site/ais-jagged-frontier-what-are-ai-benchmarks.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -364,7 +364,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/ais-jagged-frontier.html
+++ b/site/ais-jagged-frontier.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/analyze-and-apply-gen-ai-customizing-and-organizing-your-ai-assistant.html
+++ b/site/analyze-and-apply-gen-ai-customizing-and-organizing-your-ai-assistant.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -176,7 +176,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/analyze-and-apply-gen-ai.html
+++ b/site/analyze-and-apply-gen-ai.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/authentic-learning-and-ai-use.html
+++ b/site/authentic-learning-and-ai-use.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -139,7 +139,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/essentials-for-smart-engagement-the-pitfalls-navigating-ai-x27-s-limitations-and-ethical-minefields.html
+++ b/site/essentials-for-smart-engagement-the-pitfalls-navigating-ai-x27-s-limitations-and-ethical-minefields.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/essentials-for-smart-engagement-the-promise-how-generative-ai-can-be-your-academic-ally.html
+++ b/site/essentials-for-smart-engagement-the-promise-how-generative-ai-can-be-your-academic-ally.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/essentials-for-smart-engagement-what-x27-s-next-your-journey-into-analyzing-amp-applying-ai.html
+++ b/site/essentials-for-smart-engagement-what-x27-s-next-your-journey-into-analyzing-amp-applying-ai.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -81,7 +81,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/essentials-for-smart-engagement-you-are-the-pilot-embracing-your-critical-role.html
+++ b/site/essentials-for-smart-engagement-you-are-the-pilot-embracing-your-critical-role.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/essentials-for-smart-engagement.html
+++ b/site/essentials-for-smart-engagement.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>

--- a/site/gen-ai-behind-the-curtain.html
+++ b/site/gen-ai-behind-the-curtain.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -452,7 +452,7 @@
 
                 </div>
         </section>
-                <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+                <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/gen-ai-fundamentals.html
+++ b/site/gen-ai-fundamentals.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -321,7 +321,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/gen-ai-tools-platforms-and-interfaces.html
+++ b/site/gen-ai-tools-platforms-and-interfaces.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -1054,7 +1054,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/index.html
+++ b/site/index.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item site-nav__item--active'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -241,7 +241,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/learning-is-hard-and-its-supposed-to-be.html
+++ b/site/learning-is-hard-and-its-supposed-to-be.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -249,7 +249,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/potential-and-limitations-of-gen-ai.html
+++ b/site/potential-and-limitations-of-gen-ai.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -475,7 +475,7 @@
 
                 </div>
         </section>
-        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+        <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>

--- a/site/understand-and-explore-generative-ai.html
+++ b/site/understand-and-explore-generative-ai.html
@@ -13,14 +13,14 @@
 <body>
 <header class="site-header">
     <div class="site-header__inner">
-        <a class="site-header__title" href="pillars-of-ai-literacy.html">AI Literacy for Students</a>
+        <a class="site-header__title" href="index.html">AI Literacy for Students</a>
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
 <nav class="site-nav" aria-label="Primary">
     <ul class="site-nav__list">
         <li class='site-nav__item'>
-            <a href='pillars-of-ai-literacy.html'>Pillars of AI Literacy</a>
+            <a href='index.html'>Pillars of AI Literacy</a>
         </li>
         <li class='site-nav__item site-nav__item--has-children'>
             <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
@@ -116,7 +116,7 @@
 
                 </div>
         </section>
-                <p class="gai-end-txt">Unless otherwise stated, this page and <a href="pillars-of-ai-literacy.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
+                <p class="gai-end-txt">Unless otherwise stated, this page and <a href="index.html">AI Literacy for Students</a> © 2025 by David Williams is licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International</a><span class="gai-cc-icons"><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon" /><img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon" /></span></p>
         </div>
     </main>
 </div>


### PR DESCRIPTION
## Summary
- rename the Pillars of AI Literacy page to index.html and point generator navigation and link normalization at the new slug
- update generated site HTML so headers, navigation, and footer attributions all reference index.html as the home page

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68e300343dac832cacee6288e2d30603