### PR TITLE
Revamp navigation styling and centralize markup

### DIFF
--- a/docs/ai-contribution-statement.html
+++ b/docs/ai-contribution-statement.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--active'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -231,5 +198,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-generated-writing-effective-and-ethical-use-activities.html
+++ b/docs/ai-generated-writing-effective-and-ethical-use-activities.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -512,10 +479,12 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-generated-writing-effective-and-ethical-use-ai-for-brainstorming-amp-structuring-ideas.html
+++ b/docs/ai-generated-writing-effective-and-ethical-use-ai-for-brainstorming-amp-structuring-ideas.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -429,5 +396,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-generated-writing-effective-and-ethical-use-drafting-support-brain-driven-prose-ai-assisted-polish.html
+++ b/docs/ai-generated-writing-effective-and-ethical-use-drafting-support-brain-driven-prose-ai-assisted-polish.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -544,5 +511,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-generated-writing-effective-and-ethical-use-the-core-of-ethical-ai-use-the-contribution-statement.html
+++ b/docs/ai-generated-writing-effective-and-ethical-use-the-core-of-ethical-ai-use-the-contribution-statement.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -140,5 +107,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-generated-writing-effective-and-ethical-use.html
+++ b/docs/ai-generated-writing-effective-and-ethical-use.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -124,5 +91,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-literacy-starter-template-clean.html
+++ b/docs/ai-literacy-starter-template-clean.html
@@ -289,5 +289,6 @@
             </div>
         </footer>
     </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-quick-queries-and-idea-sparker-ii-ai-as-a-quot-quick-information-scout-quot-testing-ai-x27-s-knowledge-amp-your-critical-skills.html
