### PR TITLE
Move page-level footers outside main

### DIFF
--- a/docs/ai-contribution-statement.html
+++ b/docs/ai-contribution-statement.html
@@ -263,25 +263,27 @@
             </div>
           </section>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/ai-generated-writing-effective-and-ethical-use-activities.html
+++ b/docs/ai-generated-writing-effective-and-ethical-use-activities.html
@@ -1062,25 +1062,27 @@
             </div>
           </section>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/ai-generated-writing-effective-and-ethical-use.html
+++ b/docs/ai-generated-writing-effective-and-ethical-use.html
@@ -141,8 +141,7 @@
             </p>
           </section>
         </div>
-      </main>
-    </div>
+      
     <section class="gai-box">
       <h2 class="gai-h-with-icon">
         <i aria-hidden="true" class="fas fa-compass"></i>
@@ -171,6 +170,8 @@
         </li>
       </ul>
     </section>
+    </main>
+    </div>
     <script src="nav.js"></script>
   </body>
 </html>

--- a/docs/ai-literacy-starter-template-clean.html
+++ b/docs/ai-literacy-starter-template-clean.html
@@ -842,6 +842,7 @@
             </div>
           </section>
         </div>
+
       </main>
       <footer class="gai-cont">
         <div class="gai-references">
@@ -858,6 +859,7 @@
           </p>
         </div>
       </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/ai-quick-queries-and-idea-sparker-iv-wrap-up-sparking-your-own-brilliance.html
+++ b/docs/ai-quick-queries-and-idea-sparker-iv-wrap-up-sparking-your-own-brilliance.html
@@ -75,25 +75,27 @@
             </div>
           </div>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/ai-quick-queries-and-idea-sparker.html
+++ b/docs/ai-quick-queries-and-idea-sparker.html
@@ -131,8 +131,7 @@
             </p>
           </section>
         </div>
-      </main>
-    </div>
+      
     <section class="gai-box">
       <h2 class="gai-h-with-icon">
         <i aria-hidden="true" class="fas fa-compass"></i>
@@ -156,6 +155,8 @@
         </li>
       </ul>
     </section>
+    </main>
+    </div>
     <script src="nav.js"></script>
   </body>
 </html>

--- a/docs/ai-research-assistants-what-a-deep-research-tool-does.html
+++ b/docs/ai-research-assistants-what-a-deep-research-tool-does.html
@@ -483,25 +483,27 @@
             </strong>
           </p>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/ai-research-assistants.html
+++ b/docs/ai-research-assistants.html
@@ -289,8 +289,7 @@
             </div>
           </section>
         </div>
-      </main>
-    </div>
+      
     <section class="gai-box">
       <h2 class="gai-h-with-icon">
         <i aria-hidden="true" class="fas fa-compass"></i>
@@ -304,6 +303,8 @@
         </li>
       </ul>
     </section>
+    </main>
+    </div>
     <script src="nav.js"></script>
   </body>
 </html>

--- a/docs/ai-risks-and-ethical-considerations-other-resources.html
+++ b/docs/ai-risks-and-ethical-considerations-other-resources.html
@@ -107,25 +107,27 @@
             </div>
           </div>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/ai-risks-and-ethical-considerations.html
+++ b/docs/ai-risks-and-ethical-considerations.html
@@ -765,8 +765,7 @@
             </div>
           </details>
         </div>
-      </main>
-    </div>
+      
     <section class="gai-box">
       <h2 class="gai-h-with-icon">
         <i aria-hidden="true" class="fas fa-compass"></i>
@@ -785,6 +784,8 @@
         </li>
       </ul>
     </section>
+    </main>
+    </div>
     <script src="nav.js"></script>
   </body>
 </html>

--- a/docs/ai-study-buddy-and-skill-builder-1-unpacking-complex-ideas.html
+++ b/docs/ai-study-buddy-and-skill-builder-1-unpacking-complex-ideas.html
@@ -585,23 +585,25 @@
             AI is your study amplifier, not your study replacement. The understanding you build is still yours to earn.
           </p>
         </section>
-        <footer>
-          <p>
-            This tutoring prompt is adapted from work by Lilach Mollick and Ethan Mollick, licensed under
-            <a href="https://creativecommons.org/licenses/by/4.0/" rel="noopener noreferrer" target="_blank">
-              Creative Commons Attribution 4.0 International License
-            </a>
-            .
-          </p>
-          <p>
-            This tutoring prompt is adapted from work by Lilach Mollick and Ethan Mollick, licensed under
-            <a href="https://creativecommons.org/licenses/by/4.0/" rel="noopener noreferrer" target="_blank">
-              Creative Commons Attribution 4.0 International License
-            </a>
-            .
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p>
+          This tutoring prompt is adapted from work by Lilach Mollick and Ethan Mollick, licensed under
+          <a href="https://creativecommons.org/licenses/by/4.0/" rel="noopener noreferrer" target="_blank">
+            Creative Commons Attribution 4.0 International License
+          </a>
+          .
+        </p>
+        <p>
+          This tutoring prompt is adapted from work by Lilach Mollick and Ethan Mollick, licensed under
+          <a href="https://creativecommons.org/licenses/by/4.0/" rel="noopener noreferrer" target="_blank">
+            Creative Commons Attribution 4.0 International License
+          </a>
+          .
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/ai-study-buddy-and-skill-builder-enhancing-presentation-amp-speaking-skills.html
+++ b/docs/ai-study-buddy-and-skill-builder-enhancing-presentation-amp-speaking-skills.html
@@ -979,25 +979,27 @@
             </details>
           </div>
         </section>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/ai-study-buddy-and-skill-builder.html