+++ b/docs/ai-quick-queries-and-idea-sparker-ii-ai-as-a-quot-quick-information-scout-quot-testing-ai-x27-s-knowledge-amp-your-critical-skills.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -260,5 +227,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-quick-queries-and-idea-sparker-iii-ai-as-a-brainstorming-partner-idea-sparker.html
+++ b/docs/ai-quick-queries-and-idea-sparker-iii-ai-as-a-brainstorming-partner-idea-sparker.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -265,5 +232,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-quick-queries-and-idea-sparker-iv-wrap-up-sparking-your-own-brilliance.html
+++ b/docs/ai-quick-queries-and-idea-sparker-iv-wrap-up-sparking-your-own-brilliance.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -92,10 +59,12 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-quick-queries-and-idea-sparker.html
+++ b/docs/ai-quick-queries-and-idea-sparker.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -123,5 +90,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-research-assistants-what-a-deep-research-tool-does.html
+++ b/docs/ai-research-assistants-what-a-deep-research-tool-does.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -237,10 +204,12 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-research-assistants.html
+++ b/docs/ai-research-assistants.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -195,5 +162,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-risks-and-ethical-considerations-ai-risks-and-ethical-impacts-part-2.html
+++ b/docs/ai-risks-and-ethical-considerations-ai-risks-and-ethical-impacts-part-2.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -493,5 +460,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-risks-and-ethical-considerations-other-resources.html
+++ b/docs/ai-risks-and-ethical-considerations-other-resources.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -111,10 +78,12 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-risks-and-ethical-considerations.html
+++ b/docs/ai-risks-and-ethical-considerations.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -434,5 +401,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-study-buddy-and-skill-builder-1-socratic-dialogue-amp-questioning.html
+++ b/docs/ai-study-buddy-and-skill-builder-1-socratic-dialogue-amp-questioning.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -406,5 +373,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-study-buddy-and-skill-builder-1-unpacking-complex-ideas.html
+++ b/docs/ai-study-buddy-and-skill-builder-1-unpacking-complex-ideas.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -425,5 +392,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-study-buddy-and-skill-builder-enhancing-presentation-amp-speaking-skills.html
+++ b/docs/ai-study-buddy-and-skill-builder-enhancing-presentation-amp-speaking-skills.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -637,10 +604,12 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ai-study-buddy-and-skill-builder.html
+++ b/docs/ai-study-buddy-and-skill-builder.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -229,5 +196,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ais-jagged-frontier-what-are-ai-benchmarks.html
+++ b/docs/ais-jagged-frontier-what-are-ai-benchmarks.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -368,10 +335,12 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/ais-jagged-frontier.html
+++ b/docs/ais-jagged-frontier.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -337,5 +304,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/analyze-and-apply-gen-ai-customizing-and-organizing-your-ai-assistant.html
+++ b/docs/analyze-and-apply-gen-ai-customizing-and-organizing-your-ai-assistant.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -180,10 +147,12 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/analyze-and-apply-gen-ai.html
+++ b/docs/analyze-and-apply-gen-ai.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -398,5 +365,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/authentic-learning-and-ai-use.html
+++ b/docs/authentic-learning-and-ai-use.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -143,5 +110,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/essentials-for-smart-engagement-the-pitfalls-navigating-ai-x27-s-limitations-and-ethical-minefields.html
+++ b/docs/essentials-for-smart-engagement-the-pitfalls-navigating-ai-x27-s-limitations-and-ethical-minefields.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -173,5 +140,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/essentials-for-smart-engagement-the-promise-how-generative-ai-can-be-your-academic-ally.html
+++ b/docs/essentials-for-smart-engagement-the-promise-how-generative-ai-can-be-your-academic-ally.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -248,5 +215,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/essentials-for-smart-engagement-what-x27-s-next-your-journey-into-analyzing-amp-applying-ai.html
+++ b/docs/essentials-for-smart-engagement-what-x27-s-next-your-journey-into-analyzing-amp-applying-ai.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -85,10 +52,12 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/essentials-for-smart-engagement-you-are-the-pilot-embracing-your-critical-role.html
+++ b/docs/essentials-for-smart-engagement-you-are-the-pilot-embracing-your-critical-role.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -94,5 +61,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/essentials-for-smart-engagement.html
+++ b/docs/essentials-for-smart-engagement.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -141,5 +108,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/gen-ai-behind-the-curtain.html
+++ b/docs/gen-ai-behind-the-curtain.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -456,5 +423,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/gen-ai-fundamentals.html
+++ b/docs/gen-ai-fundamentals.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -325,5 +292,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/gen-ai-tools-platforms-and-interfaces.html
+++ b/docs/gen-ai-tools-platforms-and-interfaces.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -1058,5 +1025,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item site-nav__item--active'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -245,5 +212,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/learning-is-hard-and-its-supposed-to-be.html
+++ b/docs/learning-is-hard-and-its-supposed-to-be.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -253,5 +220,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -1,0 +1,77 @@
+<ul class="site-nav__list">
+    <li class="site-nav__item">
+        <a class="site-nav__link" data-nav-link href="index.html">Pillars of AI Literacy</a>
+    </li>
+    <li class="site-nav__item site-nav__item--has-children" data-nav-section="authentic-learning">
+        <div class="site-nav__parent">
+            <a class="site-nav__link" data-nav-link href="authentic-learning-and-ai-use.html">Authentic Learning and AI Use</a>
+            <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="nav-authentic-learning">
+                <span class="visually-hidden">Toggle submenu for Authentic Learning and AI Use</span>
+                <span aria-hidden="true" class="site-nav__toggle-icon"></span>
+            </button>
+        </div>
+        <ul class="site-nav__sublist" id="nav-authentic-learning" hidden>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="learning-is-hard-and-its-supposed-to-be.html">Learning is Hard - and it's supposed to be</a>
+            </li>
+        </ul>
+    </li>
+    <li class="site-nav__item site-nav__item--has-children" data-nav-section="understand-explore">
+        <div class="site-nav__parent">
+            <a class="site-nav__link" data-nav-link href="understand-and-explore-generative-ai.html">Understand and Explore Generative AI</a>
+            <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="nav-understand-explore">
+                <span class="visually-hidden">Toggle submenu for Understand and Explore Generative AI</span>
+                <span aria-hidden="true" class="site-nav__toggle-icon"></span>
+            </button>
+        </div>
+        <ul class="site-nav__sublist" id="nav-understand-explore" hidden>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="gen-ai-fundamentals.html">Gen AI Fundamentals</a>
+            </li>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="gen-ai-behind-the-curtain.html">Gen AI - Behind the Curtain</a>
+            </li>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="gen-ai-tools-platforms-and-interfaces.html">Gen AI Tools, Platforms, and Interfaces</a>
+            </li>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="potential-and-limitations-of-gen-ai.html">Potential and Limitations of Gen AI</a>
+            </li>
+        </ul>
+    </li>
+    <li class="site-nav__item site-nav__item--has-children" data-nav-section="analyze-apply">
+        <div class="site-nav__parent">
+            <a class="site-nav__link" data-nav-link href="analyze-and-apply-gen-ai.html">Analyze and Apply Gen AI</a>
+            <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="nav-analyze-apply">
+                <span class="visually-hidden">Toggle submenu for Analyze and Apply Gen AI</span>
+                <span aria-hidden="true" class="site-nav__toggle-icon"></span>
+            </button>
+        </div>
+        <ul class="site-nav__sublist" id="nav-analyze-apply" hidden>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="essentials-for-smart-engagement.html">Essentials for Smart Engagement</a>
+            </li>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="ai-quick-queries-and-idea-sparker.html">AI Quick Queries &amp; Idea Sparker</a>
+            </li>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="ai-study-buddy-and-skill-builder.html">AI Study Buddy &amp; Skill Builder</a>
+            </li>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="ai-generated-writing-effective-and-ethical-use.html">AI-Generated Writing: Effective and Ethical Use</a>
+            </li>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="ai-research-assistants.html">AI Research Assistants</a>
+            </li>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="ai-risks-and-ethical-considerations.html">AI Risks &amp; Ethical Considerations</a>
+            </li>
+            <li class="site-nav__subitem">
+                <a class="site-nav__sublink" data-nav-link href="ais-jagged-frontier.html">AI's Jagged Frontier</a>
+            </li>
+        </ul>
+    </li>
+    <li class="site-nav__item">
+        <a class="site-nav__link" data-nav-link href="ai-contribution-statement.html">AI Contribution Statement</a>
+    </li>
+</ul>