+++ b/docs/ai-study-buddy-and-skill-builder.html
@@ -312,8 +312,7 @@
             </p>
           </div>
         </section>
-      </main>
-    </div>
+      
     <section class="gai-box">
       <h2 class="gai-h-with-icon">
         <i aria-hidden="true" class="fas fa-compass"></i>
@@ -337,6 +336,8 @@
         </li>
       </ul>
     </section>
+    </main>
+    </div>
     <script src="nav.js"></script>
   </body>
 </html>

--- a/docs/ais-jagged-frontier-what-are-ai-benchmarks.html
+++ b/docs/ais-jagged-frontier-what-are-ai-benchmarks.html
@@ -549,25 +549,27 @@
             - See how benchmarks connect to capability mapping
           </p>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/ais-jagged-frontier.html
+++ b/docs/ais-jagged-frontier.html
@@ -605,8 +605,7 @@
             The more you use generative AI, the more you will discover the jagged frontier. This needs to be an ongoing test because the jagged frontier is changing all the time as AI models and the tools improve.
           </p>
         </div>
-      </main>
-    </div>
+      
     <section class="gai-box">
       <h2 class="gai-h-with-icon">
         <i aria-hidden="true" class="fas fa-compass"></i>
@@ -620,6 +619,8 @@
         </li>
       </ul>
     </section>
+    </main>
+    </div>
     <script src="nav.js"></script>
   </body>
 </html>

--- a/docs/analyze-and-apply-gen-ai-customizing-and-organizing-your-ai-assistant.html
+++ b/docs/analyze-and-apply-gen-ai-customizing-and-organizing-your-ai-assistant.html
@@ -291,25 +291,27 @@
             </div>
           </div>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/analyze-and-apply-gen-ai.html
+++ b/docs/analyze-and-apply-gen-ai.html
@@ -833,8 +833,7 @@
             </div>
           </details>
         </div>
-      </main>
-    </div>
+      
     <section class="gai-box">
       <h2 class="gai-h-with-icon">
         <i aria-hidden="true" class="fas fa-compass"></i>
@@ -848,6 +847,8 @@
         </li>
       </ul>
     </section>
+    </main>
+    </div>
     <script src="nav.js"></script>
   </body>
 </html>

--- a/docs/authentic-learning-and-ai-use.html
+++ b/docs/authentic-learning-and-ai-use.html
@@ -157,25 +157,27 @@
             The most successful students won't be those who use AI the most, nor those who avoid it entirely. They'll be the ones who understand how to maintain their intellectual growth while strategically leveraging AI's capabilities.
           </p>
         </section>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/essentials-for-smart-engagement-what-x27-s-next-your-journey-into-analyzing-amp-applying-ai.html
+++ b/docs/essentials-for-smart-engagement-what-x27-s-next-your-journey-into-analyzing-amp-applying-ai.html
@@ -102,25 +102,27 @@
             </div>
           </div>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/essentials-for-smart-engagement.html
+++ b/docs/essentials-for-smart-engagement.html
@@ -152,8 +152,7 @@
         <p>
           This guide will take you through AI's exciting potential and its crucial limitations, preparing you to be a smart and responsible user. Let's dive in!
         </p>
-      </main>
-    </div>
+      
     <section class="gai-box">
       <h2 class="gai-h-with-icon">
         <i aria-hidden="true" class="fas fa-compass"></i>
@@ -182,6 +181,8 @@
         </li>
       </ul>
     </section>
+    </main>
+    </div>
     <script src="nav.js"></script>
   </body>
 </html>

--- a/docs/gen-ai-behind-the-curtain.html
+++ b/docs/gen-ai-behind-the-curtain.html
@@ -350,26 +350,7 @@
             </div>
           </section>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
-      </main>
-    </div>
+      
     <div>
       <p>
         <img alt="Image description" loading="lazy" src="https://d1qywhc7l90rsa.cloudfront.net/accounts/157304/images/AI_Timeline.png">
@@ -676,6 +657,29 @@
           </p>
         </section>
       </div>
+    </div>
+    
+
+      </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/gen-ai-fundamentals.html
+++ b/docs/gen-ai-fundamentals.html
@@ -458,25 +458,27 @@
             </p>
           </div>
         </section>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/gen-ai-tools-platforms-and-interfaces.html