--- a/docs/nav.js
+++ b/docs/nav.js
@@ -1,0 +1,126 @@
+(function () {
+    const NAV_PLACEHOLDER_SELECTOR = '[data-nav-placeholder]';
+    const NAV_LINK_SELECTOR = '[data-nav-link]';
+    const NAV_TOGGLE_SELECTOR = '.site-nav__toggle';
+
+    function normalizePath(pathname) {
+        if (!pathname) {
+            return 'index.html';
+        }
+        const path = pathname.split('?')[0].split('#')[0];
+        return path === '' ? 'index.html' : path;
+    }
+
+    function markActiveLinks(navElement) {
+        const currentPath = normalizePath(window.location.pathname.split('/').pop());
+        const links = navElement.querySelectorAll(NAV_LINK_SELECTOR);
+        let expandedParent = null;
+
+        links.forEach((link) => {
+            const href = normalizePath(link.getAttribute('href'));
+            if (href === currentPath) {
+                link.classList.add('is-active');
+                link.setAttribute('aria-current', 'page');
+
+                const subitem = link.closest('.site-nav__subitem');
+                const item = link.closest('.site-nav__item');
+
+                if (subitem) {
+                    subitem.classList.add('is-active');
+                }
+
+                if (item) {
+                    item.classList.add('is-active');
+
+                    if (item.classList.contains('site-nav__item--has-children')) {
+                        expandedParent = item;
+                    } else {
+                        const parentWithChildren = link.closest('.site-nav__item--has-children');
+                        if (parentWithChildren) {
+                            expandedParent = parentWithChildren;
+                        }
+                    }
+                }
+            }
+        });
+
+        if (expandedParent) {
+            expandedParent.classList.add('is-open');
+        }
+    }
+
+    function syncToggleState(item) {
+        const toggle = item.querySelector(NAV_TOGGLE_SELECTOR);
+        const sublist = item.querySelector('.site-nav__sublist');
+        const isOpen = item.classList.contains('is-open');
+
+        if (toggle) {
+            toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        }
+
+        if (sublist) {
+            if (isOpen) {
+                sublist.removeAttribute('hidden');
+            } else {
+                sublist.setAttribute('hidden', '');
+            }
+        }
+    }
+
+    function attachToggleHandlers(navElement) {
+        const itemsWithChildren = navElement.querySelectorAll('.site-nav__item--has-children');
+
+        itemsWithChildren.forEach((item) => {
+            syncToggleState(item);
+
+            const toggle = item.querySelector(NAV_TOGGLE_SELECTOR);
+            if (!toggle) {
+                return;
+            }
+
+            toggle.addEventListener('click', () => {
+                const isOpen = item.classList.toggle('is-open');
+                syncToggleState(item);
+
+                if (isOpen) {
+                    item.classList.add('is-open');
+                }
+            });
+        });
+    }
+
+    async function loadNavigation(navElement) {
+        try {
+            const response = await fetch('nav.html', { cache: 'no-cache' });
+            if (!response.ok) {
+                throw new Error('Failed to load navigation.');
+            }
+
+            const html = await response.text();
+            navElement.innerHTML = html;
+
+            markActiveLinks(navElement);
+            attachToggleHandlers(navElement);
+        } catch (error) {
+            navElement.innerHTML = '<div class="site-nav__error">Navigation could not be loaded.</div>';
+            console.error(error);
+        }
+    }
+
+    function init() {
+        const navElements = document.querySelectorAll(NAV_PLACEHOLDER_SELECTOR);
+        if (!navElements.length) {
+            return;
+        }
+
+        navElements.forEach((navElement) => {
+            loadNavigation(navElement);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/docs/potential-and-limitations-of-gen-ai.html
+++ b/docs/potential-and-limitations-of-gen-ai.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem site-nav__subitem--active'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -479,5 +446,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3,6 +3,18 @@ html {
     font-size: 77%;
 }
 
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 body {
     margin: 0;
     font-family: 'Inter', sans-serif;
@@ -1180,84 +1192,173 @@ body {
 }
 
 .site-nav {
-    background-color: #ffffff;
-    border-bottom: 0.0625rem solid #e5e7eb;
-    box-shadow: 0 0.25rem 0.75rem rgba(15, 23, 42, 0.08);
+    background-color: #111827;
+    padding: 2rem 1.5rem;
+    box-shadow: 0 1.25rem 2.5rem rgba(15, 23, 42, 0.18);
+}
+
+.site-nav__loading,
+.site-nav__error,
+.site-nav__noscript {
+    max-width: 32rem;
+    margin: 0 auto;
+    padding: 1rem 1.25rem;
+    background-color: rgba(15, 23, 42, 0.35);
+    color: #f9fafb;
+    border-radius: 0.75rem;
+    font-weight: 500;
+    text-align: center;
+}
+
+.site-nav__error {
+    background-color: rgba(220, 38, 38, 0.15);
+    color: #fecaca;
 }
 
 .site-nav__list {
-    max-width: 56.25rem;
+    width: 100%;
+    max-width: 36rem;
     margin: 0 auto;
-    padding: 1.25rem 1.5rem;
+    padding: 0;
     list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
 }
 
 .site-nav__item {
-    margin-bottom: 1rem;
+    margin: 0;
 }
 
-.site-nav__item:last-child {
-    margin-bottom: 0;
+.site-nav__parent {
+    display: flex;
+    align-items: stretch;
+    gap: 0.75rem;
 }
 
-.site-nav__item > a {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.9rem;
-    border-radius: 999px;
-    background-color: #e2e8f0;
-    color: #0f172a;
+.site-nav__link,
+.site-nav__sublink {
+    display: block;
+    padding: 0.85rem 1.1rem;
+    border-radius: 0.85rem;
+    background-color: #1f2937;
+    color: #f9fafb;
+    text-decoration: none;
     font-weight: 600;
-    text-decoration: none;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 0 0 rgba(37, 99, 235, 0);
 }
 
-.site-nav__item > a:hover {
-    background-color: #cbd5f5;
-    color: #1d4ed8;
-    text-decoration: none;
+.site-nav__sublink {
+    font-weight: 500;
+    background-color: #1e293b;
 }
 
-.site-nav__item--has-children > a {
-    background-color: #e0f2fe;
-    color: #075985;
+.site-nav__parent .site-nav__link {
+    flex: 1 1 auto;
 }
 
-.site-nav__item--active > a,
-.site-nav__item--has-children.site-nav__item--active > a {
+.site-nav__item > .site-nav__link {
+    width: 100%;
+}
+
+.site-nav__link:hover,
+.site-nav__link:focus-visible,
+.site-nav__sublink:hover,
+.site-nav__sublink:focus-visible {
+    background-color: #1d4ed8;
+    color: #ffffff;
+    outline: none;
+    box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.25);
+}
+
+.site-nav__item.is-active > .site-nav__parent .site-nav__link,
+.site-nav__item.is-active > .site-nav__link {
     background-color: #2563eb;
     color: #ffffff;
+    box-shadow: 0 0.5rem 1.25rem rgba(37, 99, 235, 0.35);
+}
+
+.site-nav__item.is-open:not(.is-active) > .site-nav__parent .site-nav__link {
+    background-color: #1c2b45;
 }
 
 .site-nav__sublist {
     list-style: none;
-    margin: 0.5rem 0 0;
-    padding-left: 0;
+    margin: 0.35rem 0 0;
+    padding: 0 0 0 3.3rem;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 0.5rem;
 }
 
-.site-nav__subitem > a {
-    display: inline-flex;
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
-    background-color: #eff6ff;
-    color: #1d4ed8;
-    font-weight: 500;
-    text-decoration: none;
-    transition: background-color 0.2s ease, color 0.2s ease;
+.site-nav__subitem {
+    margin: 0;
 }
 
-.site-nav__subitem > a:hover {
-    background-color: #dbeafe;
-    color: #1e3a8a;
-}
-
-.site-nav__subitem--active > a {
+.site-nav__subitem.is-active .site-nav__sublink {
     background-color: #1d4ed8;
     color: #ffffff;
+    box-shadow: 0 0.5rem 1.25rem rgba(37, 99, 235, 0.35);
+}
+
+.site-nav__toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    border: 0.125rem solid rgba(148, 163, 184, 0.4);
+    border-radius: 0.85rem;
+    background-color: rgba(15, 23, 42, 0.6);
+    color: #cbd5f5;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.site-nav__toggle:hover,
+.site-nav__toggle:focus-visible {
+    background-color: rgba(37, 99, 235, 0.15);
+    border-color: rgba(37, 99, 235, 0.5);
+    color: #ffffff;
+    outline: none;
+}
+
+.site-nav__item.is-open .site-nav__toggle {
+    background-color: rgba(37, 99, 235, 0.25);
+    border-color: rgba(37, 99, 235, 0.65);
+    color: #ffffff;
+}
+
+.site-nav__toggle-icon {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-right: 0.16rem solid currentColor;
+    border-bottom: 0.16rem solid currentColor;
+    transform: rotate(45deg);
+    transition: transform 0.2s ease;
+}
+
+.site-nav__item.is-open .site-nav__toggle-icon {
+    transform: rotate(225deg);
+}
+
+.site-nav__error {
+    border: 0.1rem solid rgba(248, 113, 113, 0.45);
+}
+
+.site-nav__noscript {
+    background-color: rgba(37, 99, 235, 0.18);
+    color: #dbeafe;
+}
+
+@media (max-width: 640px) {
+    .site-nav {
+        padding: 1.75rem 1rem;
+    }
+
+    .site-nav__sublist {
+        padding-left: 2.8rem;
+    }
 }
 
 @media (min-width: 960px) {
@@ -1266,7 +1367,7 @@ body {
         padding-right: calc((100vw - 56.25rem) / 2 + 1.5rem);
     }
 
-    .site-nav__list {
+    .site-nav {
         padding-left: calc((100vw - 56.25rem) / 2 + 1.5rem);
         padding-right: calc((100vw - 56.25rem) / 2 + 1.5rem);
     }

--- a/docs/understand-and-explore-generative-ai.html
+++ b/docs/understand-and-explore-generative-ai.html
@@ -17,42 +17,9 @@
         <p class="site-header__tagline">Understand, explore, and apply generative AI responsibly.</p>
     </div>
 </header>
-<nav class="site-nav" aria-label="Primary">
-    <ul class="site-nav__list">
-        <li class='site-nav__item'>
-            <a href='index.html'>Pillars of AI Literacy</a>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='authentic-learning-and-ai-use.html'>Authentic Learning and AI Use</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='learning-is-hard-and-its-supposed-to-be.html'>Learning is Hard - and it's supposed to be</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children site-nav__item--active'>
-            <a href='understand-and-explore-generative-ai.html'>Understand and Explore Generative AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='gen-ai-fundamentals.html'>Gen AI Fundamentals</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-behind-the-curtain.html'>Gen AI - Behind the Curtain</a></li>
-                <li class='site-nav__subitem'><a href='gen-ai-tools-platforms-and-interfaces.html'>Gen AI Tools, Platforms, and Interfaces</a></li>
-                <li class='site-nav__subitem'><a href='potential-and-limitations-of-gen-ai.html'>Potential and Limitations of Gen AI</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item site-nav__item--has-children'>
-            <a href='analyze-and-apply-gen-ai.html'>Analyze and Apply Gen AI</a>
-            <ul class='site-nav__sublist'>
-                <li class='site-nav__subitem'><a href='essentials-for-smart-engagement.html'>Essentials for Smart Engagement</a></li>
-                <li class='site-nav__subitem'><a href='ai-quick-queries-and-idea-sparker.html'>AI Quick Queries & Idea Sparker</a></li>
-                <li class='site-nav__subitem'><a href='ai-study-buddy-and-skill-builder.html'>AI Study Buddy & Skill Builder</a></li>
-                <li class='site-nav__subitem'><a href='ai-generated-writing-effective-and-ethical-use.html'>AI-Generated Writing: Effective and Ethical Use</a></li>
-                <li class='site-nav__subitem'><a href='ai-research-assistants.html'>AI Research Assistants</a></li>
-                <li class='site-nav__subitem'><a href='ai-risks-and-ethical-considerations.html'>AI Risks & Ethical Considerations</a></li>
-                <li class='site-nav__subitem'><a href='ais-jagged-frontier.html'>AI's Jagged Frontier</a></li>
-            </ul>
-        </li>
-        <li class='site-nav__item'>
-            <a href='ai-contribution-statement.html'>AI Contribution Statement</a>
-        </li>
-    </ul>
+<nav class="site-nav" aria-label="Primary" data-nav-placeholder>
+    <div class="site-nav__loading">Loading navigation…</div>
+    <noscript><div class="site-nav__noscript">Navigation requires JavaScript to display. Enable scripts in your browser to use this menu.</div></noscript>
 </nav>
 <div id="gai-wrap">
     <main>
@@ -120,5 +87,6 @@
         </div>
     </main>
 </div>
+    <script src="nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace per-page navigation markup with a shared `nav.html` include and loader script that highlights the active page
- restyle the navigation to use collapsible cards that mirror the reference layout while preserving the existing color palette
- update each HTML document to reference the shared navigation placeholder with a graceful loading message

## Testing
- python -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68e48a5dbafc832c83593273d19bcecc