+++ b/docs/gen-ai-tools-platforms-and-interfaces.html
@@ -858,37 +858,7 @@
             and find the one that best matches your workflow. Remember that these platforms are rapidly evolving, with new features and capabilities being added regularly, so it's worth staying informed about updates and changes to make the most of these powerful AI assistants.
           </p>
         </div>
-        <footer>
-          <p>
-            This section comes from Georgetown University Library (
-            <a href="https://guides.library.georgetown.edu/ai/tools" rel="noopener noreferrer" target="_blank">
-              original
-            </a>
-            ) and is licensed under a
-            <a href="https://creativecommons.org/licenses/by-nc/4.0/" rel="noopener noreferrer" target="_blank">
-              Creative Commons Attribution NonCommercial 4.0 International License
-            </a>
-            .
-          </p>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
-      </main>
-    </div>
+      
     <div>
       <h2>
         Harnessing Specialty AI Tools
@@ -2513,6 +2483,40 @@
           </tr>
         </tbody>
       </table>
+    </div>
+    
+
+      </main>
+      <footer>
+        <p>
+          This section comes from Georgetown University Library (
+          <a href="https://guides.library.georgetown.edu/ai/tools" rel="noopener noreferrer" target="_blank">
+            original
+          </a>
+          ) and is licensed under a
+          <a href="https://creativecommons.org/licenses/by-nc/4.0/" rel="noopener noreferrer" target="_blank">
+            Creative Commons Attribution NonCommercial 4.0 International License
+          </a>
+          .
+        </p>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -287,25 +287,27 @@
             </p>
           </footer>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/learning-is-hard-and-its-supposed-to-be.html
+++ b/docs/learning-is-hard-and-its-supposed-to-be.html
@@ -498,25 +498,27 @@
             Use the playbook: understand the learning activity, follow the AI policy, separate human tasks from AI tasks, interleave your own thinking with carefully limited AI assists, verify the results, and log what you learned. Follow it and you’ll finish each assignment not just with a grade, but with stronger reasoning habits that no algorithm can provide.
           </p>
         </section>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/potential-and-limitations-of-gen-ai.html
+++ b/docs/potential-and-limitations-of-gen-ai.html
@@ -762,25 +762,27 @@
             </div>
           </section>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>

--- a/docs/understand-and-explore-generative-ai.html
+++ b/docs/understand-and-explore-generative-ai.html
@@ -139,25 +139,27 @@
             </div>
           </section>
         </div>
-        <footer>
-          <p class="gai-end-txt">
-            Unless otherwise stated, this page and
-            <a href="index.html">
-              AI Literacy for Students
-            </a>
-            © 2025 by David Williams is licensed under
-            <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-              Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-            </a>
-            <span class="gai-cc-icons">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
-              <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
-            </span>
-          </p>
-        </footer>
+
       </main>
+      <footer>
+        <p class="gai-end-txt">
+          Unless otherwise stated, this page and
+          <a href="index.html">
+            AI Literacy for Students
+          </a>
+          © 2025 by David Williams is licensed under
+          <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+            Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+          </a>
+          <span class="gai-cc-icons">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" alt="Creative Commons icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" alt="Attribution icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" alt="Non-Commercial icon">
+            <img loading="lazy" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" alt="Share Alike icon">
+          </span>
+        </p>
+      </footer>
+
     </div>
     <script src="nav.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- relocate each docs page's licensing footer so it follows the `<main>` landmark, keeping page-level content inside the primary landmark while leaving the footer within the site wrapper
- align the starter template's reference footer with the new placement so supplemental callouts stay in `<main>` and the shared footer lives beside it

## Testing
- python - <<'PY'
import pathlib, re
issues = []
for path in sorted(pathlib.Path('docs').glob('*.html')):
    text = path.read_text()
    main_idx = text.rfind('</main>')
    if main_idx == -1:
        continue
    body_idx = text.find('</body>', main_idx)
    if body_idx == -1:
        continue
    segment = text[main_idx+len('</main>'):body_idx]
    cleaned = re.sub(r'\s+', '', segment)
    cleaned = re.sub(r'</div>', '', cleaned, flags=re.IGNORECASE)
    cleaned = re.sub(r'<footer[^>]*>.*?</footer>', '', cleaned, flags=re.IGNORECASE | re.DOTALL)
    cleaned = re.sub(r'<script[^>]*></script>', '', cleaned, flags=re.IGNORECASE | re.DOTALL)
    cleaned = re.sub(r'<script[^>]*>', '', cleaned, flags=re.IGNORECASE | re.DOTALL)
    cleaned = re.sub(r'<!--.*?-->', '', cleaned, flags=re.DOTALL)
    if cleaned:
        issues.append((path, cleaned[:80]))
if issues:
    for path, snippet in issues:
        print('Issue:', path, 'Snippet:', snippet)
else:
    print('All files clean!')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e4b33fffdc832c8eee28174339b517